### PR TITLE
fix(security): upgrade python-jose to 3.4.0 (CVE-2024-33663)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "email-validator>=2.1.0",
     # Authentication
     "google-auth>=2.27.0",
-    "python-jose[cryptography]>=3.3.0",
+    "python-jose[cryptography]>=3.4.0",
     # HTTP client
     "httpx>=0.26.0",
     # Azure

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1789,7 +1789,7 @@ requires-dist = [
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.1" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
-    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
+    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.4.0" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "pytorch-lightning", specifier = ">=2.5.0" },
     { name = "rembg", extras = ["cpu"], specifier = ">=2.0.50" },

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ pre-commit==3.6.2
 pydantic-settings==2.2.1
 pytest==8.0.2
 python-dotenv==1.0.1
-python-jose[cryptography]==3.3.0
+python-jose[cryptography]==3.4.0
 python-multipart==0.0.18
 types-pillow==10.2.0.20240311
 types-python-jose==3.3.4.20240106


### PR DESCRIPTION
## Summary
- Upgrades python-jose constraint to >=3.4.0 to fix CVE-2024-33663
- Updates `backend/pyproject.toml`, `backend/uv.lock`, and root `requirements.txt`

## Security Details
- **CVE**: CVE-2024-33663
- **Severity**: Critical (CVSS v4: 9.3)
- **Issue**: Algorithm confusion with OpenSSH ECDSA keys and other key formats
- **Vulnerable versions**: < 3.4.0
- **Fixed version**: 3.4.0

Note: The lock file already had 3.5.0, but the constraint allowed 3.3.0 which could cause regression.

## References
- https://github.com/claust/pussel/security/dependabot/8
- https://nvd.nist.gov/vuln/detail/CVE-2024-33663

## Test plan
- [ ] Verify backend starts correctly with `uv run uvicorn app.main:app`
- [ ] Run backend tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)