### PR TITLE
fix(puzzle_shapes): correct edge alignment between adjacent pieces

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - id: black
         language_version: python3.12
         args: [--line-length=120]
-        exclude: ^network/
+        exclude: ^(network/|shared/)
 
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
@@ -34,7 +34,7 @@ repos:
       - id: isort
         name: isort (python)
         args: [--profile=black, --line-length=120]
-        exclude: ^network/
+        exclude: ^(network/|shared/)
 
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0
@@ -46,7 +46,7 @@ repos:
           - flake8-bugbear
           - flake8-comprehensions
           - flake8-pytest-style
-        exclude: ^network/
+        exclude: ^(network/|shared/)
 
   # Backend pyright type checking
   - repo: local
@@ -60,13 +60,13 @@ repos:
         pass_filenames: false
         require_serial: true
 
-  # Shared library pyright type checking
+  # Shared library Python checks - runs make check-shared for formatting, linting, and type checking
   - repo: local
     hooks:
-      - id: shared-pyright
-        name: shared library pyright type checking
-        description: Run pyright type checking for shared puzzle_shapes library
-        entry: bash -c 'cd shared/puzzle_shapes && pyright .'
+      - id: shared-python-checks
+        name: shared library python checks (make check-shared)
+        description: Run black, isort, flake8, pyright via root Makefile (uses uv)
+        entry: make check-shared
         language: system
         files: ^shared/.*\.py$
         pass_filenames: false

--- a/network/pyproject.toml
+++ b/network/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
     "matplotlib>=3.7.0",
     "requests>=2.31.0",
     "tqdm>=4.65.0",
+    # Shared packages
+    "puzzle-shapes",
 ]
 
 [project.optional-dependencies]
@@ -76,3 +78,6 @@ extend-exclude = '''
 pythonVersion = "3.12"
 typeCheckingMode = "standard"
 exclude = [".venv", "datasets", "checkpoints", "logs", "experiments"]
+
+[tool.uv.sources]
+puzzle-shapes = { path = "../shared/puzzle_shapes" }

--- a/network/uv.lock
+++ b/network/uv.lock
@@ -1546,6 +1546,7 @@ dependencies = [
     { name = "matplotlib" },
     { name = "pandas" },
     { name = "pillow" },
+    { name = "puzzle-shapes" },
     { name = "pytorch-lightning" },
     { name = "requests" },
     { name = "scikit-learn" },
@@ -1587,6 +1588,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pandas-stubs", marker = "extra == 'dev'" },
     { name = "pillow", specifier = ">=11.0.0" },
+    { name = "puzzle-shapes", directory = "../shared/puzzle_shapes" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390" },
     { name = "pytorch-lightning", specifier = ">=2.5.0" },
     { name = "requests", specifier = ">=2.31.0" },
@@ -1598,6 +1600,26 @@ requires-dist = [
     { name = "types-pillow", marker = "extra == 'dev'" },
     { name = "types-requests", marker = "extra == 'dev'" },
     { name = "types-tqdm", marker = "extra == 'dev'" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "puzzle-shapes"
+version = "0.1.0"
+source = { directory = "../shared/puzzle_shapes" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
+    { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
+    { name = "numpy", specifier = ">=1.24.0" },
+    { name = "pillow", specifier = ">=10.0.0" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
 ]
 provides-extras = ["dev"]
 

--- a/shared/puzzle_shapes/puzzle_shapes/edge_grid.py
+++ b/shared/puzzle_shapes/puzzle_shapes/edge_grid.py
@@ -609,30 +609,30 @@ def get_piece_curves(
     all_curves.extend(top_curves)
 
     # Right edge: vertical_edges[row][col+1]
-    # This edge is "owned" by the piece to the right, so we invert it
-    # to get the complementary shape (tab becomes blank, blank becomes tab).
+    # This edge is shared with the piece to the right where it's the LEFT edge.
+    # We need to traverse the same curves in reverse direction to maintain alignment.
     # Need: (1,1) -> (1,0), tab protrudes +X
-    # Transform: rotate 90 deg CW (= 270 deg CCW = 3), then translate
+    # Transform: use same rotation as left edge (90 deg CCW) but reverse curve direction
     right_edge = edge_grid.vertical_edges[row][col + 1]
     right_curves = transform_curves(
-        invert_curves(right_edge.curves),
-        translate=(1.0, 1.0),
+        reverse_curves(right_edge.curves),
+        translate=(1.0, 0.0),
         scale=(1.0, 1.0),
-        rotate_90_ccw=3,  # 90 deg CW = 270 deg CCW
+        rotate_90_ccw=1,  # Same rotation as left edge
     )
     all_curves.extend(right_curves)
 
     # Bottom edge: horizontal_edges[row+1][col]
-    # This edge is "owned" by the piece below, so we invert it
-    # to get the complementary shape (tab becomes blank, blank becomes tab).
+    # This edge is shared with the piece below where it's the TOP edge.
+    # We need to traverse the same curves in reverse direction to maintain alignment.
     # Need: (1,0) -> (0,0), tab protrudes -Y
-    # Transform: rotate 180 deg (= 2 x 90 deg CCW), then translate
+    # Transform: use same rotation as top edge (0 deg) but reverse curve direction
     bottom_edge = edge_grid.horizontal_edges[row + 1][col]
     bottom_curves = transform_curves(
-        invert_curves(bottom_edge.curves),
-        translate=(1.0, 0.0),
+        reverse_curves(bottom_edge.curves),
+        translate=(0.0, 0.0),
         scale=(1.0, 1.0),
-        rotate_90_ccw=2,  # 180 deg
+        rotate_90_ccw=0,  # Same rotation as top edge
     )
     all_curves.extend(bottom_curves)
 

--- a/shared/puzzle_shapes/tests/test_edge_alignment.py
+++ b/shared/puzzle_shapes/tests/test_edge_alignment.py
@@ -463,9 +463,7 @@ class TestVisualEdgeAlignment:
                 color = yellow if is_even else blue
 
                 # Get polygon for this piece
-                polygon = TestVisualEdgeAlignment.get_piece_polygon(
-                    grid, row, col, piece_size, rows, points_per_curve
-                )
+                polygon = TestVisualEdgeAlignment.get_piece_polygon(grid, row, col, piece_size, rows, points_per_curve)
 
                 # Create a temporary image for this piece with transparency
                 piece_img = Image.new("RGBA", (img_width, img_height), (0, 0, 0, 0))
@@ -535,12 +533,10 @@ class TestVisualEdgeAlignment:
         max_allowed_artifacts = 50  # pixels
 
         assert white_count < max_allowed_artifacts, (
-            f"Found {white_count} white pixels (gaps) in 3x3 puzzle. "
-            f"Sample positions: {samples[:5]}"
+            f"Found {white_count} white pixels (gaps) in 3x3 puzzle. " f"Sample positions: {samples[:5]}"
         )
         assert green_count < max_allowed_artifacts, (
-            f"Found {green_count} green pixels (overlaps) in 3x3 puzzle. "
-            f"Sample positions: {samples[:5]}"
+            f"Found {green_count} green pixels (overlaps) in 3x3 puzzle. " f"Sample positions: {samples[:5]}"
         )
 
     def test_visual_no_gaps_or_overlaps_4x4(self) -> None:
@@ -553,12 +549,10 @@ class TestVisualEdgeAlignment:
         max_allowed_artifacts = 50
 
         assert white_count < max_allowed_artifacts, (
-            f"Found {white_count} white pixels (gaps) in 4x4 puzzle. "
-            f"Sample positions: {samples[:5]}"
+            f"Found {white_count} white pixels (gaps) in 4x4 puzzle. " f"Sample positions: {samples[:5]}"
         )
         assert green_count < max_allowed_artifacts, (
-            f"Found {green_count} green pixels (overlaps) in 4x4 puzzle. "
-            f"Sample positions: {samples[:5]}"
+            f"Found {green_count} green pixels (overlaps) in 4x4 puzzle. " f"Sample positions: {samples[:5]}"
         )
 
     def test_visual_multiple_seeds(self) -> None:
@@ -572,10 +566,8 @@ class TestVisualEdgeAlignment:
             white_count, green_count, samples = self.check_for_artifacts(image)
 
             assert white_count < max_allowed_artifacts, (
-                f"Seed {seed}: Found {white_count} white pixels (gaps). "
-                f"Sample positions: {samples[:5]}"
+                f"Seed {seed}: Found {white_count} white pixels (gaps). " f"Sample positions: {samples[:5]}"
             )
             assert green_count < max_allowed_artifacts, (
-                f"Seed {seed}: Found {green_count} green pixels (overlaps). "
-                f"Sample positions: {samples[:5]}"
+                f"Seed {seed}: Found {green_count} green pixels (overlaps). " f"Sample positions: {samples[:5]}"
             )

--- a/shared/puzzle_shapes/tests/test_edge_alignment.py
+++ b/shared/puzzle_shapes/tests/test_edge_alignment.py
@@ -1,0 +1,382 @@
+"""Tests for verifying puzzle piece edge alignment.
+
+These tests generate puzzle pieces and verify that adjacent pieces share
+the exact same edge coordinates (no gaps or overlaps).
+"""
+
+import math
+from typing import List, Tuple
+
+import pytest
+
+from puzzle_shapes.edge_grid import EdgeGrid, generate_edge_grid, get_piece_curves
+from puzzle_shapes.models import BezierCurve
+
+
+def sample_curve_points(curve: BezierCurve, num_points: int = 20) -> List[Tuple[float, float]]:
+    """Sample points along a Bezier curve."""
+    points = []
+    for i in range(num_points):
+        t = i / (num_points - 1)
+        points.append(curve.evaluate(t))
+    return points
+
+
+def get_edge_curves(curves: List[BezierCurve]) -> dict:
+    """Split a piece's curves into edges by finding corner transitions.
+
+    Curves are returned in clockwise order: top -> right -> bottom -> left.
+    We identify edge boundaries by finding where curves reach corner positions.
+
+    Returns:
+        Dictionary with "top", "right", "bottom", "left" keys.
+    """
+    # Corner tolerance
+    tol = 0.1
+
+    def near_corner(point: Tuple[float, float], corner: Tuple[float, float]) -> bool:
+        return abs(point[0] - corner[0]) < tol and abs(point[1] - corner[1]) < tol
+
+    # Find edge boundary indices by looking for curves ending at corners
+    # Top edge: starts at (0,1), ends when we reach (1,1)
+    # Right edge: starts at (1,1), ends when we reach (1,0)
+    # Bottom edge: starts at (1,0), ends when we reach (0,0)
+    # Left edge: starts at (0,0), ends when we reach (0,1)
+
+    top_end = right_end = bottom_end = len(curves)
+
+    for i, curve in enumerate(curves):
+        end = curve.p3
+        if top_end == len(curves) and near_corner(end, (1.0, 1.0)):
+            top_end = i + 1
+        elif right_end == len(curves) and near_corner(end, (1.0, 0.0)):
+            right_end = i + 1
+        elif bottom_end == len(curves) and near_corner(end, (0.0, 0.0)):
+            bottom_end = i + 1
+
+    return {
+        "top": curves[0:top_end],
+        "right": curves[top_end:right_end],
+        "bottom": curves[right_end:bottom_end],
+        "left": curves[bottom_end:],
+    }
+
+
+def get_edge_points(
+    curves: List[BezierCurve],
+    edge: str,
+    num_points: int = 20,
+) -> List[Tuple[float, float]]:
+    """Extract points from a specific edge of a piece.
+
+    Args:
+        curves: All curves for the piece (in clockwise order: top, right, bottom, left).
+        edge: Which edge to extract ("top", "right", "bottom", "left").
+        num_points: Number of points to sample per curve.
+
+    Returns:
+        List of sampled points along the specified edge.
+    """
+    edge_curves = get_edge_curves(curves)
+    selected_curves = edge_curves.get(edge, [])
+
+    points = []
+    for curve in selected_curves:
+        points.extend(sample_curve_points(curve, num_points))
+
+    return points
+
+
+def points_match(
+    points1: List[Tuple[float, float]],
+    points2: List[Tuple[float, float]],
+    tolerance: float = 0.001,
+) -> Tuple[bool, float]:
+    """Check if two lists of points match (within tolerance).
+
+    Since adjacent edges are traversed in opposite directions,
+    we need to compare points1 to reversed points2.
+
+    Returns:
+        Tuple of (match_status, max_distance).
+    """
+    if len(points1) == 0 or len(points2) == 0:
+        return (False, float("inf"))
+
+    # Reverse points2 since edges are traversed in opposite directions
+    points2_reversed = list(reversed(points2))
+
+    # Resample to same length if needed
+    if len(points1) != len(points2_reversed):
+        # Just compare available points
+        min_len = min(len(points1), len(points2_reversed))
+        points1 = points1[:min_len]
+        points2_reversed = points2_reversed[:min_len]
+
+    max_dist = 0.0
+    for p1, p2 in zip(points1, points2_reversed):
+        dist = math.sqrt((p1[0] - p2[0]) ** 2 + (p1[1] - p2[1]) ** 2)
+        max_dist = max(max_dist, dist)
+
+    return (max_dist < tolerance, max_dist)
+
+
+def transform_point_to_grid(
+    point: Tuple[float, float],
+    row: int,
+    col: int,
+    piece_width: float,
+    piece_height: float,
+    total_rows: int,
+) -> Tuple[float, float]:
+    """Transform a point from normalized piece space to grid space.
+
+    Note: Row 0 is at the visual "top" of the puzzle, so we invert
+    the y-coordinate to get proper grid coordinates where y increases upward.
+    """
+    x = col * piece_width + point[0] * piece_width
+    # Invert row so that row 0 is at the top (higher y in grid coords)
+    y = (total_rows - 1 - row) * piece_height + point[1] * piece_height
+    return (x, y)
+
+
+class TestEdgeAlignment:
+    """Tests for verifying puzzle piece edges align correctly."""
+
+    @pytest.fixture
+    def edge_grid_2x2(self) -> EdgeGrid:
+        """Create a 2x2 puzzle grid with fixed seed."""
+        return generate_edge_grid(rows=2, cols=2, seed=42)
+
+    @pytest.fixture
+    def edge_grid_3x3(self) -> EdgeGrid:
+        """Create a 3x3 puzzle grid with fixed seed."""
+        return generate_edge_grid(rows=3, cols=3, seed=42)
+
+    @pytest.fixture
+    def edge_grid_4x4(self) -> EdgeGrid:
+        """Create a 4x4 puzzle grid with fixed seed."""
+        return generate_edge_grid(rows=4, cols=4, seed=42)
+
+    def test_horizontal_edge_alignment_2x2(self, edge_grid_2x2: EdgeGrid) -> None:
+        """Test that horizontally adjacent pieces share the same vertical edge."""
+        grid = edge_grid_2x2
+        piece_width = 1.0
+        piece_height = 1.0
+        total_rows = 2
+
+        # Check piece (0,0) right edge matches piece (0,1) left edge
+        piece_00_curves = get_piece_curves(grid, 0, 0)
+        piece_01_curves = get_piece_curves(grid, 0, 1)
+
+        # Get right edge of piece (0,0) and left edge of piece (0,1)
+        # Transform to grid coordinates for comparison
+        piece_00_right = get_edge_points(piece_00_curves, "right")
+        piece_01_left = get_edge_points(piece_01_curves, "left")
+
+        # Transform to grid space
+        piece_00_right_grid = [
+            transform_point_to_grid(p, 0, 0, piece_width, piece_height, total_rows) for p in piece_00_right
+        ]
+        piece_01_left_grid = [
+            transform_point_to_grid(p, 0, 1, piece_width, piece_height, total_rows) for p in piece_01_left
+        ]
+
+        match, max_dist = points_match(piece_00_right_grid, piece_01_left_grid, tolerance=0.01)
+        assert match, f"Horizontal edge mismatch: max distance = {max_dist}"
+
+    def test_vertical_edge_alignment_2x2(self, edge_grid_2x2: EdgeGrid) -> None:
+        """Test that vertically adjacent pieces share the same horizontal edge."""
+        grid = edge_grid_2x2
+        piece_width = 1.0
+        piece_height = 1.0
+        total_rows = 2
+
+        # Check piece (0,0) bottom edge matches piece (1,0) top edge
+        piece_00_curves = get_piece_curves(grid, 0, 0)
+        piece_10_curves = get_piece_curves(grid, 1, 0)
+
+        piece_00_bottom = get_edge_points(piece_00_curves, "bottom")
+        piece_10_top = get_edge_points(piece_10_curves, "top")
+
+        # Transform to grid space
+        piece_00_bottom_grid = [
+            transform_point_to_grid(p, 0, 0, piece_width, piece_height, total_rows) for p in piece_00_bottom
+        ]
+        piece_10_top_grid = [
+            transform_point_to_grid(p, 1, 0, piece_width, piece_height, total_rows) for p in piece_10_top
+        ]
+
+        match, max_dist = points_match(piece_00_bottom_grid, piece_10_top_grid, tolerance=0.01)
+        assert match, f"Vertical edge mismatch: max distance = {max_dist}"
+
+    def test_all_horizontal_edges_3x3(self, edge_grid_3x3: EdgeGrid) -> None:
+        """Test all horizontal adjacencies in a 3x3 grid."""
+        grid = edge_grid_3x3
+        piece_width = 1.0
+        piece_height = 1.0
+        total_rows = 3
+
+        for row in range(3):
+            for col in range(2):  # Only check internal horizontal edges
+                piece_left_curves = get_piece_curves(grid, row, col)
+                piece_right_curves = get_piece_curves(grid, row, col + 1)
+
+                left_right_edge = get_edge_points(piece_left_curves, "right")
+                right_left_edge = get_edge_points(piece_right_curves, "left")
+
+                left_right_grid = [
+                    transform_point_to_grid(p, row, col, piece_width, piece_height, total_rows) for p in left_right_edge
+                ]
+                right_left_grid = [
+                    transform_point_to_grid(p, row, col + 1, piece_width, piece_height, total_rows)
+                    for p in right_left_edge
+                ]
+
+                match, max_dist = points_match(left_right_grid, right_left_grid, tolerance=0.01)
+                assert match, (
+                    f"Horizontal edge mismatch at ({row},{col})-({row},{col + 1}): " f"max distance = {max_dist}"
+                )
+
+    def test_all_vertical_edges_3x3(self, edge_grid_3x3: EdgeGrid) -> None:
+        """Test all vertical adjacencies in a 3x3 grid."""
+        grid = edge_grid_3x3
+        piece_width = 1.0
+        piece_height = 1.0
+        total_rows = 3
+
+        for row in range(2):  # Only check internal vertical edges
+            for col in range(3):
+                piece_top_curves = get_piece_curves(grid, row, col)
+                piece_bottom_curves = get_piece_curves(grid, row + 1, col)
+
+                top_bottom_edge = get_edge_points(piece_top_curves, "bottom")
+                bottom_top_edge = get_edge_points(piece_bottom_curves, "top")
+
+                top_bottom_grid = [
+                    transform_point_to_grid(p, row, col, piece_width, piece_height, total_rows) for p in top_bottom_edge
+                ]
+                bottom_top_grid = [
+                    transform_point_to_grid(p, row + 1, col, piece_width, piece_height, total_rows)
+                    for p in bottom_top_edge
+                ]
+
+                match, max_dist = points_match(top_bottom_grid, bottom_top_grid, tolerance=0.01)
+                assert match, (
+                    f"Vertical edge mismatch at ({row},{col})-({row + 1},{col}): " f"max distance = {max_dist}"
+                )
+
+    def test_all_edges_4x4(self, edge_grid_4x4: EdgeGrid) -> None:
+        """Test all adjacencies in a 4x4 grid."""
+        grid = edge_grid_4x4
+        piece_width = 1.0
+        piece_height = 1.0
+        total_rows = 4
+
+        errors = []
+
+        # Test horizontal adjacencies
+        for row in range(4):
+            for col in range(3):
+                piece_left_curves = get_piece_curves(grid, row, col)
+                piece_right_curves = get_piece_curves(grid, row, col + 1)
+
+                left_right_edge = get_edge_points(piece_left_curves, "right")
+                right_left_edge = get_edge_points(piece_right_curves, "left")
+
+                left_right_grid = [
+                    transform_point_to_grid(p, row, col, piece_width, piece_height, total_rows) for p in left_right_edge
+                ]
+                right_left_grid = [
+                    transform_point_to_grid(p, row, col + 1, piece_width, piece_height, total_rows)
+                    for p in right_left_edge
+                ]
+
+                match, max_dist = points_match(left_right_grid, right_left_grid, tolerance=0.01)
+                if not match:
+                    errors.append(f"H({row},{col})-({row},{col + 1}): {max_dist:.4f}")
+
+        # Test vertical adjacencies
+        for row in range(3):
+            for col in range(4):
+                piece_top_curves = get_piece_curves(grid, row, col)
+                piece_bottom_curves = get_piece_curves(grid, row + 1, col)
+
+                top_bottom_edge = get_edge_points(piece_top_curves, "bottom")
+                bottom_top_edge = get_edge_points(piece_bottom_curves, "top")
+
+                top_bottom_grid = [
+                    transform_point_to_grid(p, row, col, piece_width, piece_height, total_rows) for p in top_bottom_edge
+                ]
+                bottom_top_grid = [
+                    transform_point_to_grid(p, row + 1, col, piece_width, piece_height, total_rows)
+                    for p in bottom_top_edge
+                ]
+
+                match, max_dist = points_match(top_bottom_grid, bottom_top_grid, tolerance=0.01)
+                if not match:
+                    errors.append(f"V({row},{col})-({row + 1},{col}): {max_dist:.4f}")
+
+        assert len(errors) == 0, f"Edge misalignments found: {errors}"
+
+    def test_multiple_seeds(self) -> None:
+        """Test edge alignment with multiple random seeds."""
+        for seed in [1, 42, 100, 999, 12345]:
+            grid = generate_edge_grid(rows=3, cols=3, seed=seed)
+            piece_width = 1.0
+            piece_height = 1.0
+            total_rows = 3
+
+            # Test center piece (1,1) against all neighbors
+            center_curves = get_piece_curves(grid, 1, 1)
+
+            # Check right neighbor
+            right_curves = get_piece_curves(grid, 1, 2)
+            center_right = get_edge_points(center_curves, "right")
+            right_left = get_edge_points(right_curves, "left")
+
+            center_right_grid = [
+                transform_point_to_grid(p, 1, 1, piece_width, piece_height, total_rows) for p in center_right
+            ]
+            right_left_grid = [
+                transform_point_to_grid(p, 1, 2, piece_width, piece_height, total_rows) for p in right_left
+            ]
+
+            match, max_dist = points_match(center_right_grid, right_left_grid, tolerance=0.01)
+            assert match, f"Seed {seed}: horizontal edge mismatch, max_dist={max_dist}"
+
+            # Check bottom neighbor
+            bottom_curves = get_piece_curves(grid, 2, 1)
+            center_bottom = get_edge_points(center_curves, "bottom")
+            bottom_top = get_edge_points(bottom_curves, "top")
+
+            center_bottom_grid = [
+                transform_point_to_grid(p, 1, 1, piece_width, piece_height, total_rows) for p in center_bottom
+            ]
+            bottom_top_grid = [
+                transform_point_to_grid(p, 2, 1, piece_width, piece_height, total_rows) for p in bottom_top
+            ]
+
+            match, max_dist = points_match(center_bottom_grid, bottom_top_grid, tolerance=0.01)
+            assert match, f"Seed {seed}: vertical edge mismatch, max_dist={max_dist}"
+
+    def test_edge_continuity(self, edge_grid_2x2: EdgeGrid) -> None:
+        """Test that curves within a piece form a continuous boundary."""
+        grid = edge_grid_2x2
+        curves = get_piece_curves(grid, 0, 0)
+
+        # Each curve should end where the next one starts
+        tolerance = 0.001
+        for i in range(len(curves) - 1):
+            end_point = curves[i].p3
+            start_point = curves[i + 1].p0
+            dist = math.sqrt((end_point[0] - start_point[0]) ** 2 + (end_point[1] - start_point[1]) ** 2)
+            assert dist < tolerance, (
+                f"Curve discontinuity at index {i}: " f"end={end_point}, start={start_point}, dist={dist}"
+            )
+
+        # Last curve should connect back to first curve (closed boundary)
+        end_point = curves[-1].p3
+        start_point = curves[0].p0
+        dist = math.sqrt((end_point[0] - start_point[0]) ** 2 + (end_point[1] - start_point[1]) ** 2)
+        assert dist < tolerance, f"Boundary not closed: last end={end_point}, first start={start_point}, dist={dist}"

--- a/shared/puzzle_shapes/tests/test_edge_alignment.py
+++ b/shared/puzzle_shapes/tests/test_edge_alignment.py
@@ -23,7 +23,7 @@ def sample_curve_points(curve: BezierCurve, num_points: int = 20) -> List[Tuple[
     return points
 
 
-def get_edge_curves(curves: List[BezierCurve]) -> dict:
+def get_edge_curves(curves: List[BezierCurve]) -> dict[str, list[BezierCurve]]:
     """Split a piece's curves into edges by finding corner transitions.
 
     Curves are returned in clockwise order: top -> right -> bottom -> left.


### PR DESCRIPTION
## Summary

- Fix `get_piece_curves()` to use `reverse_curves()` instead of `invert_curves()` for right and bottom edges, ensuring adjacent pieces share exactly the same edge coordinates
- Add `puzzle-shapes` shared package dependency to `network/pyproject.toml`
- Add comprehensive unit tests for edge alignment verification covering 2x2, 3x3, and 4x4 grids with multiple random seeds

## Problem

The bug caused Y coordinates to be mirrored between adjacent pieces (e.g., 83.6 vs 316.4 for the same edge), resulting in gaps or overlaps when pieces were placed next to each other.

## Solution

Changed edge transformation approach:
- **Before**: Used `invert_curves()` which flips Y coordinates, combined with different rotations for owner vs neighbor
- **After**: Use `reverse_curves()` (traverse in opposite direction) with the same rotation as the "owner" edge

This ensures both pieces see exactly the same physical edge coordinates, just traversed in opposite directions.

## Test plan

- [x] All 7 new edge alignment tests pass
- [x] Tests cover horizontal and vertical adjacencies
- [x] Tests verify edge continuity (closed boundary)
- [x] Tests run with multiple random seeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)