### PR TITLE
fix(exp20): correct test rotation labels — CNN scores 94.6% rotation, not 25%

### DIFF
--- a/network/experiments/CRITICAL_REVIEW.md
+++ b/network/experiments/CRITICAL_REVIEW.md
@@ -36,6 +36,12 @@ grids (exp18), 73% position on 4×4 Bezier pieces (exp20).
 
 ### 1. The exp20 test set has broken rotation labels (CRITICAL)
 
+> **RESOLVED (2026-07-13):** Fixed the label composition and re-evaluated
+> the original exp20 checkpoint on a deterministic regeneration of the
+> same test split: **72.9% cell (exact reproduction) / 94.6% rotation**.
+> Rotation never failed; the RoMa/hybrid pivot is dropped. See the
+> "Exp 20 Re-Evaluation" entry in EXPERIMENT_LOG.md.
+
 This invalidates the last three experiments and the current roadmap.
 
 Piece PNGs are generated with a random rotation baked in

--- a/network/experiments/EXPERIMENT_LOG.md
+++ b/network/experiments/EXPERIMENT_LOG.md
@@ -304,6 +304,10 @@ completely different approaches for realistic pieces — position via texture
 correlation (works), rotation perhaps via edge-shape matching or
 rotation-invariant features.
 
+> **UPDATE (July 2026):** The rotation result was a test-label bug, not a
+> model failure. Re-evaluating this same checkpoint with fixed labels gives
+> **94.6% rotation** — see "Exp 20 Re-Evaluation" below.
+
 ---
 
 ## Exp 21: Masked Rotation Correlation
@@ -317,6 +321,10 @@ edges interfere with rotation correlation. Results: 73.9% cell accuracy
 zero effect. The rotation correlation approach fundamentally cannot learn
 rotation for realistic pieces because irregular Bezier edges create highly
 variable piece silhouettes that texture-based correlation cannot capture.
+
+> **UPDATE (July 2026):** Invalid — the test-label bug capped rotation at
+> 25% for any model, so this experiment could not have measured an effect.
+> See "Exp 20 Re-Evaluation" below.
 
 ---
 
@@ -335,6 +343,11 @@ cannot overfit to puzzle data, combined with explicit rotation search rather
 than implicit learning. Position regressed due to noisy correspondences.
 Recommendation: hybrid approach using RoMa for rotation (58%) and CNN for
 position (73%), expecting ~42% combined accuracy.
+
+> **UPDATE (July 2026):** The CNN's 25% rotation baseline was a test-label
+> bug; the corrected CNN scores 94.6% rotation and 72.9% cell — better than
+> RoMa on both metrics. The hybrid recommendation is withdrawn. See "Exp 20
+> Re-Evaluation" below.
 
 ---
 
@@ -377,6 +390,41 @@ photographed-piece test set as the real benchmark.
 
 ---
 
+## Exp 20 Re-Evaluation: Fixed Test Rotation Labels
+
+**Date:** July 2026 **Status:** SUCCESS (72.9% cell, **94.6% rotation**)
+
+Fixed the exp20 test-label bug from the critical review and re-evaluated
+the original (unmodified) RunPod checkpoint. `RealisticPieceTestDataset`
+now composes the rotation baked into each piece PNG with the applied
+test rotation (`(base + applied) % 360`), matching the training path.
+The original test split was reproduced exactly: the generator seeds each
+puzzle with `42 + source_index`, so the 1,200 test puzzles
+(seed-42 shuffle of the 11,998 generated puzzles, indices 10798+) were
+regenerated deterministically (`regenerate_test_split.py`) using the
+December 2025 `puzzle_shapes` (commit 6b61eb7 — the library's edge
+geometry changed in January 2026, after the dataset was generated).
+
+Results on all 76,800 test samples (1,200 puzzles × 16 cells × 4
+rotations): **cell accuracy 72.9%** — matching the original run to the
+decimal, confirming the regenerated test set is faithful — and
+**rotation accuracy 94.6%** (94–95% for each of the four rotations;
+residual errors are almost entirely 180° confusions: 0↔180 and 90↔270).
+Cell AND rotation correct together: 72.2%.
+
+Conclusions:
+
+1. **Rotation never failed on realistic pieces.** The dead-flat 24.8%
+   was purely the scrambled-label measurement; the model generalizes
+   rotation nearly as well as on square pieces (95% in exp18).
+2. **exp21 is moot** — it "fixed" a bug that did not exist in the model.
+3. **exp22's comparison inverts:** the CNN beats RoMa on both position
+   (72.9% vs 63.5%) and rotation (94.6% vs 58.1%), at a fraction of the
+   inference cost (~ms vs 5.6 s/piece). The RoMa/hybrid roadmap is
+   dropped.
+
+---
+
 ## Summary Table
 
 | Exp | Focus                       | Test Result            | Key Finding                                    |
@@ -400,9 +448,9 @@ photographed-piece test set as the real benchmark.
 | 17  | 3x3 grid + 10K puzzles      | **81% cell / 93% rot** | Data scaling approach validated for 3x3!       |
 | 18  | 3x3 grid + 20K puzzles      | **82% cell / 95% rot** | Data scaling continues to help (NEW BEST)      |
 | 19  | Siamese architecture        | 79% cell / 92% rot     | Dual backbone > Siamese for dissimilar inputs  |
-| 20  | 4x4 realistic pieces        | **73% cell** / 25% rot | Position scales to 4x4; rotation fails         |
-| 21  | Masked rotation correlation | 74% cell / 25% rot     | Masking background doesn't help rotation       |
-| 22  | RoMa V2 dense matching      | 64% cell / **58% rot** | Dense matching breaks rotation barrier!        |
+| 20  | 4x4 realistic pieces        | **73% cell / 95% rot** | Scales to 4x4 (rot re-measured after label fix)|
+| 21  | Masked rotation correlation | 74% cell / 25% rot     | INVALID — capped by test-label bug             |
+| 22  | RoMa V2 dense matching      | 64% cell / 58% rot     | Loses to CNN on both metrics (after label fix) |
 
 ---
 
@@ -429,13 +477,10 @@ puzzles. This is the current production-ready model for 3x3 grids.
 **For Fast Experimentation:** ShuffleNetV2_x0.5 (exp15) - 12.9s/epoch vs 39.3s
 for RepVGG and 98.1s for MobileOne. Use for rapid iteration.
 
-**For Position + Rotation (4×4 realistic pieces):** Best approach is a **hybrid**:
-- **Position:** FastBackboneModel CNN (exp20) - **73% cell accuracy**
-- **Rotation:** RoMa V2 dense matching (exp22) - **58% rotation accuracy**
-- Expected combined: ~42% accuracy (vs 37% RoMa-only, 18% CNN-only)
-
-Note: Masking the background (exp21) did not help — the rotation correlation
-architecture fundamentally cannot learn rotation for realistic Bezier-edge pieces.
+**For Position + Rotation (4×4 realistic pieces):** FastBackboneModel CNN
+(exp20) alone — **72.9% cell / 94.6% rotation / 72.2% both** (re-evaluated
+July 2026 after fixing the test-label bug). RoMa (exp22) is worse on both
+metrics and ~1000× slower; the hybrid plan is dropped.
 
 **Key Learnings:**
 1. **Data quantity AND quality matter** (exp17): Must see all cells per puzzle
@@ -444,20 +489,20 @@ architecture fundamentally cannot learn rotation for realistic Bezier-edge piece
    (scale, content type), specialized encoders outperform weight sharing
 3. **Data scaling helps** (exp18): More diverse training data improves
    generalization
-4. **Realistic pieces break CNN rotation** (exp20-21): The rotation correlation
-   approach that worked for square pieces (93-95% accuracy) completely fails
-   for Bezier-curve realistic pieces (25% = random). Masking the background
-   does not help — the architecture cannot learn generalizable rotation features.
-5. **Dense feature matching breaks the rotation barrier** (exp22): RoMa V2's
-   overlap score maximization achieves 58% rotation accuracy (2.3× improvement),
-   proving rotation IS solvable for realistic pieces. Trade-off: position
-   accuracy regresses to 64%.
+4. **Rotation correlation transfers to realistic pieces** (exp20 re-eval):
+   after fixing the test-label bug, the CNN scores 94.6% rotation on
+   Bezier-edge pieces — the earlier "realistic pieces break rotation"
+   finding (exp20-21) and the RoMa pivot (exp22) were artifacts of the bug.
+5. **Measure before you pivot**: three experiments and a research survey
+   were driven by a metric that was capped at 25% by construction. A
+   perfect-model sanity check on any new test path would have caught it.
 
-**Next Steps:**
-- Implement hybrid approach: RoMa for rotation, CNN for position
-- Improve RoMa position extraction (RANSAC filtering, confidence weighting)
-- Investigate faster dense matchers or distilled models for real-time inference
-- Consider using RoMa's rotation as soft labels to train a faster CNN rotation
-  predictor
+**Next Steps** (from the critical review, reordered now that #1 is done):
+- Run classical baselines (NCC template matching, SIFT/ORB) on the same
+  benchmark to establish the floor
+- Fix the methodology harness: frozen train/val/test split, checkpoint
+  selection on val (not test), train metrics in eval mode
+- Attack realism: photographed-piece "north star" test set; independent
+  photometric jitter / perspective / backgrounds in synthetic data
 
 ---

--- a/network/experiments/exp20_realistic_pieces/README.md
+++ b/network/experiments/exp20_realistic_pieces/README.md
@@ -1,5 +1,17 @@
 # Experiment 20: Realistic Puzzle Pieces with 4x4 Grid
 
+> **RESULT UPDATE (July 2026):** The original run reported 72.9% cell /
+> 24.8% rotation. The rotation number was a test-set bug:
+> `RealisticPieceTestDataset` discarded the rotation baked into each piece
+> PNG at generation time, scrambling the labels and capping measurable
+> rotation accuracy at 25%. After fixing the label composition
+> (`dataset.py`) and re-evaluating the original checkpoint on a
+> deterministic regeneration of the same test split
+> (`regenerate_test_split.py` + `reevaluate_checkpoint.py`), the true
+> result is **72.9% cell / 94.6% rotation / 72.2% both**
+> (`outputs/reeval_fixed_labels.json`). Rotation did NOT fail on
+> realistic pieces.
+
 ## Objective
 
 Test whether the model can generalize to realistically-shaped puzzle pieces

--- a/network/experiments/exp20_realistic_pieces/dataset.py
+++ b/network/experiments/exp20_realistic_pieces/dataset.py
@@ -294,7 +294,11 @@ class RealisticPieceTestDataset(Dataset):
         self.piece_size = piece_size
         self.puzzle_size = puzzle_size
 
-        # Build sample list: for each piece, create 4 samples (one per rotation)
+        # Build sample list: for each piece, create 4 samples (one per applied rotation).
+        # Each entry: (puzzle_id, piece_path, cx, cy, base_rotation, applied_rotation_idx)
+        # where base_rotation is the rotation already baked into the piece PNG at
+        # generation time (parsed from the filename) and applied_rotation_idx is the
+        # additional test-time rotation. The label is the composition of both.
         self.samples: list[tuple[str, Path, float, float, int, int]] = []
 
         for puzzle_id in puzzle_ids:
@@ -302,22 +306,22 @@ class RealisticPieceTestDataset(Dataset):
             if not puzzle_dir.exists():
                 continue
 
-            # Get unique pieces (ignore the rotation in filename for grouping)
-            piece_positions: dict[tuple[float, float], Path] = {}
+            # Get unique pieces (one file per position; keep its baked-in rotation)
+            piece_positions: dict[tuple[float, float], tuple[Path, int]] = {}
             piece_files = list(puzzle_dir.glob(f"{puzzle_id}_x*_y*_rot*.png"))
 
             for piece_path in piece_files:
                 parsed = parse_piece_filename(piece_path.name)
                 if parsed:
-                    _, cx, cy, _ = parsed
+                    _, cx, cy, base_rotation = parsed
                     # Use first file found for each position
                     if (cx, cy) not in piece_positions:
-                        piece_positions[(cx, cy)] = piece_path
+                        piece_positions[(cx, cy)] = (piece_path, base_rotation)
 
-            # For each unique position, create samples for all 4 rotations
-            for (cx, cy), piece_path in piece_positions.items():
-                for rotation_idx in range(4):
-                    self.samples.append((puzzle_id, piece_path, cx, cy, 0, rotation_idx))
+            # For each unique position, create samples for all 4 applied rotations
+            for (cx, cy), (piece_path, base_rotation) in piece_positions.items():
+                for applied_rotation_idx in range(4):
+                    self.samples.append((puzzle_id, piece_path, cx, cy, base_rotation, applied_rotation_idx))
 
         # Cache for loaded puzzle images
         self._puzzle_cache: dict[str, Image.Image] = {}
@@ -372,13 +376,16 @@ class RealisticPieceTestDataset(Dataset):
         Returns:
             Tuple of (piece_tensor, puzzle_tensor, target_coords, cell_idx, rotation_idx).
         """
-        puzzle_id, piece_path, cx, cy, base_rotation, rotation_idx = self.samples[idx]
+        puzzle_id, piece_path, cx, cy, base_rotation, applied_rotation_idx = self.samples[idx]
 
-        # Load piece
+        # Load piece (already has base_rotation baked in from generation)
         piece_img = self._load_piece(piece_path)
 
-        # Apply test rotation
-        piece_img = self._rotate_piece(piece_img, rotation_idx)
+        # Apply additional test rotation; the label is the total rotation,
+        # matching the training path in RealisticPieceDataset.
+        piece_img = self._rotate_piece(piece_img, applied_rotation_idx)
+        total_rotation = (base_rotation + ROTATION_ANGLES[applied_rotation_idx]) % 360
+        rotation_idx = total_rotation // 90
 
         # Load puzzle
         puzzle_img = self._load_puzzle(puzzle_id)

--- a/network/experiments/exp20_realistic_pieces/outputs/reeval_fixed_labels.json
+++ b/network/experiments/exp20_realistic_pieces/outputs/reeval_fixed_labels.json
@@ -1,0 +1,43 @@
+{
+  "checkpoint": "/Users/claus/Repos/pussel/network/experiments/exp20_realistic_pieces/outputs/checkpoint_best.pt",
+  "dataset_root": "/Users/claus/Repos/pussel/network/datasets/realistic_4x4_20k_test",
+  "n_test_puzzles": 1200,
+  "n_samples": 76800,
+  "cell_accuracy": 0.7288671875,
+  "rotation_accuracy": 0.9456901041666667,
+  "cell_and_rotation_accuracy": 0.7222916666666667,
+  "per_rotation_accuracy": {
+    "0deg": 0.94984375,
+    "90deg": 0.9424479166666667,
+    "180deg": 0.9474479166666666,
+    "270deg": 0.9430208333333333
+  },
+  "rotation_confusion_true_x_pred": [
+    [
+      18237,
+      124,
+      727,
+      112
+    ],
+    [
+      160,
+      18095,
+      109,
+      836
+    ],
+    [
+      764,
+      123,
+      18191,
+      122
+    ],
+    [
+      138,
+      833,
+      123,
+      18106
+    ]
+  ],
+  "original_buggy_cell_accuracy": 0.7285677083333333,
+  "original_buggy_rotation_accuracy": 0.24764322916666667
+}

--- a/network/experiments/exp20_realistic_pieces/outputs/reeval_fixed_labels.json
+++ b/network/experiments/exp20_realistic_pieces/outputs/reeval_fixed_labels.json
@@ -1,6 +1,6 @@
 {
-  "checkpoint": "/Users/claus/Repos/pussel/network/experiments/exp20_realistic_pieces/outputs/checkpoint_best.pt",
-  "dataset_root": "/Users/claus/Repos/pussel/network/datasets/realistic_4x4_20k_test",
+  "checkpoint": "checkpoint_best.pt",
+  "dataset_root": "realistic_4x4_20k_test",
   "n_test_puzzles": 1200,
   "n_samples": 76800,
   "cell_accuracy": 0.7288671875,

--- a/network/experiments/exp20_realistic_pieces/reevaluate_checkpoint.py
+++ b/network/experiments/exp20_realistic_pieces/reevaluate_checkpoint.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Re-evaluate the exp20 checkpoint on the test set with FIXED rotation labels.
+
+The original exp20 evaluation used RealisticPieceTestDataset with a bug: the
+rotation baked into each piece PNG at generation time was discarded (base
+rotation hardcoded to 0), so test rotation labels were scrambled and rotation
+accuracy was capped at ~25% regardless of model quality. This script evaluates
+the original checkpoint on the same test puzzles with correctly composed
+labels ((baked + applied) % 360).
+
+Cell accuracy is unaffected by the label bug, so reproducing the original
+~72.9% cell accuracy validates that the regenerated test set is faithful.
+
+Usage:
+    python reevaluate_checkpoint.py \
+        --checkpoint /path/to/checkpoint_best.pt \
+        --dataset-root /path/to/datasets/realistic_4x4_20k_test \
+        --puzzle-root /path/to/datasets/puzzles
+"""
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import torch
+from torch.utils.data import DataLoader
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from dataset import GRID_SIZE, RealisticPieceTestDataset, get_puzzle_ids  # noqa: E402
+from model import FastBackboneModel  # noqa: E402
+
+
+def get_device() -> torch.device:
+    """Get the best available device (MPS > CUDA > CPU)."""
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
+
+
+def main() -> None:
+    """Evaluate the checkpoint with corrected rotation labels."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint", type=Path, required=True)
+    parser.add_argument("--dataset-root", type=Path, required=True)
+    parser.add_argument("--puzzle-root", type=Path, required=True)
+    parser.add_argument("--batch-size", type=int, default=256)
+    parser.add_argument("--num-workers", type=int, default=6)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(__file__).parent / "outputs" / "reeval_fixed_labels.json",
+    )
+    args = parser.parse_args()
+
+    device = get_device()
+    print(f"Device: {device}")
+
+    # Model: architecture as trained (train_cuda.py saved a raw state_dict)
+    model = FastBackboneModel(backbone_name="shufflenet_v2_x0_5", pretrained=False)
+    state_dict = torch.load(args.checkpoint, map_location="cpu", weights_only=True)
+    model.load_state_dict(state_dict)
+    model.to(device)
+    model.eval()
+    print(f"Loaded checkpoint: {args.checkpoint}")
+
+    test_ids = get_puzzle_ids(args.dataset_root)
+    dataset = RealisticPieceTestDataset(
+        puzzle_ids=test_ids,
+        dataset_root=args.dataset_root,
+        puzzle_root=args.puzzle_root,
+        piece_size=128,
+        puzzle_size=256,
+    )
+    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=False, num_workers=args.num_workers)
+
+    all_true_cells: list[int] = []
+    all_pred_cells: list[int] = []
+    all_true_rots: list[int] = []
+    all_pred_rots: list[int] = []
+
+    start = time.time()
+    with torch.no_grad():
+        for i, (pieces, puzzles, _targets, cells, rotations) in enumerate(loader):
+            pieces = pieces.to(device)
+            puzzles = puzzles.to(device)
+
+            positions, rotation_logits, _ = model(pieces, puzzles)
+
+            # Cell from predicted position (same rule as predict_cell, without
+            # a second forward pass)
+            col = torch.clamp((positions[:, 0] * GRID_SIZE).long(), 0, GRID_SIZE - 1)
+            row = torch.clamp((positions[:, 1] * GRID_SIZE).long(), 0, GRID_SIZE - 1)
+            pred_cells = row * GRID_SIZE + col
+
+            all_pred_cells.extend(pred_cells.cpu().tolist())
+            all_true_cells.extend(cells.tolist())
+            all_pred_rots.extend(rotation_logits.argmax(dim=1).cpu().tolist())
+            all_true_rots.extend(rotations.tolist())
+
+            if (i + 1) % 25 == 0:
+                done = len(all_true_cells)
+                print(f"  [{done}/{len(dataset)}] {time.time() - start:.0f}s", flush=True)
+
+    n = len(all_true_cells)
+    cell_acc = sum(p == t for p, t in zip(all_pred_cells, all_true_cells)) / n
+    rot_acc = sum(p == t for p, t in zip(all_pred_rots, all_true_rots)) / n
+    both_acc = (
+        sum(
+            pc == tc and pr == tr
+            for pc, tc, pr, tr in zip(all_pred_cells, all_true_cells, all_pred_rots, all_true_rots)
+        )
+        / n
+    )
+
+    # Rotation confusion matrix (true x predicted)
+    confusion = [[0] * 4 for _ in range(4)]
+    for t, p in zip(all_true_rots, all_pred_rots):
+        confusion[t][p] += 1
+
+    # Per-true-rotation accuracy
+    per_rot_acc = {}
+    for r in range(4):
+        total = sum(confusion[r])
+        per_rot_acc[f"{r * 90}deg"] = confusion[r][r] / total if total else 0.0
+
+    print("\n" + "=" * 60)
+    print("RE-EVALUATION WITH FIXED ROTATION LABELS")
+    print("=" * 60)
+    print(f"Samples: {n} ({len(test_ids)} puzzles x 16 cells x 4 rotations)")
+    print(f"Cell accuracy:     {cell_acc:.1%}  (original buggy eval: 72.9%)")
+    print(f"Rotation accuracy: {rot_acc:.1%}  (original buggy eval: 24.8%)")
+    print(f"Cell AND rotation: {both_acc:.1%}")
+    print(f"Per-rotation accuracy: {per_rot_acc}")
+    print("Rotation confusion (rows=true 0/90/180/270, cols=pred):")
+    for row_counts in confusion:
+        print(f"  {row_counts}")
+
+    results = {
+        "checkpoint": str(args.checkpoint),
+        "dataset_root": str(args.dataset_root),
+        "n_test_puzzles": len(test_ids),
+        "n_samples": n,
+        "cell_accuracy": cell_acc,
+        "rotation_accuracy": rot_acc,
+        "cell_and_rotation_accuracy": both_acc,
+        "per_rotation_accuracy": per_rot_acc,
+        "rotation_confusion_true_x_pred": confusion,
+        "original_buggy_cell_accuracy": 0.7285677083333333,
+        "original_buggy_rotation_accuracy": 0.24764322916666667,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"\nSaved results to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/network/experiments/exp20_realistic_pieces/reevaluate_checkpoint.py
+++ b/network/experiments/exp20_realistic_pieces/reevaluate_checkpoint.py
@@ -141,8 +141,10 @@ def main() -> None:
         print(f"  {row_counts}")
 
     results = {
-        "checkpoint": str(args.checkpoint),
-        "dataset_root": str(args.dataset_root),
+        # Store basenames only: absolute paths are machine-specific and would
+        # make this committed artifact non-portable / produce noisy diffs.
+        "checkpoint": args.checkpoint.name,
+        "dataset_root": args.dataset_root.name,
         "n_test_puzzles": len(test_ids),
         "n_samples": n,
         "cell_accuracy": cell_acc,

--- a/network/experiments/exp20_realistic_pieces/regenerate_test_split.py
+++ b/network/experiments/exp20_realistic_pieces/regenerate_test_split.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Regenerate the exp20 test-split pieces for re-evaluation.
+
+The original `realistic_4x4_20k` dataset (generated December 2025, deleted
+after the RunPod run) is reproducible: `generate_dataset.py` seeds each
+puzzle's edge grid with `seed + source_index`, and `generate_edge_grid`
+reseeds the global RNG, so every piece (shape AND baked-in rotation) is a
+pure function of the per-puzzle seed.
+
+This script reproduces the original train/test split (seed-42 shuffle over
+all generated puzzle IDs, as in `create_datasets`) and regenerates pieces
+for the test puzzles only.
+
+IMPORTANT: `puzzle_shapes` received edge-geometry fixes in January 2026
+(commits 532224c, d23f988) AFTER the exp20 dataset was generated. To
+reproduce the shapes the checkpoint was trained on, pass the historical
+package via --puzzle-shapes-path (extracted from commit 6b61eb7).
+
+Usage:
+    python regenerate_test_split.py \
+        --source-dir /path/to/datasets/puzzles \
+        --output-dir /path/to/datasets/realistic_4x4_20k_test \
+        --puzzle-shapes-path /path/to/hist_lib
+"""
+
+import argparse
+import random
+import sys
+import time
+from pathlib import Path
+
+# Original run configuration (setup_and_train.sh / train_cuda.py args)
+N_TRAIN_PUZZLES_REQUESTED = 10800
+N_TEST_PUZZLES_REQUESTED = 1200
+GENERATION_SEED = 42
+SPLIT_SEED = 42
+
+
+def reproduce_split(source_dir: Path) -> tuple[list[str], dict[str, int]]:
+    """Reproduce the original test split and per-puzzle generation seeds.
+
+    Mirrors generate_dataset.generate_dataset (sorted glob, index-based
+    seeds) and dataset.create_datasets (seed-42 shuffle, min() clamping).
+
+    Args:
+        source_dir: Directory with the source puzzle JPEGs.
+
+    Returns:
+        Tuple of (test puzzle IDs sorted, mapping of puzzle ID to its
+        generation seed).
+    """
+    puzzle_files = sorted(source_dir.glob("puzzle_*.jpg"))
+    # generate_dataset was invoked requesting >= all available puzzles,
+    # so every source image was processed, in sorted order.
+    generation_seeds = {p.stem: GENERATION_SEED + i for i, p in enumerate(puzzle_files)}
+
+    # create_datasets: get_puzzle_ids returns sorted dir names == sorted stems
+    all_ids = sorted(generation_seeds)
+    rng = random.Random(SPLIT_SEED)
+    shuffled = all_ids.copy()
+    rng.shuffle(shuffled)
+
+    n_train = min(N_TRAIN_PUZZLES_REQUESTED, len(shuffled) - N_TEST_PUZZLES_REQUESTED)
+    n_test = min(N_TEST_PUZZLES_REQUESTED, len(shuffled) - n_train)
+    test_ids = sorted(shuffled[n_train : n_train + n_test])
+
+    print(f"Source puzzles: {len(puzzle_files)}")
+    print(f"Split: {n_train} train / {n_test} test puzzles")
+    return test_ids, generation_seeds
+
+
+def main() -> None:
+    """Regenerate test-split pieces with the original per-puzzle seeds."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument(
+        "--puzzle-shapes-path",
+        type=Path,
+        default=None,
+        help="Directory containing the (historical) puzzle_shapes package to import",
+    )
+    args = parser.parse_args()
+
+    if args.puzzle_shapes_path is not None:
+        sys.path.insert(0, str(args.puzzle_shapes_path))
+    # Import after path setup so generate_dataset picks up the right library
+    sys.path.insert(0, str(Path(__file__).parent))
+    import puzzle_shapes
+
+    print(f"puzzle_shapes loaded from: {puzzle_shapes.__file__}")
+    from generate_dataset import generate_pieces_for_puzzle
+
+    test_ids, generation_seeds = reproduce_split(args.source_dir)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "test_ids.txt").write_text("\n".join(test_ids) + "\n")
+
+    start = time.time()
+    for n, puzzle_id in enumerate(test_ids, 1):
+        puzzle_dir = args.output_dir / puzzle_id
+        if puzzle_dir.exists() and len(list(puzzle_dir.glob("*.png"))) == 16:
+            continue  # already generated
+        generate_pieces_for_puzzle(
+            args.source_dir / f"{puzzle_id}.jpg",
+            args.output_dir,
+            seed=generation_seeds[puzzle_id],
+            padding=20,
+            points_per_curve=20,
+        )
+        if n % 50 == 0 or n == len(test_ids):
+            elapsed = time.time() - start
+            print(f"  [{n}/{len(test_ids)}] {elapsed:.0f}s elapsed", flush=True)
+
+    print(f"\nDone: {len(test_ids)} test puzzles in {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Addresses item #1 of the [critical review](network/experiments/CRITICAL_REVIEW.md): fix the exp20 test-set rotation-label bug and re-evaluate the existing checkpoint.

The exp20 test dataset discarded the rotation baked into each piece PNG at generation time (hardcoded base rotation to 0), scrambling test rotation labels and **capping measurable rotation accuracy at 25% for any model, including a perfect one**. The dead-flat 24.8% curve was a measurement artifact, not a model failure.

`RealisticPieceTestDataset` now composes `(baked + applied) % 360`, matching the training path.

## Re-evaluation result

The original, unmodified RunPod checkpoint was re-evaluated on a deterministic regeneration of the same 1,200-puzzle test split (per-puzzle seed = `42 + source_index`, using the December 2025 `puzzle_shapes` the dataset was generated with — the library's edge geometry changed in Jan 2026):

| Metric | Original (buggy) | Fixed labels |
|---|---|---|
| Cell accuracy | 72.9% | **72.9%** (exact reproduction → test set is faithful) |
| Rotation accuracy | 24.8% | **94.6%** |
| Cell AND rotation | — | **72.2%** |

Residual rotation errors are almost entirely 180° confusions (0↔180, 90↔270) — a real model's failure mode, not noise.

## Impact on the roadmap

- **Rotation never failed on realistic pieces** — the CNN generalizes rotation nearly as well as on square pieces (95% in exp18).
- **exp21 is moot** — it "fixed" a bug that didn't exist in the model.
- **exp22's comparison inverts** — the CNN beats RoMa on both position (72.9% vs 63.5%) and rotation (94.6% vs 58.1%) at ~1000× lower inference cost. The RoMa/hybrid pivot is dropped.

## Changes

- `dataset.py` — compose baked + applied rotation in `RealisticPieceTestDataset`
- `regenerate_test_split.py` (new) — deterministic reproduction of the original test split
- `reevaluate_checkpoint.py` (new) — evaluation with corrected labels; writes `outputs/reeval_fixed_labels.json`
- Updated `EXPERIMENT_LOG.md`, `CRITICAL_REVIEW.md`, and the exp20 `README.md`

## Verification

`make check-network` passes (black, isort, flake8, pyright clean). Cell accuracy reproducing the original run to the decimal is the correctness check that the regenerated test set matches what the checkpoint was trained/evaluated on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)