### PR TITLE
exp23: classical baselines (NCC, SIFT, ORB) on the exp20 realistic-pieces benchmark

### DIFF
--- a/network/experiments/CRITICAL_REVIEW.md
+++ b/network/experiments/CRITICAL_REVIEW.md
@@ -74,6 +74,14 @@ training set. Consequences:
 
 ### 2. Every experiment measures a toy surrogate of the real task
 
+> **CONFIRMED (2026-07-13):** exp23 ran the classical baselines on the
+> exp20 benchmark. A zero-training SIFT→NCC hybrid scores **82.9% cell /
+> 90.3% rotation / 82.2% both** — 10 points above the CNN's 72.2%
+> both-correct — and even plain masked NCC beats the CNN on position
+> (77.5% vs 72.9%). The CNN *under-performs* the classical floor on the
+> surrogate, winning only rotation (94.6% vs 90.3%). See
+> `exp23_classical_baselines/`.
+
 The "piece" is a pixel-exact crop of the very same digital image the
 network receives as the puzzle input — same pixels, same lighting, no
 camera, no perspective, no background, no scale uncertainty (exp20 adds
@@ -155,6 +163,11 @@ chosen on this faulty comparison.
    template matching over cells × 4 rotations, and SIFT/ORB matching.
    This gives the floor every learned result must beat — and a reality
    check on whether the surrogate task is trivially solvable.
+
+   > **DONE (2026-07-13, exp23):** the floor is 82.2% both-correct
+   > (SIFT→NCC hybrid, no training), above the CNN's 72.2%. The
+   > surrogate is largely solvable by template matching; learned models
+   > must beat 82% here before any synthetic-benchmark gain counts.
 3. **Fix the methodology harness once, centrally:** a frozen
    train/val/test split shared by all experiments (val for selection,
    test touched once per experiment), checkpoint selection on val, train

--- a/network/experiments/EXPERIMENT_LOG.md
+++ b/network/experiments/EXPERIMENT_LOG.md
@@ -425,6 +425,48 @@ Conclusions:
 
 ---
 
+## Exp 23: Classical Baselines (NCC, SIFT, ORB)
+
+**Date:** July 2026 **Status:** BASELINE (best classical: **82.2% both** —
+above the CNN's 72.2%)
+
+Ran the non-learned baselines called for by item #2 of the critical
+review on the exact exp20 re-evaluation protocol (1,200 regenerated test
+puzzles × 16 pieces × 4 applied rotations = 76,800 samples, labels
+composed as `(baked + applied) % 360`). Classical methods used native
+resolution (256×256 puzzles, ~110–130 px piece crops, no 128×128
+squashing). Full results in `exp23_classical_baselines/`.
+
+| Method              | Cell      | Rotation  | Both      | Coverage | ms/sample |
+| ------------------- | --------- | --------- | --------- | -------- | --------- |
+| SIFT→NCC hybrid     | **82.9%** | 90.3%     | **82.2%** | 99.6%    | 45        |
+| Masked NCC          | 77.5%     | 87.2%     | 76.9%     | 99.6%    | 77        |
+| CNN (exp20 re-eval) | 72.9%     | **94.6%** | 72.2%     | 100%     | ~10 (GPU) |
+| SIFT                | 43.9%     | 44.1%     | 43.6%     | 45.4%    | 3.2       |
+| ORB (tuned)         | 38.4%     | 38.3%     | 37.7%     | 40.4%    | 4.8       |
+
+NCC = `cv2.matchTemplate` (`TM_CCOEFF_NORMED`, black-background mask)
+over the 4 candidate rotations. SIFT/ORB = ratio test + partial-affine
+RANSAC; position from inlier centroid, rotation from the transform angle
+snapped to 90°. SIFT is nearly perfect when it matches (96.7% cell /
+97.3% rotation on the 45% of pieces with enough texture) — its headline
+number is a coverage failure, not wrong answers — hence the hybrid:
+SIFT when it matches, NCC otherwise, still zero-training.
+
+Conclusions:
+
+1. **The classical floor is above the CNN.** Even plain masked NCC beats
+   the trained model on position and both-correct; the hybrid beats it
+   by 10 points. The CNN only wins rotation (94.6% vs 90.3%).
+2. **The surrogate task is largely solvable by template matching**, as
+   the review suspected. Learned results on this benchmark must clear
+   ~82% both-correct to demonstrate value over classical matching —
+   until the benchmark is made adversarial to pixel matching
+   (photometric jitter, perspective, backgrounds) or replaced with
+   photographed pieces.
+
+---
+
 ## Summary Table
 
 | Exp | Focus                       | Test Result            | Key Finding                                    |
@@ -451,6 +493,7 @@ Conclusions:
 | 20  | 4x4 realistic pieces        | **73% cell / 95% rot** | Scales to 4x4 (rot re-measured after label fix)|
 | 21  | Masked rotation correlation | 74% cell / 25% rot     | INVALID — capped by test-label bug             |
 | 22  | RoMa V2 dense matching      | 64% cell / 58% rot     | Loses to CNN on both metrics (after label fix) |
+| 23  | Classical baselines         | **83% cell / 90% rot** | SIFT→NCC hybrid beats the CNN with no training |
 
 ---
 
@@ -477,10 +520,13 @@ puzzles. This is the current production-ready model for 3x3 grids.
 **For Fast Experimentation:** ShuffleNetV2_x0.5 (exp15) - 12.9s/epoch vs 39.3s
 for RepVGG and 98.1s for MobileOne. Use for rapid iteration.
 
-**For Position + Rotation (4×4 realistic pieces):** FastBackboneModel CNN
-(exp20) alone — **72.9% cell / 94.6% rotation / 72.2% both** (re-evaluated
-July 2026 after fixing the test-label bug). RoMa (exp22) is worse on both
-metrics and ~1000× slower; the hybrid plan is dropped.
+**For Position + Rotation (4×4 realistic pieces):** the zero-training
+SIFT→NCC classical hybrid (exp23) — **82.9% cell / 90.3% rotation / 82.2%
+both** at ~45 ms/piece on CPU — currently beats the FastBackboneModel CNN
+(exp20, re-evaluated July 2026: 72.9% cell / 94.6% rotation / 72.2% both).
+The CNN wins only on rotation. RoMa (exp22) is worse than both and ~1000×
+slower; the RoMa hybrid plan is dropped. Any future learned model on this
+benchmark must clear the 82% classical floor to count as progress.
 
 **Key Learnings:**
 1. **Data quantity AND quality matter** (exp17): Must see all cells per puzzle
@@ -497,12 +543,12 @@ metrics and ~1000× slower; the hybrid plan is dropped.
    were driven by a metric that was capped at 25% by construction. A
    perfect-model sanity check on any new test path would have caught it.
 
-**Next Steps** (from the critical review, reordered now that #1 is done):
-- Run classical baselines (NCC template matching, SIFT/ORB) on the same
-  benchmark to establish the floor
+**Next Steps** (from the critical review; #1 and #2 are done):
 - Fix the methodology harness: frozen train/val/test split, checkpoint
   selection on val (not test), train metrics in eval mode
 - Attack realism: photographed-piece "north star" test set; independent
-  photometric jitter / perspective / backgrounds in synthetic data
+  photometric jitter / perspective / backgrounds in synthetic data —
+  now urgent, since exp23 showed the synthetic benchmark is largely
+  solvable by pixel matching and cannot demonstrate learned-model value
 
 ---

--- a/network/experiments/exp23_classical_baselines/README.md
+++ b/network/experiments/exp23_classical_baselines/README.md
@@ -1,0 +1,112 @@
+# Experiment 23: Classical Baselines (NCC, SIFT, ORB)
+
+## Objective
+
+Run the non-learned baselines that item #2 of `../CRITICAL_REVIEW.md` called
+for: establish the floor every learned result must beat on the exp20 4x4
+realistic-pieces benchmark, and answer whether the synthetic surrogate task is
+trivially solvable by template matching.
+
+## Setup
+
+Exact same protocol as the exp20 CNN re-evaluation (July 2026, fixed rotation
+labels):
+
+- Test set: `realistic_4x4_20k_test` — 1,200 puzzles x 16 pieces x 4 applied
+  rotations = **76,800 samples**
+- Labels composed as `(baked_rotation_from_filename + applied) % 360`; the
+  applied rotation uses the same PIL `rotate(expand=False)` call as
+  `RealisticPieceTestDataset`
+- Metrics: cell accuracy (16-way), rotation accuracy (4-way), both-correct
+- Matched subsample: 200 puzzles (seed 42, 12,800 samples) reported for all
+  methods so any slower method can be compared on identical data
+
+**Resolution:** classical methods use the images at native resolution —
+puzzle JPEGs are 256x256 and piece PNGs are variable-size tight crops
+(~110–130 px) on black backgrounds. Unlike the CNN input pipeline, pieces are
+*not* squashed to 128x128 squares. Runtimes are per sample, single CPU core
+(Apple M-series); the run is parallelized over puzzles with 8 workers.
+
+### Methods
+
+1. **NCC** — masked `cv2.matchTemplate` with `TM_CCOEFF_NORMED` (mask =
+   pixels brighter than 8, i.e. not the black background). The piece is slid
+   over the full puzzle at each of the 4 candidate un-rotations (lossless
+   `np.rot90`); the best-scoring location + rotation wins. Predicted cell =
+   4x4 cell containing the matched template center.
+2. **SIFT** — keypoints on the masked piece matched to puzzle keypoints
+   (BFMatcher, Lowe ratio 0.75), partial-affine RANSAC
+   (`cv2.estimateAffinePartial2D`, reproj threshold 3.0, min 4 good matches /
+   3 inliers). Position = inlier centroid; rotation = transform angle snapped
+   to the nearest 90°.
+3. **ORB** — same harness as SIFT with Hamming matching. Default ORB detects
+   almost no keypoints on these small low-texture pieces (~8% coverage), so it
+   runs with `nfeatures=3000, fastThreshold=0, edgeThreshold=10, nlevels=12`
+   (~40% coverage).
+4. **SIFT→NCC hybrid** — still fully classical: use the SIFT prediction when
+   SIFT matches, otherwise fall back to NCC. Derived from the same per-sample
+   records, so its runtime is SIFT plus NCC on the ~55% of samples that need
+   the fallback.
+
+Keypoint methods sometimes produce no prediction (too few keypoints/matches/
+inliers). Headline metrics count those samples as wrong; `*_covered` values in
+`outputs/results.json` condition on a prediction existing. NCC coverage is
+99.6% (the remaining 0.4% are samples where the masked response was NaN/inf at
+every candidate rotation).
+
+## Results (full 76,800 samples)
+
+| Method              | Cell      | Rotation  | Both      | Coverage | ms/sample |
+| ------------------- | --------- | --------- | --------- | -------- | --------- |
+| **SIFT→NCC hybrid** | **82.9%** | 90.3%     | **82.2%** | 99.6%    | 45.4      |
+| NCC (masked CCOEFF) | 77.5%     | 87.2%     | 76.9%     | 99.6%    | 76.8      |
+| CNN (exp20 re-eval) | 72.9%     | **94.6%** | 72.2%     | 100%     | ~10 (GPU) |
+| SIFT                | 43.9%     | 44.1%     | 43.6%     | 45.4%    | 3.2       |
+| ORB (tuned)         | 38.4%     | 38.3%     | 37.7%     | 40.4%    | 4.8       |
+
+On the matched 200-puzzle subsample (seed 42, 12,800 samples): hybrid
+83.5% both, NCC 78.0% both, SIFT 44.3% both, ORB 39.1% both — same ordering,
+so the subsample is a faithful stand-in if a slower method ever needs it.
+
+When SIFT does match, it is nearly perfect: 96.7% cell / 97.3% rotation on
+the 45% of samples it covers. Its failures are coverage failures (too little
+texture on the piece), not wrong answers. SIFT/ORB puzzle keypoint extraction
+adds ~9 ms per puzzle, amortized over 64 samples.
+
+## Conclusions
+
+1. **The floor is above the CNN.** The best classical method (SIFT→NCC
+   hybrid, 82.2% both-correct) beats the exp20 CNN (72.2%) by 10 points, and
+   even plain masked NCC beats it on position (77.5% vs 72.9%) and
+   both-correct (76.9% vs 72.2%). The CNN only wins on rotation
+   (94.6% vs 90.3%).
+2. **The surrogate task is largely solvable by template matching**, as the
+   critical review suspected. It is not literally trivial (pixel-identical
+   crops would give ~100%; Bezier masking, `expand=False` rotation clipping
+   and JPEG resampling cost NCC ~23 points), but a zero-training afternoon
+   baseline outperforming the trained model means synthetic-benchmark gains
+   cannot be read as progress on the real task.
+3. **Learned-model results on this benchmark must now clear 82% both-correct**
+   to demonstrate any value over classical matching — until the benchmark
+   itself is made adversarial to pixel matching (independent photometric
+   jitter, perspective, backgrounds, sensor noise) or replaced with
+   photographed pieces, per items #4–5 of the critical review.
+
+## Files
+
+- `evaluate.py` — runs all methods; writes `outputs/results.json`
+- `outputs/results.json` — full + subsample metrics, parameters, CNN reference
+
+## Reproduce
+
+```bash
+cd network
+uv run python experiments/exp23_classical_baselines/evaluate.py \
+    --dataset-root datasets/realistic_4x4_20k_test \
+    --puzzle-root datasets/puzzles \
+    --workers 8
+```
+
+The test set is regenerated (not checked in); see the "Exp 20 Re-Evaluation"
+entry in `../EXPERIMENT_LOG.md` for how to rebuild it with the historical
+`puzzle_shapes` geometry.

--- a/network/experiments/exp23_classical_baselines/README.md
+++ b/network/experiments/exp23_classical_baselines/README.md
@@ -24,8 +24,11 @@ labels):
 **Resolution:** classical methods use the images at native resolution —
 puzzle JPEGs are 256x256 and piece PNGs are variable-size tight crops
 (~110–130 px) on black backgrounds. Unlike the CNN input pipeline, pieces are
-*not* squashed to 128x128 squares. Runtimes are per sample, single CPU core
-(Apple M-series); the run is parallelized over puzzles with 8 workers.
+*not* squashed to 128x128 squares. Runtimes are wall-clock per sample on an
+Apple M-series CPU with OpenCV's default internal threading (not pinned to a
+single core); the run is additionally parallelized over puzzles with 8 worker
+processes, so absolute numbers are machine-dependent and best read relative
+to each other.
 
 ### Methods
 

--- a/network/experiments/exp23_classical_baselines/__init__.py
+++ b/network/experiments/exp23_classical_baselines/__init__.py
@@ -1,0 +1,1 @@
+"""Exp23: Classical (non-learned) baselines on the exp20 realistic-pieces benchmark."""

--- a/network/experiments/exp23_classical_baselines/evaluate.py
+++ b/network/experiments/exp23_classical_baselines/evaluate.py
@@ -37,8 +37,8 @@ from dataset import ROTATION_ANGLES, get_cell_index, parse_piece_filename  # noq
 
 METHOD_NAMES = ("ncc", "sift", "orb")
 
-# Pixels with max(R, G, B) above this are considered piece content (the
-# background introduced by the generator is pure black).
+# Pixels whose grayscale value is above this are considered piece content
+# (the background introduced by the generator is pure black).
 MASK_THRESHOLD = 8
 
 LOWE_RATIO = 0.75
@@ -403,11 +403,13 @@ def summarize(
     results: dict[str, Any] = {}
     for method in methods:
         match_seconds = sum(r["times"][method] for r in all_records)
+        # The derived hybrid reuses SIFT's per-puzzle keypoint extraction.
+        prep_seconds = prep_totals.get("sift" if method == "sift_else_ncc" else method, 0.0)
         results[method] = {
             "full": compute_metrics(all_records, method),
             "subsample": compute_metrics(subsample_records, method),
             "runtime_ms_per_sample": match_seconds / len(all_records) * 1000 if all_records else 0.0,
-            "puzzle_prep_ms_per_puzzle": prep_totals.get(method, 0.0) / n_puzzles * 1000 if n_puzzles else 0.0,
+            "puzzle_prep_ms_per_puzzle": prep_seconds / n_puzzles * 1000 if n_puzzles else 0.0,
         }
     return results
 

--- a/network/experiments/exp23_classical_baselines/evaluate.py
+++ b/network/experiments/exp23_classical_baselines/evaluate.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""Classical (non-learned) baselines on the exp20 4x4 realistic-pieces benchmark.
+
+Runs OpenCV normalized cross-correlation template matching (masked
+TM_CCOEFF_NORMED over the 4 candidate rotations) and SIFT/ORB keypoint
+matching (Lowe ratio test + partial-affine RANSAC) against the exact test
+protocol used for the exp20 CNN re-evaluation: every piece of every test
+puzzle at all 4 applied rotations, labels composed as
+(baked_rotation_from_filename + applied) % 360.
+
+Images are used at their native resolution: puzzle JPEGs are 256x256 and
+piece PNGs are variable-size tight crops (~110-130 px) on black backgrounds.
+Unlike the CNN input pipeline, pieces are NOT squashed to 128x128 squares.
+
+Usage:
+    python evaluate.py \
+        --dataset-root /path/to/datasets/realistic_4x4_20k_test \
+        --puzzle-root /path/to/datasets/puzzles
+"""
+
+import argparse
+import json
+import random
+import sys
+import time
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import cv2
+import numpy as np
+from PIL import Image
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "exp20_realistic_pieces"))
+
+from dataset import ROTATION_ANGLES, get_cell_index, parse_piece_filename  # noqa: E402
+
+METHOD_NAMES = ("ncc", "sift", "orb")
+
+# Pixels with max(R, G, B) above this are considered piece content (the
+# background introduced by the generator is pure black).
+MASK_THRESHOLD = 8
+
+LOWE_RATIO = 0.75
+RANSAC_REPROJ_THRESHOLD = 3.0
+MIN_GOOD_MATCHES = 4
+MIN_INLIERS = 3
+
+# ORB needs aggressive settings on these small, low-texture pieces: default
+# FAST/edge thresholds detect almost no keypoints (~8% of samples matchable).
+ORB_PARAMS = {"nfeatures": 3000, "fastThreshold": 0, "edgeThreshold": 10, "nlevels": 12}
+
+# Per-process cache of KeypointMatcher instances (workers reuse detectors).
+_MATCHER_CACHE: dict[str, "KeypointMatcher"] = {}
+
+
+def load_observed_piece(piece_path: Path, applied_rotation_idx: int) -> np.ndarray:
+    """Load a piece PNG and apply the test-time rotation exactly as the CNN evaluation did.
+
+    Mirrors RealisticPieceTestDataset: PIL clockwise rotation with
+    expand=False and bilinear resampling (the piece PNG already has its
+    generation-time rotation baked in).
+
+    Args:
+        piece_path: Path to the piece PNG.
+        applied_rotation_idx: Index into ROTATION_ANGLES for the applied rotation.
+
+    Returns:
+        RGB uint8 array of the observed (rotated) piece.
+    """
+    piece_img = Image.open(piece_path).convert("RGB")
+    angle = ROTATION_ANGLES[applied_rotation_idx]
+    if angle != 0:
+        piece_img = piece_img.rotate(-angle, expand=False, resample=Image.Resampling.BILINEAR)
+    return np.array(piece_img)
+
+
+def piece_mask(gray: np.ndarray) -> np.ndarray:
+    """Build a template mask that excludes the black background.
+
+    Args:
+        gray: Grayscale piece image.
+
+    Returns:
+        uint8 mask (255 = piece content, 0 = background).
+    """
+    return (gray > MASK_THRESHOLD).astype(np.uint8) * 255
+
+
+def predict_ncc(observed_rgb: np.ndarray, puzzle_bgr: np.ndarray) -> tuple[int, int] | None:
+    """Predict cell and rotation via masked normalized cross-correlation.
+
+    Slides the piece over the puzzle at each of the 4 candidate un-rotations
+    (lossless np.rot90) and takes the best-scoring location + rotation.
+
+    Args:
+        observed_rgb: Observed piece (RGB uint8, rotation to be recovered).
+        puzzle_bgr: Full puzzle image (BGR uint8).
+
+    Returns:
+        Tuple of (pred_cell, pred_rotation_idx), or None if no candidate fit.
+    """
+    best_score = -np.inf
+    best: tuple[int, int] | None = None
+    puz_h, puz_w = puzzle_bgr.shape[:2]
+
+    for candidate_idx in range(4):
+        # np.rot90(k) rotates counter-clockwise: un-rotates a piece that was
+        # rotated clockwise by candidate_idx * 90 degrees.
+        template = np.ascontiguousarray(np.rot90(observed_rgb, k=candidate_idx))
+        template_bgr = cv2.cvtColor(template, cv2.COLOR_RGB2BGR)
+        tpl_h, tpl_w = template_bgr.shape[:2]
+        if tpl_h > puz_h or tpl_w > puz_w:
+            continue
+
+        mask = piece_mask(cv2.cvtColor(template_bgr, cv2.COLOR_BGR2GRAY))
+        response = cv2.matchTemplate(puzzle_bgr, template_bgr, cv2.TM_CCOEFF_NORMED, mask=mask)
+        response = np.nan_to_num(response, nan=-np.inf, posinf=-np.inf, neginf=-np.inf)
+        _, max_val, _, max_loc = cv2.minMaxLoc(response)
+
+        if max_val > best_score:
+            best_score = max_val
+            center_x = (max_loc[0] + tpl_w / 2) / puz_w
+            center_y = (max_loc[1] + tpl_h / 2) / puz_h
+            best = (get_cell_index(center_x, center_y), candidate_idx)
+
+    return best
+
+
+class KeypointMatcher:
+    """SIFT or ORB keypoint matching with ratio test + partial-affine RANSAC.
+
+    Position is derived from the inlier centroid in puzzle coordinates and
+    rotation from the recovered similarity transform snapped to the nearest
+    90 degrees.
+    """
+
+    def __init__(self, kind: str):
+        """Initialize detector and matcher.
+
+        Args:
+            kind: Either "sift" or "orb".
+        """
+        if kind == "sift":
+            self.detector = cv2.SIFT_create()
+            self.matcher = cv2.BFMatcher(cv2.NORM_L2)
+        elif kind == "orb":
+            self.detector = cv2.ORB_create(**ORB_PARAMS)
+            self.matcher = cv2.BFMatcher(cv2.NORM_HAMMING)
+        else:
+            raise ValueError(f"Unknown keypoint matcher kind: {kind}")
+
+    def detect_puzzle(self, puzzle_gray: np.ndarray) -> tuple[Any, Any]:
+        """Detect keypoints/descriptors on the full puzzle (once per puzzle).
+
+        Args:
+            puzzle_gray: Grayscale puzzle image.
+
+        Returns:
+            Tuple of (keypoints, descriptors).
+        """
+        return self.detector.detectAndCompute(puzzle_gray, None)
+
+    def predict(
+        self,
+        observed_rgb: np.ndarray,
+        puzzle_kp: Any,
+        puzzle_des: Any,
+        puzzle_shape: tuple[int, int],
+    ) -> tuple[int, int] | None:
+        """Predict cell and rotation for one observed piece.
+
+        Args:
+            observed_rgb: Observed piece (RGB uint8).
+            puzzle_kp: Puzzle keypoints from detect_puzzle.
+            puzzle_des: Puzzle descriptors from detect_puzzle.
+            puzzle_shape: (height, width) of the puzzle image.
+
+        Returns:
+            Tuple of (pred_cell, pred_rotation_idx), or None if matching failed.
+        """
+        gray = cv2.cvtColor(observed_rgb, cv2.COLOR_RGB2GRAY)
+        piece_kp, piece_des = self.detector.detectAndCompute(gray, piece_mask(gray))
+        if piece_des is None or puzzle_des is None or len(piece_kp) < MIN_GOOD_MATCHES:
+            return None
+
+        pairs = self.matcher.knnMatch(piece_des, puzzle_des, k=2)
+        good = [m for m, n in (p for p in pairs if len(p) == 2) if m.distance < LOWE_RATIO * n.distance]
+        if len(good) < MIN_GOOD_MATCHES:
+            return None
+
+        src = np.float32([piece_kp[m.queryIdx].pt for m in good]).reshape(-1, 1, 2)
+        dst = np.float32([puzzle_kp[m.trainIdx].pt for m in good]).reshape(-1, 1, 2)
+        transform, inliers = cv2.estimateAffinePartial2D(
+            src, dst, method=cv2.RANSAC, ransacReprojThreshold=RANSAC_REPROJ_THRESHOLD
+        )
+        if transform is None or inliers is None or int(inliers.sum()) < MIN_INLIERS:
+            return None
+
+        # The transform un-rotates the observed piece onto the puzzle, so its
+        # rotation angle is minus the piece's total rotation.
+        theta = np.degrees(np.arctan2(transform[1, 0], transform[0, 0]))
+        pred_rotation_idx = int(round(-theta / 90)) % 4
+
+        inlier_flags = inliers.ravel().astype(bool)
+        centroid = dst.reshape(-1, 2)[inlier_flags].mean(axis=0)
+        puz_h, puz_w = puzzle_shape
+        pred_cell = get_cell_index(float(centroid[0]) / puz_w, float(centroid[1]) / puz_h)
+        return pred_cell, pred_rotation_idx
+
+
+def _get_matcher(kind: str) -> KeypointMatcher:
+    """Get (or create) the per-process matcher for the given kind.
+
+    Args:
+        kind: Either "sift" or "orb".
+
+    Returns:
+        Cached KeypointMatcher instance.
+    """
+    if kind not in _MATCHER_CACHE:
+        _MATCHER_CACHE[kind] = KeypointMatcher(kind)
+    return _MATCHER_CACHE[kind]
+
+
+def enumerate_pieces(puzzle_dir: Path, puzzle_id: str) -> list[tuple[Path, float, float, int]]:
+    """Enumerate unique piece files for a puzzle, mirroring RealisticPieceTestDataset.
+
+    Args:
+        puzzle_dir: Directory containing the puzzle's piece PNGs.
+        puzzle_id: Puzzle identifier.
+
+    Returns:
+        List of (piece_path, cx, cy, base_rotation), first file per position.
+    """
+    positions: dict[tuple[float, float], tuple[Path, int]] = {}
+    for piece_path in puzzle_dir.glob(f"{puzzle_id}_x*_y*_rot*.png"):
+        parsed = parse_piece_filename(piece_path.name)
+        if parsed:
+            _, cx, cy, base_rotation = parsed
+            if (cx, cy) not in positions:
+                positions[(cx, cy)] = (piece_path, base_rotation)
+    return [(path, cx, cy, rot) for (cx, cy), (path, rot) in sorted(positions.items())]
+
+
+def evaluate_puzzle(job: tuple[str, str, str, tuple[str, ...]]) -> tuple[list[dict[str, Any]], dict[str, float]]:
+    """Evaluate all samples of one puzzle with all requested methods (worker entry point).
+
+    Args:
+        job: Tuple of (puzzle_id, dataset_root, puzzle_root, methods).
+
+    Returns:
+        Tuple of (sample records, per-method puzzle preparation seconds).
+    """
+    puzzle_id, dataset_root, puzzle_root, methods = job
+    cv2.setRNGSeed(0)  # make RANSAC deterministic regardless of worker/puzzle assignment
+    puzzle_rgb = np.array(Image.open(Path(puzzle_root) / f"{puzzle_id}.jpg").convert("RGB"))
+    puzzle_bgr = cv2.cvtColor(puzzle_rgb, cv2.COLOR_RGB2BGR)
+    puzzle_gray = cv2.cvtColor(puzzle_rgb, cv2.COLOR_RGB2GRAY)
+    puzzle_shape = puzzle_gray.shape[:2]
+
+    # One-time per-puzzle keypoint extraction (amortized over 64 samples).
+    prep_seconds: dict[str, float] = {}
+    puzzle_features: dict[str, tuple[Any, Any]] = {}
+    for method in methods:
+        if method in ("sift", "orb"):
+            start = time.perf_counter()
+            puzzle_features[method] = _get_matcher(method).detect_puzzle(puzzle_gray)
+            prep_seconds[method] = time.perf_counter() - start
+
+    records: list[dict[str, Any]] = []
+    for piece_path, cx, cy, base_rotation in enumerate_pieces(Path(dataset_root) / puzzle_id, puzzle_id):
+        true_cell = get_cell_index(cx, cy)
+        for applied_idx in range(4):
+            true_rotation_idx = ((base_rotation + ROTATION_ANGLES[applied_idx]) % 360) // 90
+            observed = load_observed_piece(piece_path, applied_idx)
+
+            preds: dict[str, tuple[int, int] | None] = {}
+            times: dict[str, float] = {}
+            for method in methods:
+                start = time.perf_counter()
+                if method == "ncc":
+                    preds[method] = predict_ncc(observed, puzzle_bgr)
+                else:
+                    kp, des = puzzle_features[method]
+                    preds[method] = _get_matcher(method).predict(observed, kp, des, puzzle_shape)
+                times[method] = time.perf_counter() - start
+
+            records.append(
+                {
+                    "puzzle_id": puzzle_id,
+                    "true_cell": true_cell,
+                    "true_rotation_idx": true_rotation_idx,
+                    "preds": preds,
+                    "times": times,
+                }
+            )
+    return records, prep_seconds
+
+
+def compute_metrics(records: list[dict[str, Any]], method: str) -> dict[str, Any]:
+    """Compute accuracy metrics for one method over a set of sample records.
+
+    Samples where the method produced no prediction count as wrong in the
+    headline metrics; *_covered variants condition on a prediction existing.
+
+    Args:
+        records: Sample records from evaluate_puzzle.
+        method: Method name.
+
+    Returns:
+        Metrics dictionary.
+    """
+    n = len(records)
+    covered = [r for r in records if r["preds"][method] is not None]
+    cell_ok = sum(r["preds"][method][0] == r["true_cell"] for r in covered)
+    rot_ok = sum(r["preds"][method][1] == r["true_rotation_idx"] for r in covered)
+    both_ok = sum(
+        r["preds"][method][0] == r["true_cell"] and r["preds"][method][1] == r["true_rotation_idx"] for r in covered
+    )
+    n_cov = len(covered)
+    return {
+        "n_samples": n,
+        "coverage": n_cov / n if n else 0.0,
+        "cell_accuracy": cell_ok / n if n else 0.0,
+        "rotation_accuracy": rot_ok / n if n else 0.0,
+        "both_accuracy": both_ok / n if n else 0.0,
+        "cell_accuracy_covered": cell_ok / n_cov if n_cov else 0.0,
+        "rotation_accuracy_covered": rot_ok / n_cov if n_cov else 0.0,
+        "both_accuracy_covered": both_ok / n_cov if n_cov else 0.0,
+    }
+
+
+def run_evaluation(
+    puzzle_ids: list[str], dataset_root: Path, puzzle_root: Path, methods: tuple[str, ...], workers: int
+) -> tuple[list[dict[str, Any]], dict[str, float]]:
+    """Evaluate all puzzles in parallel.
+
+    Args:
+        puzzle_ids: Puzzle IDs to evaluate.
+        dataset_root: Root directory of the piece dataset.
+        puzzle_root: Root directory of the puzzle JPEGs.
+        methods: Method names to run.
+        workers: Number of worker processes.
+
+    Returns:
+        Tuple of (all sample records, summed per-method puzzle prep seconds).
+    """
+    jobs = [(pid, str(dataset_root), str(puzzle_root), methods) for pid in puzzle_ids]
+    all_records: list[dict[str, Any]] = []
+    prep_totals: dict[str, float] = dict.fromkeys(methods, 0.0)
+    start = time.time()
+    with ProcessPoolExecutor(max_workers=workers) as pool:
+        for i, (records, prep_seconds) in enumerate(pool.map(evaluate_puzzle, jobs, chunksize=4)):
+            all_records.extend(records)
+            for method, seconds in prep_seconds.items():
+                prep_totals[method] += seconds
+            if (i + 1) % 100 == 0:
+                print(f"  [{i + 1}/{len(jobs)} puzzles] {time.time() - start:.0f}s", flush=True)
+    return all_records, prep_totals
+
+
+def add_hybrid(records: list[dict[str, Any]]) -> None:
+    """Add a derived sift_else_ncc prediction to each record in place.
+
+    The hybrid is still fully classical: use the SIFT prediction when SIFT
+    produced one (it is highly accurate when it matches), otherwise fall back
+    to NCC. Its per-sample time is the SIFT time plus the NCC time on the
+    samples where the fallback is actually needed.
+
+    Args:
+        records: Sample records that already contain "sift" and "ncc" entries.
+    """
+    for record in records:
+        sift_pred = record["preds"]["sift"]
+        record["preds"]["sift_else_ncc"] = sift_pred if sift_pred is not None else record["preds"]["ncc"]
+        record["times"]["sift_else_ncc"] = record["times"]["sift"] + (
+            record["times"]["ncc"] if sift_pred is None else 0.0
+        )
+
+
+def summarize(
+    all_records: list[dict[str, Any]],
+    prep_totals: dict[str, float],
+    methods: tuple[str, ...],
+    subsample_ids: list[str],
+    n_puzzles: int,
+) -> dict[str, Any]:
+    """Aggregate metrics over the full set and the matched subsample.
+
+    Args:
+        all_records: Sample records from all puzzles.
+        prep_totals: Summed per-method puzzle preparation seconds.
+        methods: Method names that were run.
+        subsample_ids: Puzzle IDs in the seed-42 subsample.
+        n_puzzles: Total number of puzzles evaluated.
+
+    Returns:
+        Per-method results dictionary.
+    """
+    subsample_set = set(subsample_ids)
+    subsample_records = [r for r in all_records if r["puzzle_id"] in subsample_set]
+    results: dict[str, Any] = {}
+    for method in methods:
+        match_seconds = sum(r["times"][method] for r in all_records)
+        results[method] = {
+            "full": compute_metrics(all_records, method),
+            "subsample": compute_metrics(subsample_records, method),
+            "runtime_ms_per_sample": match_seconds / len(all_records) * 1000 if all_records else 0.0,
+            "puzzle_prep_ms_per_puzzle": prep_totals.get(method, 0.0) / n_puzzles * 1000 if n_puzzles else 0.0,
+        }
+    return results
+
+
+def main() -> None:
+    """Run the classical baselines and write results.json."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset-root", type=Path, required=True)
+    parser.add_argument("--puzzle-root", type=Path, required=True)
+    parser.add_argument("--methods", type=str, default="ncc,sift,orb")
+    parser.add_argument("--workers", type=int, default=8)
+    parser.add_argument("--limit-puzzles", type=int, default=0, help="Evaluate only the first N puzzles (0 = all)")
+    parser.add_argument("--subsample-size", type=int, default=200)
+    parser.add_argument("--subsample-seed", type=int, default=42)
+    parser.add_argument("--output", type=Path, default=Path(__file__).parent / "outputs" / "results.json")
+    args = parser.parse_args()
+
+    methods = tuple(m.strip() for m in args.methods.split(",") if m.strip())
+    for method in methods:
+        if method not in METHOD_NAMES:
+            raise SystemExit(f"Unknown method: {method} (choose from {METHOD_NAMES})")
+
+    puzzle_ids = sorted(d.name for d in args.dataset_root.iterdir() if d.is_dir() and d.name.startswith("puzzle_"))
+    if args.limit_puzzles:
+        puzzle_ids = puzzle_ids[: args.limit_puzzles]
+    rng = random.Random(args.subsample_seed)
+    subsample_ids = sorted(rng.sample(puzzle_ids, min(args.subsample_size, len(puzzle_ids))))
+    print(f"Puzzles: {len(puzzle_ids)} | subsample: {len(subsample_ids)} (seed {args.subsample_seed})")
+    print(f"Methods: {', '.join(methods)} | workers: {args.workers}")
+
+    all_records, prep_totals = run_evaluation(puzzle_ids, args.dataset_root, args.puzzle_root, methods, args.workers)
+    report_methods = methods
+    if "sift" in methods and "ncc" in methods:
+        add_hybrid(all_records)
+        report_methods = methods + ("sift_else_ncc",)
+    results = summarize(all_records, prep_totals, report_methods, subsample_ids, len(puzzle_ids))
+
+    print(f"\nSamples: {len(all_records)} ({len(puzzle_ids)} puzzles x 16 pieces x 4 rotations)")
+    for method in report_methods:
+        full = results[method]["full"]
+        print(
+            f"{method.upper():5s} cell={full['cell_accuracy']:.1%} rot={full['rotation_accuracy']:.1%} "
+            f"both={full['both_accuracy']:.1%} coverage={full['coverage']:.1%} "
+            f"({results[method]['runtime_ms_per_sample']:.1f} ms/sample)"
+        )
+
+    output = {
+        "dataset_root": args.dataset_root.name,
+        "puzzle_root": args.puzzle_root.name,
+        "n_puzzles": len(puzzle_ids),
+        "n_samples": len(all_records),
+        "subsample": {"seed": args.subsample_seed, "n_puzzles": len(subsample_ids)},
+        "protocol": {
+            "applied_rotations_per_piece": 4,
+            "label_composition": "(baked_rotation_from_filename + applied) % 360",
+            "piece_resolution": "native crop (~110-130 px), not resized",
+            "puzzle_resolution": "native 256x256",
+            "ncc": {"opencv_method": "TM_CCOEFF_NORMED", "masked": True, "mask_threshold": MASK_THRESHOLD},
+            "keypoint": {
+                "lowe_ratio": LOWE_RATIO,
+                "ransac_reproj_threshold": RANSAC_REPROJ_THRESHOLD,
+                "min_good_matches": MIN_GOOD_MATCHES,
+                "min_inliers": MIN_INLIERS,
+                "orb_params": ORB_PARAMS,
+            },
+        },
+        "cnn_reference": {
+            "checkpoint": "exp20 checkpoint_best.pt (reeval_fixed_labels.json)",
+            "cell_accuracy": 0.729,
+            "rotation_accuracy": 0.946,
+            "both_accuracy": 0.722,
+        },
+        "methods": results,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w") as f:
+        json.dump(output, f, indent=2)
+    print(f"\nSaved results to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/network/experiments/exp23_classical_baselines/outputs/results.json
+++ b/network/experiments/exp23_classical_baselines/outputs/results.json
@@ -131,7 +131,7 @@
         "both_accuracy_covered": 0.838482044848675
       },
       "runtime_ms_per_sample": 45.39359526747418,
-      "puzzle_prep_ms_per_puzzle": 0.0
+      "puzzle_prep_ms_per_puzzle": 9.283352888399653
     }
   }
 }

--- a/network/experiments/exp23_classical_baselines/outputs/results.json
+++ b/network/experiments/exp23_classical_baselines/outputs/results.json
@@ -1,0 +1,137 @@
+{
+  "dataset_root": "realistic_4x4_20k_test",
+  "puzzle_root": "puzzles",
+  "n_puzzles": 1200,
+  "n_samples": 76800,
+  "subsample": {
+    "seed": 42,
+    "n_puzzles": 200
+  },
+  "protocol": {
+    "applied_rotations_per_piece": 4,
+    "label_composition": "(baked_rotation_from_filename + applied) % 360",
+    "piece_resolution": "native crop (~110-130 px), not resized",
+    "puzzle_resolution": "native 256x256",
+    "ncc": {
+      "opencv_method": "TM_CCOEFF_NORMED",
+      "masked": true,
+      "mask_threshold": 8
+    },
+    "keypoint": {
+      "lowe_ratio": 0.75,
+      "ransac_reproj_threshold": 3.0,
+      "min_good_matches": 4,
+      "min_inliers": 3,
+      "orb_params": {
+        "nfeatures": 3000,
+        "fastThreshold": 0,
+        "edgeThreshold": 10,
+        "nlevels": 12
+      }
+    }
+  },
+  "cnn_reference": {
+    "checkpoint": "exp20 checkpoint_best.pt (reeval_fixed_labels.json)",
+    "cell_accuracy": 0.729,
+    "rotation_accuracy": 0.946,
+    "both_accuracy": 0.722
+  },
+  "methods": {
+    "ncc": {
+      "full": {
+        "n_samples": 76800,
+        "coverage": 0.9958072916666667,
+        "cell_accuracy": 0.7751432291666667,
+        "rotation_accuracy": 0.8721875,
+        "both_accuracy": 0.7690494791666667,
+        "cell_accuracy_covered": 0.7784068621041346,
+        "rotation_accuracy_covered": 0.8758597243651769,
+        "both_accuracy_covered": 0.772287455215879
+      },
+      "subsample": {
+        "n_samples": 12800,
+        "coverage": 0.99640625,
+        "cell_accuracy": 0.7853125,
+        "rotation_accuracy": 0.8859375,
+        "both_accuracy": 0.78015625,
+        "cell_accuracy_covered": 0.7881448957189902,
+        "rotation_accuracy_covered": 0.889132821075741,
+        "both_accuracy_covered": 0.7829700486122001
+      },
+      "runtime_ms_per_sample": 76.77820453695479,
+      "puzzle_prep_ms_per_puzzle": 0.0
+    },
+    "sift": {
+      "full": {
+        "n_samples": 76800,
+        "coverage": 0.4536588541666667,
+        "cell_accuracy": 0.43854166666666666,
+        "rotation_accuracy": 0.4413671875,
+        "both_accuracy": 0.4361328125,
+        "cell_accuracy_covered": 0.9666771906661692,
+        "rotation_accuracy_covered": 0.9729054849171953,
+        "both_accuracy_covered": 0.9613673545535433
+      },
+      "subsample": {
+        "n_samples": 12800,
+        "coverage": 0.462421875,
+        "cell_accuracy": 0.445625,
+        "rotation_accuracy": 0.44828125,
+        "both_accuracy": 0.44265625,
+        "cell_accuracy_covered": 0.963676296671735,
+        "rotation_accuracy_covered": 0.9694205102213211,
+        "both_accuracy_covered": 0.9572562932927859
+      },
+      "runtime_ms_per_sample": 3.231012778504881,
+      "puzzle_prep_ms_per_puzzle": 9.283352888399653
+    },
+    "orb": {
+      "full": {
+        "n_samples": 76800,
+        "coverage": 0.40358072916666665,
+        "cell_accuracy": 0.38376302083333336,
+        "rotation_accuracy": 0.3825390625,
+        "both_accuracy": 0.3770442708333333,
+        "cell_accuracy_covered": 0.9508953056944669,
+        "rotation_accuracy_covered": 0.9478625584771737,
+        "both_accuracy_covered": 0.9342474592676238
+      },
+      "subsample": {
+        "n_samples": 12800,
+        "coverage": 0.4196875,
+        "cell_accuracy": 0.3984375,
+        "rotation_accuracy": 0.3965625,
+        "both_accuracy": 0.39140625,
+        "cell_accuracy_covered": 0.9493670886075949,
+        "rotation_accuracy_covered": 0.9448994787788533,
+        "both_accuracy_covered": 0.9326135517498139
+      },
+      "runtime_ms_per_sample": 4.790394365288553,
+      "puzzle_prep_ms_per_puzzle": 9.104627712361738
+    },
+    "sift_else_ncc": {
+      "full": {
+        "n_samples": 76800,
+        "coverage": 0.9958072916666667,
+        "cell_accuracy": 0.82859375,
+        "rotation_accuracy": 0.9031510416666667,
+        "both_accuracy": 0.8219401041666666,
+        "cell_accuracy_covered": 0.832082428933811,
+        "rotation_accuracy_covered": 0.9069536337247313,
+        "both_accuracy_covered": 0.8254007688485577
+      },
+      "subsample": {
+        "n_samples": 12800,
+        "coverage": 0.99640625,
+        "cell_accuracy": 0.8415625,
+        "rotation_accuracy": 0.9184375,
+        "both_accuracy": 0.83546875,
+        "cell_accuracy_covered": 0.8445977732476085,
+        "rotation_accuracy_covered": 0.9217500392033872,
+        "both_accuracy_covered": 0.838482044848675
+      },
+      "runtime_ms_per_sample": 45.39359526747418,
+      "puzzle_prep_ms_per_puzzle": 0.0
+    }
+  }
+}

--- a/network/pyproject.toml
+++ b/network/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "timm>=0.9.12",
     # Data processing
     "albumentations>=2.0.8",
+    "opencv-python-headless>=4.11.0",
     "pillow>=12.2.0",
     "pandas>=2.0.0",
     "scikit-learn>=1.2.0",

--- a/network/uv.lock
+++ b/network/uv.lock
@@ -1544,6 +1544,7 @@ source = { editable = "." }
 dependencies = [
     { name = "albumentations" },
     { name = "matplotlib" },
+    { name = "opencv-python-headless" },
     { name = "pandas" },
     { name = "pillow" },
     { name = "puzzle-shapes" },
@@ -1585,6 +1586,7 @@ requires-dist = [
     { name = "flake8-pytest-style", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.13.2" },
     { name = "matplotlib", specifier = ">=3.7.0" },
+    { name = "opencv-python-headless", specifier = ">=4.11.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pandas-stubs", marker = "extra == 'dev'" },
     { name = "pillow", specifier = ">=12.2.0" },


### PR DESCRIPTION
## What

Runs the non-learned baselines called for by item #2 of `network/experiments/CRITICAL_REVIEW.md` on the exp20 4x4 realistic-pieces benchmark, using the exact protocol of the July 2026 CNN re-evaluation: 1,200 regenerated test puzzles x 16 pieces x 4 applied rotations = 76,800 samples, labels composed as `(baked_rotation_from_filename + applied) % 360`.

New experiment: `network/experiments/exp23_classical_baselines/` (`evaluate.py`, `README.md`, `outputs/results.json`), plus updates to `EXPERIMENT_LOG.md` and `CRITICAL_REVIEW.md`.

## Results (full 76,800 samples)

| Method | Cell | Rotation | Both | Coverage | ms/sample (CPU) |
|---|---|---|---|---|---|
| SIFT→NCC hybrid | **82.9%** | 90.3% | **82.2%** | 99.6% | 45 |
| Masked NCC (TM_CCOEFF_NORMED) | 77.5% | 87.2% | 76.9% | 99.6% | 77 |
| CNN (exp20 re-eval) | 72.9% | **94.6%** | 72.2% | 100% | ~10 (GPU) |
| SIFT | 43.9% | 44.1% | 43.6% | 45.4% | 3.2 |
| ORB (tuned) | 38.4% | 38.3% | 37.7% | 40.4% | 4.8 |

**The zero-training classical floor is above the CNN**: the SIFT→NCC hybrid beats it by 10 points on both-correct, and plain masked NCC beats it on position. The CNN wins only rotation. The synthetic surrogate is largely solvable by template matching, so future learned models must clear ~82% both-correct here for synthetic gains to count as progress — which makes the review's realism items (photographed pieces, matching-adversarial synthetic data) the next priority.

## Reviewer notes

- Classical methods use native resolution (256x256 puzzles, unresized ~110–130 px piece crops), unlike the CNN's 128x128-squashed input; documented in the README and results.json.
- SIFT's low headline is coverage, not accuracy: 96.7% cell / 97.3% rotation on the 45% of pieces it can match. Headline metrics count no-prediction samples as wrong; `*_covered` variants are in results.json. Hence the hybrid (SIFT when matched, NCC fallback) as the honest floor — still fully classical.
- ORB needed non-default detector params (`fastThreshold=0, edgeThreshold=10, nlevels=12`); defaults matched only ~8% of pieces.
- RANSAC is seeded per puzzle (`cv2.setRNGSeed`) so results are reproducible regardless of worker scheduling. NCC and SIFT ran the full set; the seed-42 200-puzzle subsample slice is also reported per method for matched comparisons with slower future methods.
- The test set itself is regenerated locally (gitignored); rebuild instructions are referenced in the README (historical `puzzle_shapes` geometry, see the "Exp 20 Re-Evaluation" log entry).
- `make check-network` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)