### PR TITLE
chore(network): make puzzle-shapes path source editable

### DIFF
--- a/network/pyproject.toml
+++ b/network/pyproject.toml
@@ -80,4 +80,4 @@ typeCheckingMode = "standard"
 exclude = [".venv", "datasets", "checkpoints", "logs", "experiments"]
 
 [tool.uv.sources]
-puzzle-shapes = { path = "../shared/puzzle_shapes" }
+puzzle-shapes = { path = "../shared/puzzle_shapes", editable = true }

--- a/network/uv.lock
+++ b/network/uv.lock
@@ -1588,7 +1588,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pandas-stubs", marker = "extra == 'dev'" },
     { name = "pillow", specifier = ">=12.2.0" },
-    { name = "puzzle-shapes", directory = "../shared/puzzle_shapes" },
+    { name = "puzzle-shapes", editable = "../shared/puzzle_shapes" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390" },
     { name = "pytorch-lightning", specifier = ">=2.5.0" },
     { name = "requests", specifier = ">=2.33.0" },
@@ -1606,7 +1606,7 @@ provides-extras = ["dev"]
 [[package]]
 name = "puzzle-shapes"
 version = "0.1.0"
-source = { directory = "../shared/puzzle_shapes" }
+source = { editable = "../shared/puzzle_shapes" }
 dependencies = [
     { name = "numpy" },
     { name = "pillow" },


### PR DESCRIPTION
Experiment to fix the failing network Dependabot PRs (#43, #44), whose `uv sync --locked` was rejected by the Linux CI runner while validating locally on macOS.

The one structural difference from the backend project (whose Dependabot uv PRs pass CI) is that backend declares its `puzzle-shapes` local path source as `editable = true`, while network did not. This aligns them and relocks `network/uv.lock`.

**The real test is whether Network CI passes here.** If green, this is the durable fix; the existing Dependabot PRs can then be `@dependabot recreate`d to pick up the editable source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)