### PR TITLE
Add real mode for solving physical puzzles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ make start-frontend        # Start Next.js dev server on http://localhost:3000
 - **`app/main.py`** - FastAPI application with CORS, endpoints, and in-memory puzzle storage
 - **`app/config.py`** - Pydantic settings for configuration (upload dir, size limits, CORS)
 - **`app/models/puzzle_model.py`** - Pydantic models for API requests/responses
-- **`app/services/image_processor.py`** - Mock image processing (to be replaced with ML model)
+- **`app/services/image_processor.py`** - Runs the trained CNN model (loads `FastBackboneModel` from a checkpoint in `network/experiments/`) to predict piece position + rotation via `torch.no_grad()` inference; falls back to a neutral result (position 0.5,0.5, confidence 0.0) on error
 - **`app/services/storage.py`** - File storage utilities
 
 #### API Endpoints
@@ -225,14 +225,30 @@ GitHub Actions workflows test/deploy on push to main/release:
 - **Backend CI** (`.github/workflows/backend-ci.yml`):
   - Code quality: black, isort, flake8, pyright
   - Tests with coverage (uploads to Codecov)
-  - Azure deployment (main branch only)
+  - Azure deployment (main branch only) — builds a container, pushes to Azure
+    Container Registry, and deploys to an Azure Web App via the Bicep infra in
+    `infrastructure/`
 - **Frontend CI** (`.github/workflows/frontend-ci.yml`):
   - OxLint type-aware linting
   - TypeScript type checking
   - Prettier formatting check
   - Vitest tests
   - Next.js production build
+  - Playwright e2e tests (against a locally started backend)
+  - **No deployment step** — the frontend is not deployed by CI or IaC (see below)
 - **Network CI** (`.github/workflows/network-ci.yml`): Python quality checks for ML code
+
+### Deployment Status
+- **Backend**: deployed to **Azure** (App Service running a container) via
+  `backend-ci.yml` + `infrastructure/main.bicep`. Infra provisions only the
+  backend App Service, a Container Registry, and a Storage Account.
+- **Frontend**: **not deployed anywhere.** There is no Vercel setup (the
+  `vercel.svg`, `.vercel` gitignore entry, and README "Deploy on Vercel" text
+  are leftover `create-next-app` scaffolding, not a real config) and no Azure
+  frontend resource. The `pussel-frontend.azurewebsites.net` /
+  `pussel.thomasen.dk` origins in `infrastructure/modules/appService.bicep` are
+  only CORS allowlist entries, not deploy targets. The frontend currently runs
+  locally against a local or Azure backend (`NEXT_PUBLIC_API_URL`).
 
 ## Important Notes
 
@@ -259,7 +275,11 @@ pyright is configured with standard mode - all functions must have type annotati
 - CI requires `.env.test` file for environment variables
 
 ### ML Model Integration
-Current backend uses mock image processor in `app/services/image_processor.py`. The trained model from `network/` should eventually replace this mock implementation.
+The backend serves the trained model directly: `app/services/image_processor.py`
+loads a checkpoint from `network/experiments/` (e.g.
+`exp18_3x3_20k_puzzles/outputs/checkpoint_best.pt`) and runs inference on each
+piece. To ship a newer model, retrain in `network/` and point the processor at
+the new checkpoint.
 
 ### Pre-commit Hooks
 Pre-commit is configured at the root level and applies to:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,25 +6,33 @@ import os
 import uuid
 from typing import Annotated, Dict, Optional
 
-from fastapi import Depends, FastAPI, HTTPException, Query, UploadFile
+from fastapi import Depends, FastAPI, Form, HTTPException, Query, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
-from PIL import Image
+from PIL import Image, ImageOps, UnidentifiedImageError
+from pydantic import ValidationError
 
 from app.auth.dependencies import get_current_user
 from app.auth.service import AuthService, get_auth_service
 from app.config import settings
 from app.models.puzzle_model import (
+    BoundingBox,
+    Corner,
     CutPuzzleRequest,
     CutPuzzleResponse,
+    DetectFrameResponse,
     GeneratePieceRequest,
     GeneratePieceResponse,
+    PiecePreviewResponse,
     PieceResponse,
     PuzzleResponse,
+    QuadCorners,
 )
 from app.models.user_model import GoogleAuthRequest, TokenResponse, User
 from app.services.image_processor import get_image_processor
+from app.services.piece_detector import get_piece_detector
 from app.services.piece_shape import PieceShapeGenerator
 from app.services.puzzle_cutter import get_puzzle_cutter
+from app.services.puzzle_detector import get_puzzle_detector
 
 # Initialize FastAPI app
 app = FastAPI(title=settings.PROJECT_NAME)
@@ -149,6 +157,119 @@ async def upload_puzzle(
 
     puzzle_images[puzzle_id] = file_path
     return PuzzleResponse(puzzle_id=puzzle_id)
+
+
+@app.post("/api/v1/puzzle/detect-frame", response_model=DetectFrameResponse)
+async def detect_frame(
+    current_user: Annotated[User, Depends(get_current_user)],
+    file: Optional[UploadFile] = None,
+    corners: Annotated[Optional[str], Form(description="Manually adjusted corners as JSON QuadCorners")] = None,
+) -> DetectFrameResponse:
+    """Detect the puzzle picture in a photo and return a perspective-corrected crop.
+
+    This endpoint is stateless: nothing is persisted. The frontend previews the
+    trimmed image and, once accepted, uploads it via the regular upload endpoint.
+    When ``corners`` is provided (manual adjustment), detection is skipped and
+    the supplied corners are used for the warp with confidence 1.0.
+
+    Args:
+        current_user: The authenticated user.
+        file: The raw photo of the puzzle.
+        corners: Optional JSON-encoded QuadCorners overriding auto-detection.
+
+    Returns:
+        DetectFrameResponse with the trimmed image (base64 data URL), the
+        corners used, and a detection confidence.
+
+    Raises:
+        HTTPException: If no/invalid file is provided, the file is too large,
+            or the corners payload is malformed.
+    """
+    _ = current_user  # Acknowledge the parameter is intentionally unused for now
+    if file is None:
+        raise HTTPException(status_code=400, detail="No file provided")
+
+    if file.size and file.size > settings.MAX_UPLOAD_SIZE:
+        raise HTTPException(status_code=413, detail="File too large")
+
+    contents = await file.read()
+    if len(contents) > settings.MAX_UPLOAD_SIZE:
+        raise HTTPException(status_code=413, detail="File too large")
+
+    try:
+        image = Image.open(io.BytesIO(contents))
+        # Phone photos carry EXIF orientation; correct it so corners match what the user sees
+        image = ImageOps.exif_transpose(image).convert("RGB")
+    except (UnidentifiedImageError, OSError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="Invalid image file") from exc
+
+    detector = get_puzzle_detector()
+    if corners is not None:
+        try:
+            quad = QuadCorners.model_validate_json(corners)
+        except ValidationError as exc:
+            raise HTTPException(status_code=400, detail="Invalid corners payload") from exc
+        used_corners = quad
+        confidence = 1.0
+        trimmed = detector.warp(image, quad.as_points())
+    else:
+        points, confidence = detector.detect_corners(image)
+        used_corners = QuadCorners.from_points(points)
+        trimmed = detector.warp(image, points)
+
+    buffer = io.BytesIO()
+    trimmed.save(buffer, format="JPEG", quality=90)
+    trimmed_base64 = base64.b64encode(buffer.getvalue()).decode()
+
+    return DetectFrameResponse(
+        trimmed_image=f"data:image/jpeg;base64,{trimmed_base64}",
+        corners=used_corners,
+        confidence=confidence,
+    )
+
+
+@app.post("/api/v1/piece/preview", response_model=PiecePreviewResponse)
+async def preview_piece(
+    current_user: Annotated[User, Depends(get_current_user)],
+    file: Optional[UploadFile] = None,
+) -> PiecePreviewResponse:
+    """Detect the puzzle piece region in a live camera frame.
+
+    Stateless and lightweight: the frontend streams downscaled frames here
+    while the piece camera is open and overlays the returned outline on the
+    preview, so the user can see what will be captured.
+
+    Args:
+        current_user: The authenticated user.
+        file: A downscaled camera frame.
+
+    Returns:
+        PiecePreviewResponse with the detected region outline, or found=False.
+
+    Raises:
+        HTTPException: If no/invalid file is provided.
+    """
+    _ = current_user  # Acknowledge the parameter is intentionally unused for now
+    if file is None:
+        raise HTTPException(status_code=400, detail="No file provided")
+
+    contents = await file.read()
+    try:
+        image = Image.open(io.BytesIO(contents))
+        image.load()
+    except (UnidentifiedImageError, OSError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="Invalid image file") from exc
+
+    region = get_piece_detector().detect_region(image)
+    if region is None:
+        return PiecePreviewResponse(found=False)
+
+    polygon, (x, y, w, h) = region
+    return PiecePreviewResponse(
+        found=True,
+        polygon=[Corner(x=px, y=py) for px, py in polygon],
+        bbox=BoundingBox(x=x, y=y, width=w, height=h),
+    )
 
 
 @app.post("/api/v1/puzzle/{puzzle_id}/piece", response_model=PieceResponse)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -253,7 +253,15 @@ async def preview_piece(
     if file is None:
         raise HTTPException(status_code=400, detail="No file provided")
 
+    # This endpoint is polled in a loop from the client, so guard against oversized
+    # frames. Preview frames are downscaled client-side, so a tight limit is expected.
+    if file.size and file.size > settings.MAX_UPLOAD_SIZE:
+        raise HTTPException(status_code=413, detail="File too large")
+
     contents = await file.read()
+    if len(contents) > settings.MAX_UPLOAD_SIZE:
+        raise HTTPException(status_code=413, detail="File too large")
+
     try:
         image = Image.open(io.BytesIO(contents))
         image.load()

--- a/backend/app/models/puzzle_model.py
+++ b/backend/app/models/puzzle_model.py
@@ -29,6 +29,77 @@ class PuzzleResponse(BaseModel):
     image_url: Optional[str] = None
 
 
+# Models for puzzle frame detection (real mode)
+
+
+class Corner(BaseModel):
+    """A single corner point, normalized to [0, 1] image coordinates."""
+
+    x: float = Field(..., ge=0.0, le=1.0)
+    y: float = Field(..., ge=0.0, le=1.0)
+
+
+class QuadCorners(BaseModel):
+    """Four corners of a quadrilateral in TL/TR/BR/BL order."""
+
+    top_left: Corner
+    top_right: Corner
+    bottom_right: Corner
+    bottom_left: Corner
+
+    def as_points(self) -> List[tuple[float, float]]:
+        """Return the corners as a list of (x, y) tuples in TL, TR, BR, BL order."""
+        return [
+            (self.top_left.x, self.top_left.y),
+            (self.top_right.x, self.top_right.y),
+            (self.bottom_right.x, self.bottom_right.y),
+            (self.bottom_left.x, self.bottom_left.y),
+        ]
+
+    @classmethod
+    def from_points(cls, points: List[tuple[float, float]]) -> "QuadCorners":
+        """Build a QuadCorners from a list of (x, y) tuples in TL, TR, BR, BL order.
+
+        Args:
+            points: Exactly four (x, y) tuples ordered TL, TR, BR, BL.
+
+        Returns:
+            The corresponding QuadCorners model.
+        """
+        tl, tr, br, bl = points
+        return cls(
+            top_left=Corner(x=tl[0], y=tl[1]),
+            top_right=Corner(x=tr[0], y=tr[1]),
+            bottom_right=Corner(x=br[0], y=br[1]),
+            bottom_left=Corner(x=bl[0], y=bl[1]),
+        )
+
+
+class BoundingBox(BaseModel):
+    """An axis-aligned bounding box, normalized to [0, 1] image coordinates."""
+
+    x: float = Field(..., ge=0.0, le=1.0)
+    y: float = Field(..., ge=0.0, le=1.0)
+    width: float = Field(..., ge=0.0, le=1.0)
+    height: float = Field(..., ge=0.0, le=1.0)
+
+
+class PiecePreviewResponse(BaseModel):
+    """Response model for live piece-region detection in a camera frame."""
+
+    found: bool = Field(..., description="Whether a piece-like region was detected")
+    polygon: List[Corner] = Field(default_factory=list, description="Outline of the detected region, normalized 0-1")
+    bbox: Optional[BoundingBox] = Field(default=None, description="Bounding box of the detected region")
+
+
+class DetectFrameResponse(BaseModel):
+    """Response model for puzzle frame detection."""
+
+    trimmed_image: str = Field(..., description="Base64 data URL (JPEG) of the perspective-corrected puzzle image")
+    corners: QuadCorners = Field(..., description="Corners used, normalized 0-1 relative to the EXIF-corrected photo")
+    confidence: float = Field(..., ge=0.0, le=1.0, description="Detection confidence; 1.0 for manual corners")
+
+
 class GeneratePieceRequest(BaseModel):
     """Request model for generating a realistic puzzle piece."""
 

--- a/backend/app/services/image_processor.py
+++ b/backend/app/services/image_processor.py
@@ -21,6 +21,7 @@ from app.config import settings
 from app.models.model import FastBackboneModel
 from app.models.puzzle_model import PieceResponse, Position
 from app.services.background_remover import get_background_remover
+from app.services.piece_detector import crop_to_alpha_region
 
 # Path to checkpoint (3x3 grid model with 82% cell accuracy, 95% rotation accuracy)
 DEFAULT_CHECKPOINT_PATH = str(
@@ -163,6 +164,11 @@ class ImageProcessor:
 
                 # Get RGBA image with transparent background for frontend display
                 rgba_image = remover.remove_background(contents)
+
+                # Crop to the segmented subject so the piece fills the frame for the
+                # model (training pieces fill the image) instead of floating in a
+                # large mostly-white canvas
+                rgba_image = crop_to_alpha_region(rgba_image)
 
                 # Encode as base64 PNG for frontend
                 buffer = io.BytesIO()

--- a/backend/app/services/image_processor.py
+++ b/backend/app/services/image_processor.py
@@ -73,12 +73,19 @@ class ImageProcessor:
         else:
             return torch.device("cpu")
 
-    def _load_model(self) -> FastBackboneModel:
+    def _load_model(self) -> Optional[FastBackboneModel]:
         """Load the trained model from checkpoint.
 
         Returns:
-            The loaded model in evaluation mode.
+            The loaded model in evaluation mode, or None when no checkpoint is
+            available. Without a model, ``process_piece`` returns a neutral
+            fallback prediction so the app still runs (e.g. in CI, where the
+            checkpoint is not committed).
         """
+        if not os.path.exists(CHECKPOINT_PATH):
+            print(f"Model checkpoint not found at {CHECKPOINT_PATH}; predictions will use a neutral fallback")
+            return None
+
         # Initialize model with same config as training
         model = FastBackboneModel(
             pretrained=False,  # We'll load weights from checkpoint
@@ -183,6 +190,17 @@ class ImageProcessor:
                     piece_img.paste(rgba_image)
             else:
                 piece_img = Image.open(io.BytesIO(contents)).convert("RGB")
+
+            # No model available (e.g. checkpoint not present): return a neutral
+            # prediction but still hand back the cleaned cutout for display.
+            if self.model is None:
+                return PieceResponse(
+                    position=Position(x=0.5, y=0.5),
+                    position_confidence=0.0,
+                    rotation=0,
+                    rotation_confidence=0.0,
+                    cleaned_image=cleaned_image_b64,
+                )
 
             piece_tensor = cast(Tensor, self.piece_transform(piece_img)).unsqueeze(0)
             piece_tensor = piece_tensor.to(self.device)

--- a/backend/app/services/piece_detector.py
+++ b/backend/app/services/piece_detector.py
@@ -1,0 +1,146 @@
+"""Service for detecting a puzzle piece region in a live camera frame."""
+
+import io
+from typing import List, Optional, Tuple, cast
+
+import cv2
+import numpy as np
+from PIL import Image
+
+from app.config import settings
+from app.services.background_remover import get_background_remover
+
+Point = Tuple[float, float]
+BBoxNorm = Tuple[float, float, float, float]  # x, y, width, height normalized to [0, 1]
+
+# Frames are downscaled before segmentation to keep the preview loop fast
+PREVIEW_MAX_DIM = 320
+
+# The detected region must cover at least this fraction of the frame
+MIN_PIECE_AREA_RATIO = 0.005
+
+# Cap on polygon outline points returned to the client
+MAX_POLYGON_POINTS = 60
+
+
+def largest_alpha_component(rgba: Image.Image, alpha_threshold: int = 128) -> Optional["np.ndarray"]:
+    """Find the contour of the largest opaque region in an RGBA image.
+
+    Args:
+        rgba: RGBA image, e.g. rembg output.
+        alpha_threshold: Alpha value above which a pixel counts as opaque.
+
+    Returns:
+        The largest contour from cv2.findContours, or None when the image has
+        no alpha channel or no opaque region.
+    """
+    if rgba.mode != "RGBA":
+        return None
+    alpha = np.asarray(rgba.split()[3])
+    mask = (alpha > alpha_threshold).astype(np.uint8) * 255
+    mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, np.ones((5, 5), dtype=np.uint8))
+    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if not contours:
+        return None
+    return max(contours, key=cv2.contourArea)
+
+
+def crop_to_alpha_region(rgba: Image.Image, margin: float = 0.08) -> Image.Image:
+    """Crop an RGBA image to the bounding box of its largest opaque region.
+
+    Centering the segmented subject this way puts camera captures much closer
+    to the model's training distribution (pieces filling the frame) than a
+    small cutout floating in a large canvas.
+
+    Args:
+        rgba: RGBA image, e.g. rembg output.
+        margin: Extra margin around the bounding box as a fraction of its size.
+
+    Returns:
+        The cropped image, or the input unchanged when no opaque region exists.
+    """
+    contour = largest_alpha_component(rgba)
+    if contour is None:
+        return rgba
+    x, y, w, h = cv2.boundingRect(contour)
+    pad_x = round(w * margin)
+    pad_y = round(h * margin)
+    left = max(0, x - pad_x)
+    top = max(0, y - pad_y)
+    right = min(rgba.width, x + w + pad_x)
+    bottom = min(rgba.height, y + h + pad_y)
+    if right <= left or bottom <= top:
+        return rgba
+    return rgba.crop((left, top, right, bottom))
+
+
+class PieceDetector:
+    """Detects the puzzle piece (most salient object) in a camera frame via rembg."""
+
+    def detect_region(self, image: Image.Image) -> Optional[Tuple[List[Point], BBoxNorm]]:
+        """Detect the piece region in a frame.
+
+        Args:
+            image: The camera frame (any mode; converted to RGB).
+
+        Returns:
+            A (polygon, bbox) tuple with coordinates normalized to [0, 1], or
+            None when background removal is disabled, segmentation fails, or
+            the detected region is too small.
+        """
+        if not settings.ENABLE_BACKGROUND_REMOVAL:
+            return None
+
+        rgb = image.convert("RGB")
+        width, height = rgb.size
+        scale = min(1.0, PREVIEW_MAX_DIM / max(width, height))
+        if scale < 1.0:
+            rgb = rgb.resize((max(1, round(width * scale)), max(1, round(height * scale))))
+        work_w, work_h = rgb.size
+
+        try:
+            buffer = io.BytesIO()
+            rgb.save(buffer, format="PNG")
+            rgba = get_background_remover(settings.REMBG_MODEL).remove_background(buffer.getvalue())
+        except Exception:
+            return None
+
+        contour = largest_alpha_component(rgba)
+        if contour is None:
+            return None
+        if cv2.contourArea(contour) / (work_w * work_h) < MIN_PIECE_AREA_RATIO:
+            return None
+
+        perimeter = cv2.arcLength(contour, closed=True)
+        polygon = cv2.approxPolyDP(contour, 0.005 * perimeter, closed=True).reshape(-1, 2)
+        if len(polygon) > MAX_POLYGON_POINTS:
+            step = len(polygon) / MAX_POLYGON_POINTS
+            polygon = polygon[[int(i * step) for i in range(MAX_POLYGON_POINTS)]]
+
+        points: List[Point] = [
+            (float(np.clip(x / work_w, 0.0, 1.0)), float(np.clip(y / work_h, 0.0, 1.0))) for x, y in polygon
+        ]
+        x, y, w, h = cast(Tuple[int, int, int, int], cv2.boundingRect(contour))
+        bbox: BBoxNorm = (
+            float(np.clip(x / work_w, 0.0, 1.0)),
+            float(np.clip(y / work_h, 0.0, 1.0)),
+            float(np.clip(w / work_w, 0.0, 1.0)),
+            float(np.clip(h / work_h, 0.0, 1.0)),
+        )
+        return points, bbox
+
+
+# Singleton instance
+_piece_detector: Optional[PieceDetector] = None
+
+
+def get_piece_detector() -> PieceDetector:
+    """Get or create the singleton PieceDetector instance.
+
+    Returns:
+        The shared PieceDetector instance.
+    """
+    global _piece_detector
+    if _piece_detector is None:
+        _piece_detector = PieceDetector()
+    return _piece_detector

--- a/backend/app/services/puzzle_detector.py
+++ b/backend/app/services/puzzle_detector.py
@@ -1,0 +1,311 @@
+"""Service for detecting a puzzle picture's boundary in a photo and perspective-correcting it."""
+
+import io
+import math
+from typing import List, Optional, Tuple, cast
+
+import cv2
+import numpy as np
+from PIL import Image
+
+from app.services.background_remover import get_background_remover
+
+Point = Tuple[float, float]
+
+# Corners covering the whole image, used as fallback when no quadrilateral is found
+FULL_IMAGE_CORNERS: List[Point] = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)]
+
+# Detection runs on a downscaled copy for speed; warping uses the full-resolution image
+WORKING_MAX_DIM = 1000
+
+# A candidate region must cover at least this fraction of the photo
+MIN_AREA_RATIO = 0.15
+
+# Area ratio at (or above) which the confidence heuristic saturates
+FULL_CONFIDENCE_AREA_RATIO = 0.5
+
+# Fraction of the shorter working dimension used as the border ring for background sampling
+BORDER_FRACTION = 0.05
+
+# If the border ring's 99th-percentile chroma deviation exceeds this, there is no
+# uniform background around the subject (e.g. an edge-to-edge image) and detection bails out
+MAX_BORDER_CHROMA_SPREAD = 0.06
+
+
+def _order_corners(points: "np.ndarray") -> "np.ndarray":
+    """Order 4 points as [top-left, top-right, bottom-right, bottom-left].
+
+    Uses the standard sum/diff heuristic: top-left has the smallest x+y,
+    bottom-right the largest x+y, top-right the smallest y-x, bottom-left
+    the largest y-x.
+
+    Args:
+        points: Array of shape (4, 2) with (x, y) coordinates.
+
+    Returns:
+        Array of shape (4, 2) ordered TL, TR, BR, BL.
+    """
+    ordered = np.zeros((4, 2), dtype=np.float32)
+    sums = points.sum(axis=1)
+    diffs = np.diff(points, axis=1).ravel()  # y - x
+    ordered[0] = points[np.argmin(sums)]
+    ordered[2] = points[np.argmax(sums)]
+    ordered[1] = points[np.argmin(diffs)]
+    ordered[3] = points[np.argmax(diffs)]
+    return ordered
+
+
+def _chroma(pixels: "np.ndarray") -> "np.ndarray":
+    """Compute brightness-invariant chromaticity (each channel divided by the channel sum).
+
+    Shadows keep the background's chroma while differing in brightness, so
+    chroma distance separates the subject from shadows on the background.
+
+    Args:
+        pixels: Float array of RGB values, last axis of size 3.
+
+    Returns:
+        Array of the same shape with channels normalized to sum to 1.
+    """
+    return pixels / (pixels.sum(axis=-1, keepdims=True) + 1e-6)
+
+
+class PuzzleFrameDetector:
+    """Detects the puzzle picture in a photo and warps it to a flat crop.
+
+    Detection is layered. The fast path segments the subject from a roughly
+    uniform background (sampled from the photo's border) using chroma distance
+    — which ignores shadows — plus a brighter-than-background luminance rule.
+    When the border is not a uniform background (e.g. a webcam shot with a
+    cluttered room behind the puzzle), it falls back to rembg salient-object
+    segmentation. Either way a quadrilateral is fitted to the convex hull of
+    the largest segmented region.
+    """
+
+    def __init__(self, salient_fallback: bool = True) -> None:
+        """Initialize the detector.
+
+        Args:
+            salient_fallback: Whether to fall back to rembg salient-object
+                segmentation when background-based segmentation is not
+                applicable. Disable for fast, dependency-free detection only.
+        """
+        self._salient_fallback = salient_fallback
+
+    def detect_corners(self, image: Image.Image) -> Tuple[List[Point], float]:
+        """Detect the puzzle picture's quadrilateral in the image.
+
+        The image should already be RGB and EXIF-corrected. Detection runs on a
+        downscaled copy; returned corners are normalized to [0, 1] so they apply
+        to the original image as well.
+
+        Args:
+            image: The photo to analyze.
+
+        Returns:
+            A tuple of (corners, confidence). Corners are ordered
+            [top-left, top-right, bottom-right, bottom-left], normalized 0-1.
+            Falls back to the full-image corners with confidence 0.0 when no
+            suitable region is found.
+        """
+        rgb = np.asarray(image.convert("RGB"))
+        height, width = rgb.shape[:2]
+        scale = min(1.0, WORKING_MAX_DIM / max(width, height))
+        if scale < 1.0:
+            rgb = cv2.resize(rgb, (max(1, round(width * scale)), max(1, round(height * scale))))
+        work = cv2.GaussianBlur(rgb, (7, 7), 0).astype(np.float32)
+        work_h, work_w = work.shape[:2]
+
+        mask = self._foreground_mask(work)
+        result = self._quad_from_mask(mask, work_w, work_h) if mask is not None else None
+
+        if result is None and self._salient_fallback:
+            mask = self._salient_mask(rgb)
+            result = self._quad_from_mask(mask, work_w, work_h) if mask is not None else None
+
+        if result is None:
+            return list(FULL_IMAGE_CORNERS), 0.0
+
+        quad, confidence = result
+        ordered = _order_corners(quad)
+        corners: List[Point] = [
+            (float(np.clip(x / work_w, 0.0, 1.0)), float(np.clip(y / work_h, 0.0, 1.0))) for x, y in ordered
+        ]
+        return corners, confidence
+
+    def warp(self, image: Image.Image, corners: List[Point]) -> Image.Image:
+        """Perspective-warp and crop the image using 4 normalized corners.
+
+        Args:
+            image: The full-resolution photo to warp.
+            corners: Four (x, y) points normalized to [0, 1], in any consistent
+                order; they are re-ordered TL, TR, BR, BL internally.
+
+        Returns:
+            A new image containing only the quadrilateral region, straightened
+            to a rectangle sized from the corner-to-corner distances.
+        """
+        rgb = np.asarray(image.convert("RGB"))
+        height, width = rgb.shape[:2]
+        pixels = np.array([(x * width, y * height) for x, y in corners], dtype=np.float32)
+        src = _order_corners(pixels)
+        tl, tr, br, bl = src
+
+        dst_w = max(1, round(max(math.dist(tl, tr), math.dist(bl, br))))
+        dst_h = max(1, round(max(math.dist(tl, bl), math.dist(tr, br))))
+        dst = np.array([(0, 0), (dst_w - 1, 0), (dst_w - 1, dst_h - 1), (0, dst_h - 1)], dtype=np.float32)
+
+        matrix = cv2.getPerspectiveTransform(src, dst)
+        warped = cv2.warpPerspective(rgb, matrix, (dst_w, dst_h))
+        return Image.fromarray(warped)
+
+    def _foreground_mask(self, work: "np.ndarray") -> Optional["np.ndarray"]:
+        """Segment the subject from the background sampled along the photo's border.
+
+        Args:
+            work: Blurred float RGB working image.
+
+        Returns:
+            A uint8 mask (0/255) of foreground pixels, or None when the border
+            is not uniform enough to represent a background.
+        """
+        work_h, work_w = work.shape[:2]
+        margin = max(2, round(BORDER_FRACTION * min(work_w, work_h)))
+        border_mask = np.zeros((work_h, work_w), dtype=bool)
+        border_mask[:margin] = border_mask[-margin:] = True
+        border_mask[:, :margin] = border_mask[:, -margin:] = True
+
+        pix_chroma = _chroma(work)
+        border_chroma = pix_chroma[border_mask]
+        bg_chroma = np.median(border_chroma, axis=0)
+        border_spread = float(np.percentile(np.linalg.norm(border_chroma - bg_chroma, axis=1), 99))
+        if border_spread > MAX_BORDER_CHROMA_SPREAD:
+            # Border pixels vary too much: no uniform background (e.g. edge-to-edge picture)
+            return None
+
+        chroma_dist = np.linalg.norm(pix_chroma - bg_chroma, axis=2)
+        chroma_thresh = max(0.03, 1.5 * border_spread)
+
+        # Brighter-than-background pixels are foreground too (a shadow is never brighter)
+        luminance = work.sum(axis=2)
+        border_lum = luminance[border_mask]
+        bg_lum = float(np.median(border_lum))
+        lum_spread = float(np.percentile(np.abs(border_lum - bg_lum), 99))
+        lum_thresh = max(60.0, 1.5 * lum_spread)
+
+        mask = ((chroma_dist > chroma_thresh) | (luminance > bg_lum + lum_thresh)).astype(np.uint8) * 255
+        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, np.ones((25, 25), dtype=np.uint8))
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, np.ones((11, 11), dtype=np.uint8))
+        return cast("np.ndarray", mask)
+
+    def _salient_mask(self, rgb: "np.ndarray") -> Optional["np.ndarray"]:
+        """Segment the most salient object using rembg (u2net).
+
+        Used when there is no uniform background to segment against, e.g. a
+        webcam shot of a puzzle held up in front of a cluttered room.
+
+        Args:
+            rgb: Working-size uint8 RGB image.
+
+        Returns:
+            A uint8 mask (0/255) of the salient object, or None if
+            segmentation fails.
+        """
+        try:
+            buffer = io.BytesIO()
+            Image.fromarray(rgb).save(buffer, format="PNG")
+            rgba = get_background_remover().remove_background(buffer.getvalue())
+        except Exception:
+            return None
+        if rgba.mode != "RGBA":
+            return None
+        alpha = np.asarray(rgba.split()[3])
+        mask = (alpha > 128).astype(np.uint8) * 255
+        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, np.ones((25, 25), dtype=np.uint8))
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, np.ones((11, 11), dtype=np.uint8))
+        return cast("np.ndarray", mask)
+
+    def _quad_from_mask(self, mask: "np.ndarray", work_w: int, work_h: int) -> Optional[Tuple["np.ndarray", float]]:
+        """Fit a quadrilateral to the largest region of a foreground mask.
+
+        Args:
+            mask: uint8 foreground mask (0/255).
+            work_w: Working image width.
+            work_h: Working image height.
+
+        Returns:
+            A (quad, confidence) tuple where quad has shape (4, 2), or None
+            when the mask has no region covering at least MIN_AREA_RATIO.
+        """
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        if not contours:
+            return None
+        contour = max(contours, key=cv2.contourArea)
+        contour_area = cv2.contourArea(contour)
+        area_ratio = contour_area / (work_w * work_h)
+        if area_ratio < MIN_AREA_RATIO:
+            return None
+
+        hull = cv2.convexHull(contour)
+        quad = self._quad_from_hull(hull)
+        confidence = self._confidence(quad, contour_area, cv2.contourArea(hull), area_ratio)
+        return quad, confidence
+
+    def _quad_from_hull(self, hull: "np.ndarray") -> "np.ndarray":
+        """Approximate a convex hull with a quadrilateral.
+
+        Tries increasingly coarse polygon approximations until one has exactly
+        4 points; falls back to the hull's minimum-area bounding rectangle.
+
+        Args:
+            hull: Convex hull contour from cv2.convexHull.
+
+        Returns:
+            Array of shape (4, 2), float32, unordered.
+        """
+        perimeter = cv2.arcLength(hull, closed=True)
+        for epsilon in (0.02, 0.04, 0.06, 0.08, 0.1):
+            approx = cv2.approxPolyDP(hull, epsilon * perimeter, closed=True)
+            if len(approx) == 4:
+                return approx.reshape(4, 2).astype(np.float32)
+        return cast("np.ndarray", cv2.boxPoints(cv2.minAreaRect(hull)))
+
+    def _confidence(self, quad: "np.ndarray", contour_area: float, hull_area: float, area_ratio: float) -> float:
+        """Compute a heuristic detection confidence in [0, 1].
+
+        Combines how solid the segmented region is (contour vs hull area), how
+        rectangular the fitted quad is, and how much of the photo it covers.
+        This is a heuristic, not a calibrated probability.
+
+        Args:
+            quad: The fitted quadrilateral, shape (4, 2).
+            contour_area: Area of the segmented contour.
+            hull_area: Area of the contour's convex hull.
+            area_ratio: Contour area as a fraction of the working image.
+
+        Returns:
+            Confidence value clamped to [0, 1].
+        """
+        hull_fill = contour_area / hull_area if hull_area > 0 else 0.0
+        rect_w, rect_h = cv2.minAreaRect(quad.reshape(-1, 1, 2))[1]
+        rect_area = rect_w * rect_h
+        quad_area = cv2.contourArea(quad.reshape(-1, 1, 2))
+        rectangularity = quad_area / rect_area if rect_area > 0 else 0.0
+        confidence = hull_fill * rectangularity * min(1.0, area_ratio / FULL_CONFIDENCE_AREA_RATIO)
+        return float(np.clip(confidence, 0.0, 1.0))
+
+
+# Singleton instance
+_puzzle_detector: Optional[PuzzleFrameDetector] = None
+
+
+def get_puzzle_detector() -> PuzzleFrameDetector:
+    """Get or create the singleton PuzzleFrameDetector instance.
+
+    Returns:
+        The shared PuzzleFrameDetector instance.
+    """
+    global _puzzle_detector
+    if _puzzle_detector is None:
+        _puzzle_detector = PuzzleFrameDetector()
+    return _puzzle_detector

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "pytorch-lightning>=2.6.1",
     "timm>=0.9.12",
     "rembg[cpu]>=2.0.76",
+    "opencv-python-headless>=4.10.0",
     # Force newer numba for Python 3.12 compatibility (rembg->pymatting->numba)
     "numba>=0.60.0",
     # Shared library (local path dependency)

--- a/backend/tests/test_image_processor.py
+++ b/backend/tests/test_image_processor.py
@@ -1,0 +1,45 @@
+"""Tests for the image processor's graceful degradation without a checkpoint."""
+
+import asyncio
+import io
+from unittest.mock import patch
+
+from fastapi import UploadFile
+from PIL import Image
+
+from app.services import image_processor as ip_module
+from app.services.image_processor import ImageProcessor
+
+
+def make_upload(content: bytes) -> UploadFile:
+    """Wrap raw bytes in an UploadFile for process_piece."""
+    return UploadFile(filename="piece.jpg", file=io.BytesIO(content))
+
+
+def make_jpeg() -> bytes:
+    """Create a small in-memory JPEG."""
+    buffer = io.BytesIO()
+    Image.new("RGB", (64, 64), (120, 120, 120)).save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+def test_missing_checkpoint_loads_no_model() -> None:
+    """With no checkpoint file, the processor loads no model instead of raising."""
+    with patch.object(ip_module, "CHECKPOINT_PATH", "/nonexistent/checkpoint.pt"):
+        processor = ImageProcessor()
+
+    assert processor.model is None
+
+
+def test_missing_checkpoint_returns_neutral_fallback() -> None:
+    """process_piece returns a neutral prediction when no model is available."""
+    with patch.object(ip_module, "CHECKPOINT_PATH", "/nonexistent/checkpoint.pt"):
+        processor = ImageProcessor()
+
+    result = asyncio.run(processor.process_piece(make_upload(make_jpeg()), "some-puzzle-id", remove_background=False))
+
+    assert result.position.x == 0.5
+    assert result.position.y == 0.5
+    assert result.position_confidence == 0.0
+    assert result.rotation == 0
+    assert result.rotation_confidence == 0.0

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -290,6 +290,17 @@ def test_piece_preview_invalid_image_bytes() -> None:
     assert response.status_code == 400
 
 
+def test_piece_preview_rejects_oversized_file() -> None:
+    """Piece preview returns 413 when the frame exceeds the upload size limit."""
+    oversized = b"\x00" * (settings.MAX_UPLOAD_SIZE + 1)
+    response = client.post(
+        "/api/v1/piece/preview",
+        files=photo_files(oversized),
+        headers=get_auth_header(),
+    )
+    assert response.status_code == 413
+
+
 def test_piece_preview_returns_region() -> None:
     """Piece preview maps a detected region to polygon and bbox."""
     detector = MagicMock()

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,11 +1,12 @@
 """Test module for the FastAPI puzzle solver application."""
 
+import json
 import os
 import shutil
 import sys
 import tempfile
 from datetime import datetime, timedelta, timezone
-from io import BufferedReader
+from io import BufferedReader, BytesIO
 from pathlib import Path
 from typing import Generator, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -13,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 from jose import jwt
+from PIL import Image, ImageDraw
 from typing_extensions import TypeAlias
 
 from app.main import app, settings
@@ -171,3 +173,160 @@ def test_process_piece() -> None:
         # Cleanup test image
         if os.path.exists("test_puzzle.jpg"):
             os.remove("test_puzzle.jpg")
+
+
+def make_photo_jpeg() -> bytes:
+    """Create an in-memory JPEG photo with a bright rectangle on a dark background."""
+    image = Image.new("RGB", (800, 600), (20, 20, 20))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((100, 80, 700, 520), fill=(220, 210, 190))
+    buffer = BytesIO()
+    image.save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+def photo_files(content: bytes) -> dict[str, tuple[str, BytesIO, str]]:
+    """Build the multipart files dict for a photo upload."""
+    return {"file": ("photo.jpg", BytesIO(content), "image/jpeg")}
+
+
+def test_detect_frame_requires_auth() -> None:
+    """Detect-frame rejects unauthenticated requests."""
+    response = client.post("/api/v1/puzzle/detect-frame", files=photo_files(make_photo_jpeg()))
+    assert response.status_code in (401, 403)
+
+
+def test_detect_frame_no_file() -> None:
+    """Detect-frame returns 400 when no file is provided."""
+    response = client.post("/api/v1/puzzle/detect-frame", headers=get_auth_header())
+    assert response.status_code == 400
+
+
+def test_detect_frame_detects_rectangle() -> None:
+    """Detect-frame finds the rectangle and returns a trimmed preview."""
+    response = client.post(
+        "/api/v1/puzzle/detect-frame",
+        files=photo_files(make_photo_jpeg()),
+        headers=get_auth_header(),
+    )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["trimmed_image"].startswith("data:image/jpeg;base64,")
+    assert 0.0 <= result["confidence"] <= 1.0
+    assert result["confidence"] > 0.5
+    for name in ("top_left", "top_right", "bottom_right", "bottom_left"):
+        corner = result["corners"][name]
+        assert 0.0 <= corner["x"] <= 1.0
+        assert 0.0 <= corner["y"] <= 1.0
+    # Detected corners should be close to the drawn rectangle (100,80)-(700,520) in 800x600
+    assert abs(result["corners"]["top_left"]["x"] - 100 / 800) < 0.03
+    assert abs(result["corners"]["top_left"]["y"] - 80 / 600) < 0.03
+
+
+def test_detect_frame_manual_corners() -> None:
+    """Detect-frame uses manually supplied corners with confidence 1.0."""
+    manual_corners = {
+        "top_left": {"x": 0.125, "y": 0.1333},
+        "top_right": {"x": 0.875, "y": 0.1333},
+        "bottom_right": {"x": 0.875, "y": 0.8667},
+        "bottom_left": {"x": 0.125, "y": 0.8667},
+    }
+
+    response = client.post(
+        "/api/v1/puzzle/detect-frame",
+        files=photo_files(make_photo_jpeg()),
+        data={"corners": json.dumps(manual_corners)},
+        headers=get_auth_header(),
+    )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["confidence"] == 1.0
+    assert result["corners"] == manual_corners
+    assert result["trimmed_image"].startswith("data:image/jpeg;base64,")
+
+
+def test_detect_frame_invalid_corners_json() -> None:
+    """Detect-frame returns 400 for a malformed corners payload."""
+    response = client.post(
+        "/api/v1/puzzle/detect-frame",
+        files=photo_files(make_photo_jpeg()),
+        data={"corners": "not valid json"},
+        headers=get_auth_header(),
+    )
+    assert response.status_code == 400
+
+
+def test_detect_frame_invalid_image_bytes() -> None:
+    """Detect-frame returns 400 when the file is not a decodable image."""
+    response = client.post(
+        "/api/v1/puzzle/detect-frame",
+        files=photo_files(b"fake image content"),
+        headers=get_auth_header(),
+    )
+    assert response.status_code == 400
+
+
+def test_piece_preview_requires_auth() -> None:
+    """Piece preview rejects unauthenticated requests."""
+    response = client.post("/api/v1/piece/preview", files=photo_files(make_photo_jpeg()))
+    assert response.status_code in (401, 403)
+
+
+def test_piece_preview_no_file() -> None:
+    """Piece preview returns 400 when no file is provided."""
+    response = client.post("/api/v1/piece/preview", headers=get_auth_header())
+    assert response.status_code == 400
+
+
+def test_piece_preview_invalid_image_bytes() -> None:
+    """Piece preview returns 400 for non-image bytes."""
+    response = client.post(
+        "/api/v1/piece/preview",
+        files=photo_files(b"fake image content"),
+        headers=get_auth_header(),
+    )
+    assert response.status_code == 400
+
+
+def test_piece_preview_returns_region() -> None:
+    """Piece preview maps a detected region to polygon and bbox."""
+    detector = MagicMock()
+    detector.detect_region.return_value = (
+        [(0.1, 0.2), (0.8, 0.2), (0.8, 0.9), (0.1, 0.9)],
+        (0.1, 0.2, 0.7, 0.7),
+    )
+
+    with patch("app.main.get_piece_detector", return_value=detector):
+        response = client.post(
+            "/api/v1/piece/preview",
+            files=photo_files(make_photo_jpeg()),
+            headers=get_auth_header(),
+        )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["found"] is True
+    assert len(result["polygon"]) == 4
+    assert result["polygon"][0] == {"x": 0.1, "y": 0.2}
+    assert result["bbox"] == {"x": 0.1, "y": 0.2, "width": 0.7, "height": 0.7}
+
+
+def test_piece_preview_not_found() -> None:
+    """Piece preview reports found=False when nothing is detected."""
+    detector = MagicMock()
+    detector.detect_region.return_value = None
+
+    with patch("app.main.get_piece_detector", return_value=detector):
+        response = client.post(
+            "/api/v1/piece/preview",
+            files=photo_files(make_photo_jpeg()),
+            headers=get_auth_header(),
+        )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["found"] is False
+    assert result["polygon"] == []
+    assert result["bbox"] is None

--- a/backend/tests/test_piece_detector.py
+++ b/backend/tests/test_piece_detector.py
@@ -1,0 +1,132 @@
+"""Tests for the piece detector service."""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from app.services.piece_detector import PieceDetector, crop_to_alpha_region, get_piece_detector, largest_alpha_component
+
+# Opaque region drawn into test RGBA images: left, top, right, bottom
+REGION = (60, 40, 260, 200)
+
+
+def make_rgba_with_region(size: tuple[int, int] = (320, 240)) -> Image.Image:
+    """Create a transparent RGBA image with one opaque rectangle at REGION."""
+    rgba = np.zeros((size[1], size[0], 4), dtype=np.uint8)
+    left, top, right, bottom = REGION
+    rgba[top:bottom, left:right] = (200, 120, 80, 255)
+    return Image.fromarray(rgba, mode="RGBA")
+
+
+class TestCropToAlphaRegion:
+    """Tests for crop_to_alpha_region."""
+
+    def test_crops_to_opaque_region_with_margin(self) -> None:
+        """The crop covers the opaque rectangle plus the requested margin."""
+        left, top, right, bottom = REGION
+
+        cropped = crop_to_alpha_region(make_rgba_with_region(), margin=0.1)
+
+        expected_w = round((right - left) * 1.2)
+        expected_h = round((bottom - top) * 1.2)
+        assert abs(cropped.width - expected_w) <= 2
+        assert abs(cropped.height - expected_h) <= 2
+
+    def test_fully_transparent_image_is_unchanged(self) -> None:
+        """An image with no opaque pixels is returned as-is."""
+        rgba = Image.new("RGBA", (100, 100), (0, 0, 0, 0))
+
+        assert crop_to_alpha_region(rgba) is rgba
+
+    def test_non_rgba_image_is_unchanged(self) -> None:
+        """A non-RGBA image is returned as-is."""
+        rgb = Image.new("RGB", (100, 100), (10, 20, 30))
+
+        assert crop_to_alpha_region(rgb) is rgb
+
+    def test_crop_is_clamped_to_image_bounds(self) -> None:
+        """A region touching the edge does not produce an out-of-bounds crop."""
+        rgba = np.zeros((100, 100, 4), dtype=np.uint8)
+        rgba[0:100, 0:100] = (10, 10, 10, 255)
+
+        cropped = crop_to_alpha_region(Image.fromarray(rgba, mode="RGBA"), margin=0.2)
+
+        assert cropped.size == (100, 100)
+
+
+def test_largest_alpha_component_picks_biggest_blob() -> None:
+    """With multiple opaque blobs, the largest one is selected."""
+    import cv2
+
+    rgba = np.zeros((200, 200, 4), dtype=np.uint8)
+    rgba[10:30, 10:30, 3] = 255  # small blob
+    rgba[80:180, 60:190, 3] = 255  # large blob
+
+    contour = largest_alpha_component(Image.fromarray(rgba, mode="RGBA"))
+
+    assert contour is not None
+    x, y, w, h = cv2.boundingRect(contour)
+    assert (x, y) == (60, 80)
+    assert (w, h) == (130, 100)
+
+
+class TestPieceDetector:
+    """Tests for PieceDetector.detect_region with a mocked background remover."""
+
+    @pytest.fixture
+    def frame(self) -> Image.Image:
+        """A camera frame; content is irrelevant since rembg is mocked."""
+        return Image.new("RGB", (640, 480), (50, 60, 70))
+
+    def test_detects_region_from_rembg_alpha(self, frame: Image.Image) -> None:
+        """The polygon and bbox reflect the mocked rembg alpha mask."""
+        remover = MagicMock()
+        remover.remove_background.return_value = make_rgba_with_region()
+
+        with patch("app.services.piece_detector.get_background_remover", return_value=remover):
+            result = PieceDetector().detect_region(frame)
+
+        assert result is not None
+        polygon, bbox = result
+        left, top, right, bottom = REGION
+        assert bbox[0] == pytest.approx(left / 320, abs=0.02)
+        assert bbox[1] == pytest.approx(top / 240, abs=0.02)
+        assert bbox[2] == pytest.approx((right - left) / 320, abs=0.02)
+        assert bbox[3] == pytest.approx((bottom - top) / 240, abs=0.02)
+        assert len(polygon) >= 4
+        for x, y in polygon:
+            assert 0.0 <= x <= 1.0
+            assert 0.0 <= y <= 1.0
+
+    def test_no_alpha_returns_none(self, frame: Image.Image) -> None:
+        """A fully transparent rembg result yields no detection."""
+        remover = MagicMock()
+        remover.remove_background.return_value = Image.new("RGBA", (320, 240), (0, 0, 0, 0))
+
+        with patch("app.services.piece_detector.get_background_remover", return_value=remover):
+            assert PieceDetector().detect_region(frame) is None
+
+    def test_tiny_region_returns_none(self, frame: Image.Image) -> None:
+        """A region below the minimum area ratio is rejected."""
+        rgba = np.zeros((240, 320, 4), dtype=np.uint8)
+        rgba[100:104, 100:104, 3] = 255
+        remover = MagicMock()
+        remover.remove_background.return_value = Image.fromarray(rgba, mode="RGBA")
+
+        with patch("app.services.piece_detector.get_background_remover", return_value=remover):
+            assert PieceDetector().detect_region(frame) is None
+
+    def test_rembg_failure_returns_none(self, frame: Image.Image) -> None:
+        """A rembg exception degrades to no detection instead of raising."""
+        remover = MagicMock()
+        remover.remove_background.side_effect = RuntimeError("boom")
+
+        with patch("app.services.piece_detector.get_background_remover", return_value=remover):
+            assert PieceDetector().detect_region(frame) is None
+
+
+def test_get_piece_detector_is_singleton() -> None:
+    """get_piece_detector returns the same instance on repeated calls."""
+    assert get_piece_detector() is get_piece_detector()

--- a/backend/tests/test_puzzle_detector.py
+++ b/backend/tests/test_puzzle_detector.py
@@ -1,0 +1,258 @@
+"""Tests for the puzzle frame detector service."""
+
+from typing import List, Tuple
+
+import pytest
+from PIL import Image, ImageDraw
+
+from app.services.puzzle_detector import FULL_IMAGE_CORNERS, Point, PuzzleFrameDetector, get_puzzle_detector
+
+# Canvas and rectangle used by the synthetic test image
+CANVAS_SIZE = (800, 600)
+RECT_BOUNDS = (100, 80, 700, 520)  # left, top, right, bottom in pixels
+
+CORNER_TOLERANCE = 0.03
+
+
+@pytest.fixture
+def detector() -> PuzzleFrameDetector:
+    """Provide a detector instance without the (slow) rembg salient-object fallback."""
+    return PuzzleFrameDetector(salient_fallback=False)
+
+
+def make_rectangle_image() -> Image.Image:
+    """Create a dark canvas with a bright rectangle at RECT_BOUNDS."""
+    image = Image.new("RGB", CANVAS_SIZE, (20, 20, 20))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle(RECT_BOUNDS, fill=(220, 210, 190))
+    return image
+
+
+def expected_corners() -> List[Point]:
+    """Expected normalized corners (TL, TR, BR, BL) of the synthetic rectangle."""
+    width, height = CANVAS_SIZE
+    left, top, right, bottom = RECT_BOUNDS
+    return [
+        (left / width, top / height),
+        (right / width, top / height),
+        (right / width, bottom / height),
+        (left / width, bottom / height),
+    ]
+
+
+def assert_corners_close(actual: List[Point], expected: List[Point], tolerance: float = CORNER_TOLERANCE) -> None:
+    """Assert each actual corner is within tolerance of the expected corner."""
+    for (ax, ay), (ex, ey) in zip(actual, expected):
+        assert abs(ax - ex) <= tolerance, f"x: {ax} vs {ex}"
+        assert abs(ay - ey) <= tolerance, f"y: {ay} vs {ey}"
+
+
+class TestDetectCorners:
+    """Tests for PuzzleFrameDetector.detect_corners."""
+
+    def test_detects_bright_rectangle(self, detector: PuzzleFrameDetector) -> None:
+        """A clear rectangle on a dark background is detected with ordered corners."""
+        corners, confidence = detector.detect_corners(make_rectangle_image())
+
+        assert len(corners) == 4
+        assert confidence > 0.5
+        assert_corners_close(corners, expected_corners())
+
+    def test_corners_are_normalized(self, detector: PuzzleFrameDetector) -> None:
+        """All detected corners are within [0, 1]."""
+        corners, _ = detector.detect_corners(make_rectangle_image())
+
+        for x, y in corners:
+            assert 0.0 <= x <= 1.0
+            assert 0.0 <= y <= 1.0
+
+    def test_blank_image_falls_back_to_full_frame(self, detector: PuzzleFrameDetector) -> None:
+        """A uniform image with no contours returns full-image corners and zero confidence."""
+        blank = Image.new("RGB", (640, 480), (128, 128, 128))
+
+        corners, confidence = detector.detect_corners(blank)
+
+        assert corners == FULL_IMAGE_CORNERS
+        assert confidence == 0.0
+
+    def test_small_rectangle_is_rejected(self, detector: PuzzleFrameDetector) -> None:
+        """A rectangle covering far less than MIN_AREA_RATIO is not accepted."""
+        image = Image.new("RGB", CANVAS_SIZE, (20, 20, 20))
+        draw = ImageDraw.Draw(image)
+        draw.rectangle((10, 10, 90, 70), fill=(220, 210, 190))
+
+        corners, confidence = detector.detect_corners(image)
+
+        assert corners == FULL_IMAGE_CORNERS
+        assert confidence == 0.0
+
+    def test_tilted_photo_on_noisy_background_with_shadow(self, detector: PuzzleFrameDetector) -> None:
+        """A tilted picture on a noisy table with a soft shadow is detected, shadow excluded.
+
+        Regression test for the realistic-photo case: edge-based detection failed here
+        because the picture's internal edges fragment its outline, and brightness-based
+        segmentation included the shadow.
+        """
+        import cv2
+        import numpy as np
+
+        rng = np.random.default_rng(7)
+        width, height = 1600, 1200
+        background = np.full((height, width, 3), (92, 64, 48), dtype=np.uint8)
+        noise = rng.normal(0, 8, (height, width, 1)).astype(np.int16)
+        background = np.clip(background.astype(np.int16) + noise, 0, 255).astype(np.uint8)
+
+        # A photo-like subject with internal structure (gradient + stripes), tilted
+        subject = np.zeros((512, 512, 3), dtype=np.uint8)
+        subject[:, :, 0] = np.linspace(30, 220, 512, dtype=np.uint8)[None, :]
+        subject[:, :, 1] = np.linspace(200, 40, 512, dtype=np.uint8)[:, None]
+        subject[:, :, 2] = 160
+        subject[::32] = (240, 240, 240)
+
+        dst_quad = np.array([[330, 240], [1290, 210], [1330, 950], [290, 990]], dtype=np.float32)
+        src_quad = np.array([[0, 0], [512, 0], [512, 512], [0, 512]], dtype=np.float32)
+        matrix = cv2.getPerspectiveTransform(src_quad, dst_quad)
+        warped = cv2.warpPerspective(subject, matrix, (width, height))
+        mask = cv2.warpPerspective(np.full((512, 512), 255, np.uint8), matrix, (width, height))
+
+        # Soft shadow around the subject
+        shadow = cv2.dilate(mask, np.ones((25, 25), np.uint8))
+        shadow = cv2.GaussianBlur(shadow, (51, 51), 0)
+        background = (background * (1 - 0.35 * (shadow[..., None] / 255.0))).astype(np.uint8)
+        photo = Image.fromarray(np.where(mask[..., None] > 0, warped, background))
+
+        corners, confidence = detector.detect_corners(photo)
+
+        expected = [(float(x) / width, float(y) / height) for x, y in dst_quad.tolist()]
+        assert confidence > 0.4
+        assert_corners_close(corners, expected)
+
+    def test_large_image_is_downscaled(self, detector: PuzzleFrameDetector) -> None:
+        """Detection works on images larger than the working dimension."""
+        image = Image.new("RGB", (2400, 1800), (20, 20, 20))
+        draw = ImageDraw.Draw(image)
+        draw.rectangle((300, 240, 2100, 1560), fill=(220, 210, 190))
+
+        corners, confidence = detector.detect_corners(image)
+
+        assert confidence > 0.5
+        assert_corners_close(
+            corners,
+            [
+                (300 / 2400, 240 / 1800),
+                (2100 / 2400, 240 / 1800),
+                (2100 / 2400, 1560 / 1800),
+                (300 / 2400, 1560 / 1800),
+            ],
+        )
+
+
+class TestWarp:
+    """Tests for PuzzleFrameDetector.warp."""
+
+    def test_warp_crops_to_rectangle(self, detector: PuzzleFrameDetector) -> None:
+        """Warping with the rectangle's corners yields an image matching its size."""
+        image = make_rectangle_image()
+        left, top, right, bottom = RECT_BOUNDS
+        expected_size: Tuple[int, int] = (right - left, bottom - top)
+
+        warped = detector.warp(image, expected_corners())
+
+        assert abs(warped.width - expected_size[0]) <= 2
+        assert abs(warped.height - expected_size[1]) <= 2
+
+    def test_warp_content_is_bright(self, detector: PuzzleFrameDetector) -> None:
+        """The warped crop contains the bright rectangle, not the dark background."""
+        warped = detector.warp(make_rectangle_image(), expected_corners())
+
+        center = warped.getpixel((warped.width // 2, warped.height // 2))
+        assert isinstance(center, tuple)
+        assert center[0] > 150
+
+    def test_warp_accepts_unordered_corners(self, detector: PuzzleFrameDetector) -> None:
+        """Corners in a different order produce the same crop size."""
+        tl, tr, br, bl = expected_corners()
+
+        warped = detector.warp(make_rectangle_image(), [br, tl, bl, tr])
+
+        left, top, right, bottom = RECT_BOUNDS
+        assert abs(warped.width - (right - left)) <= 2
+        assert abs(warped.height - (bottom - top)) <= 2
+
+    def test_full_image_corners_return_whole_image(self, detector: PuzzleFrameDetector) -> None:
+        """Warping with the fallback corners returns (approximately) the input image."""
+        image = make_rectangle_image()
+
+        warped = detector.warp(image, list(FULL_IMAGE_CORNERS))
+
+        assert abs(warped.width - image.width) <= 2
+        assert abs(warped.height - image.height) <= 2
+
+
+class TestSalientFallback:
+    """Tests for the rembg salient-object fallback path."""
+
+    @staticmethod
+    def make_cluttered_photo() -> Image.Image:
+        """Create a photo whose border is too varied for background segmentation."""
+        import numpy as np
+
+        rng = np.random.default_rng(3)
+        clutter = rng.integers(0, 255, (600, 800, 3), dtype=np.uint8)
+        image = Image.fromarray(clutter)
+        draw = ImageDraw.Draw(image)
+        draw.rectangle(RECT_BOUNDS, fill=(220, 210, 190))
+        return image
+
+    def test_salient_fallback_detects_subject(self) -> None:
+        """When the border is cluttered, the rembg mask drives detection."""
+        from unittest.mock import MagicMock, patch
+
+        import numpy as np
+
+        # Fake rembg output: alpha covering exactly the drawn rectangle
+        alpha = np.zeros((600, 800), dtype=np.uint8)
+        left, top, right, bottom = RECT_BOUNDS
+        alpha[top:bottom, left:right] = 255
+        rgba = np.dstack([np.zeros((600, 800, 3), dtype=np.uint8), alpha])
+        remover = MagicMock()
+        remover.remove_background.return_value = Image.fromarray(rgba, mode="RGBA")
+
+        detector = PuzzleFrameDetector(salient_fallback=True)
+        with patch("app.services.puzzle_detector.get_background_remover", return_value=remover):
+            corners, confidence = detector.detect_corners(self.make_cluttered_photo())
+
+        remover.remove_background.assert_called_once()
+        assert confidence > 0.4
+        assert_corners_close(corners, expected_corners())
+
+    def test_salient_fallback_failure_returns_full_frame(self) -> None:
+        """If rembg raises, detection degrades gracefully to the full-frame fallback."""
+        from unittest.mock import MagicMock, patch
+
+        remover = MagicMock()
+        remover.remove_background.side_effect = RuntimeError("model unavailable")
+
+        detector = PuzzleFrameDetector(salient_fallback=True)
+        with patch("app.services.puzzle_detector.get_background_remover", return_value=remover):
+            corners, confidence = detector.detect_corners(self.make_cluttered_photo())
+
+        assert corners == FULL_IMAGE_CORNERS
+        assert confidence == 0.0
+
+    def test_no_fallback_when_disabled(self) -> None:
+        """With salient_fallback=False a cluttered border goes straight to full frame."""
+        from unittest.mock import patch
+
+        detector = PuzzleFrameDetector(salient_fallback=False)
+        with patch("app.services.puzzle_detector.get_background_remover") as mock_get:
+            corners, confidence = detector.detect_corners(self.make_cluttered_photo())
+
+        mock_get.assert_not_called()
+        assert corners == FULL_IMAGE_CORNERS
+        assert confidence == 0.0
+
+
+def test_get_puzzle_detector_is_singleton() -> None:
+    """get_puzzle_detector returns the same instance on repeated calls."""
+    assert get_puzzle_detector() is get_puzzle_detector()

--- a/frontend/e2e/real-mode.spec.ts
+++ b/frontend/e2e/real-mode.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect } from './fixtures';
+import path from 'path';
+
+const TEST_PUZZLE_PATH = path.join(__dirname, '../public/test-puzzles/puzzle_001.jpg');
+// Frame detection may fall back to rembg segmentation, which is slow on the
+// first request after backend startup (model session warm-up)
+const API_TIMEOUT = 20000;
+// Piece prediction runs background removal + CNN inference and may download models on first run
+const PIECE_TIMEOUT = 30000;
+
+test.describe('Real Mode Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/real');
+  });
+
+  test('displays capture phase initially', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Solve Real Puzzle' })).toBeVisible();
+    await expect(page.getByText('Capture Your Puzzle')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Take Puzzle Photo' })).toBeVisible();
+  });
+
+  test('opens camera modal when clicking Take Puzzle Photo', async ({ page }) => {
+    await page.getByRole('button', { name: 'Take Puzzle Photo' }).click();
+
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Capture Puzzle' })).toBeVisible();
+  });
+
+  test('can close camera modal with Cancel button', async ({ page }) => {
+    await page.getByRole('button', { name: 'Take Puzzle Photo' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Cancel' }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+  });
+
+  test('back button navigates to home page', async ({ page }) => {
+    await page.locator('header a').first().click();
+
+    await expect(page).toHaveURL('/');
+  });
+});
+
+test.describe('Real Mode Flow with Backend', () => {
+  // These tests require the backend to be running and TEST_AUTH_TOKEN to be set
+  test.beforeAll(async () => {
+    let response: Response;
+    try {
+      response = await fetch('http://localhost:8000/health');
+    } catch {
+      throw new Error('Backend is not running. Start it with: make start-backend');
+    }
+    if (!response.ok) {
+      throw new Error(
+        `Backend health check failed with status ${response.status}. Ensure backend is running on http://localhost:8000`
+      );
+    }
+
+    if (!process.env.TEST_AUTH_TOKEN) {
+      console.warn(
+        'WARNING: TEST_AUTH_TOKEN not set. API requests may fail with 401. ' +
+          'Generate token with: python backend/scripts/generate_test_token.py'
+      );
+    }
+  });
+
+  test('detects puzzle frame and shows trim confirmation', async ({ page }) => {
+    await page.goto('/real');
+
+    await page.getByRole('button', { name: 'Take Puzzle Photo' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles(TEST_PUZZLE_PATH);
+
+    // Wait for detection result
+    await expect(page.getByRole('heading', { name: 'Is this your puzzle?' })).toBeVisible({
+      timeout: API_TIMEOUT,
+    });
+
+    await expect(page.getByAltText('Trimmed puzzle')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Use This' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Adjust Corners' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Retake' })).toBeVisible();
+  });
+
+  test('adjust corners shows draggable handles and returns to confirmation', async ({ page }) => {
+    await page.goto('/real');
+
+    await page.getByRole('button', { name: 'Take Puzzle Photo' }).click();
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles(TEST_PUZZLE_PATH);
+    await expect(page.getByRole('heading', { name: 'Is this your puzzle?' })).toBeVisible({
+      timeout: API_TIMEOUT,
+    });
+
+    await page.getByRole('button', { name: 'Adjust Corners' }).click();
+
+    // All four handles are visible
+    await expect(page.getByTestId('corner-handle-topLeft')).toBeVisible();
+    await expect(page.getByTestId('corner-handle-topRight')).toBeVisible();
+    await expect(page.getByTestId('corner-handle-bottomRight')).toBeVisible();
+    await expect(page.getByTestId('corner-handle-bottomLeft')).toBeVisible();
+
+    // Apply re-runs the trim with manual corners and returns to confirmation
+    await page.getByRole('button', { name: 'Apply' }).click();
+    await expect(page.getByRole('heading', { name: 'Is this your puzzle?' })).toBeVisible({
+      timeout: API_TIMEOUT,
+    });
+  });
+
+  test('accepts trim and captures a piece', async ({ page }) => {
+    await page.goto('/real');
+
+    // Photograph the puzzle
+    await page.getByRole('button', { name: 'Take Puzzle Photo' }).click();
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles(TEST_PUZZLE_PATH);
+    await expect(page.getByRole('heading', { name: 'Is this your puzzle?' })).toBeVisible({
+      timeout: API_TIMEOUT,
+    });
+
+    // Accept the trimmed image (uploads it as the puzzle)
+    await page.getByRole('button', { name: 'Use This' }).click();
+    await expect(page.getByRole('button', { name: 'Capture Piece' })).toBeVisible({
+      timeout: API_TIMEOUT,
+    });
+    await expect(page.getByText('0 pieces captured')).toBeVisible();
+
+    // Capture a piece (any image works; the backend predicts regardless)
+    await page.getByRole('button', { name: 'Capture Piece' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await page.locator('input[type="file"]').setInputFiles(TEST_PUZZLE_PATH);
+
+    // The prediction is added to the overlay and the counter updates
+    await expect(page.getByText('1 piece captured')).toBeVisible({ timeout: PIECE_TIMEOUT });
+    await expect(page.getByText('Position:')).toBeVisible();
+  });
+});

--- a/frontend/e2e/real-mode.spec.ts
+++ b/frontend/e2e/real-mode.spec.ts
@@ -3,10 +3,10 @@ import path from 'path';
 
 const TEST_PUZZLE_PATH = path.join(__dirname, '../public/test-puzzles/puzzle_001.jpg');
 // Frame detection may fall back to rembg segmentation, which is slow on the
-// first request after backend startup (model session warm-up)
-const API_TIMEOUT = 20000;
+// first request after backend startup (model download + session warm-up in CI)
+const API_TIMEOUT = 40000;
 // Piece prediction runs background removal + CNN inference and may download models on first run
-const PIECE_TIMEOUT = 30000;
+const PIECE_TIMEOUT = 60000;
 
 test.describe('Real Mode Page', () => {
   test.beforeEach(async ({ page }) => {
@@ -42,6 +42,11 @@ test.describe('Real Mode Page', () => {
 });
 
 test.describe('Real Mode Flow with Backend', () => {
+  // These flows hit rembg segmentation, which downloads its model on the first
+  // request in a fresh CI environment. Allow well beyond the default 30s per-test
+  // timeout so the assertion timeouts below (which include that download) can elapse.
+  test.describe.configure({ timeout: 120000 });
+
   // These tests require the backend to be running and TEST_AUTH_TOKEN to be set
   test.beforeAll(async () => {
     let response: Response;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -50,33 +50,33 @@ export default function HomePage() {
           <CardDescription>AI-powered puzzle piece position detection</CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
-          <Link href="/play" className="w-full">
-            <Button className="w-full gap-2" size="lg">
+          <Button asChild className="w-full gap-2" size="lg">
+            <Link href="/play">
               <Camera className="h-5 w-5" />
               New Puzzle
-            </Button>
-          </Link>
+            </Link>
+          </Button>
 
-          <Link href="/real" className="w-full">
-            <Button variant="secondary" className="w-full gap-2" size="lg">
+          <Button asChild variant="secondary" className="w-full gap-2" size="lg">
+            <Link href="/real">
               <ScanLine className="h-5 w-5" />
               Solve Real Puzzle
-            </Button>
-          </Link>
+            </Link>
+          </Button>
 
-          <Link href="/test-mode" className="w-full">
-            <Button variant="secondary" className="w-full gap-2" size="lg">
+          <Button asChild variant="secondary" className="w-full gap-2" size="lg">
+            <Link href="/test-mode">
               <FlaskConical className="h-5 w-5" />
               Test Mode
-            </Button>
-          </Link>
+            </Link>
+          </Button>
 
-          <Link href="/about" className="w-full">
-            <Button variant="outline" className="w-full gap-2" size="lg">
+          <Button asChild variant="outline" className="w-full gap-2" size="lg">
+            <Link href="/about">
               <Info className="h-5 w-5" />
               About
-            </Button>
-          </Link>
+            </Link>
+          </Button>
 
           <p className="text-muted-foreground mt-4 text-center text-sm">
             Capture your puzzle and pieces to find where each piece belongs.

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { Camera, FlaskConical, Info, LogIn, User } from 'lucide-react';
+import { Camera, FlaskConical, Info, LogIn, ScanLine, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { ThemeToggle } from '@/components/theme-toggle';
@@ -54,6 +54,13 @@ export default function HomePage() {
             <Button className="w-full gap-2" size="lg">
               <Camera className="h-5 w-5" />
               New Puzzle
+            </Button>
+          </Link>
+
+          <Link href="/real" className="w-full">
+            <Button variant="secondary" className="w-full gap-2" size="lg">
+              <ScanLine className="h-5 w-5" />
+              Solve Real Puzzle
             </Button>
           </Link>
 

--- a/frontend/src/app/real/page.tsx
+++ b/frontend/src/app/real/page.tsx
@@ -135,11 +135,11 @@ export default function RealModePage() {
     <div className="flex min-h-screen flex-col">
       {/* Header */}
       <header className="flex items-center justify-between border-b p-4">
-        <Link href="/">
-          <Button variant="ghost" size="icon">
+        <Button asChild variant="ghost" size="icon">
+          <Link href="/">
             <ArrowLeft className="h-5 w-5" />
-          </Button>
-        </Link>
+          </Link>
+        </Button>
         <div className="text-center">
           <h1 className="text-lg font-semibold">Solve Real Puzzle</h1>
           <p className="text-muted-foreground text-sm">

--- a/frontend/src/app/real/page.tsx
+++ b/frontend/src/app/real/page.tsx
@@ -1,0 +1,319 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Camera, Loader2, Plus, RotateCcw, ScanLine } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { CameraModal } from '@/components/camera';
+import { CornerAdjust, PieceCard, PuzzleDetail } from '@/components/puzzle';
+import { usePuzzleStore } from '@/stores/puzzle-store';
+import { detectFrame, uploadPuzzle, processPiece } from '@/lib/api';
+import { blobToDataUrl, dataUrlToBlob } from '@/lib/image-utils';
+import type { DetectFrameResult } from '@/types';
+
+type RealModePhase = 'capture-puzzle' | 'confirm-trim' | 'adjust-corners' | 'solving';
+
+// Real puzzles have many small pieces; the model predicts a continuous position,
+// so the overlay uses a fixed piece size rather than a grid-derived one.
+const PIECE_SIZE_RATIO = 0.12;
+
+const LOW_CONFIDENCE_THRESHOLD = 0.4;
+
+export default function RealModePage() {
+  const [phase, setPhase] = useState<RealModePhase>('capture-puzzle');
+  const [puzzleCameraOpen, setPuzzleCameraOpen] = useState(false);
+  const [pieceCameraOpen, setPieceCameraOpen] = useState(false);
+  const [rawPhotoBlob, setRawPhotoBlob] = useState<Blob | null>(null);
+  const [rawPhotoUrl, setRawPhotoUrl] = useState<string | null>(null);
+  const [detection, setDetection] = useState<DetectFrameResult | null>(null);
+
+  const {
+    puzzle,
+    puzzleImage,
+    pieces,
+    isLoading,
+    error,
+    setPuzzle,
+    addPiece,
+    setLoading,
+    setError,
+    reset,
+  } = usePuzzleStore();
+
+  // Clean up shared store state when leaving the page
+  useEffect(() => {
+    return () => {
+      reset();
+    };
+  }, [reset]);
+
+  const handlePuzzlePhoto = async (blob: Blob) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const photoUrl = await blobToDataUrl(blob);
+      setRawPhotoBlob(blob);
+      setRawPhotoUrl(photoUrl);
+
+      const result = await detectFrame(blob);
+      setDetection(result);
+      setPhase('confirm-trim');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to detect puzzle');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAcceptTrim = async () => {
+    if (!detection) return;
+
+    setLoading(true);
+    setError(null);
+    try {
+      const trimmedBlob = await dataUrlToBlob(detection.trimmedImageUrl);
+      const result = await uploadPuzzle(trimmedBlob);
+      setPuzzle(result, detection.trimmedImageUrl);
+      setPhase('solving');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to upload puzzle');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleApplyCorners = async (corners: DetectFrameResult['corners']) => {
+    if (!rawPhotoBlob) return;
+
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await detectFrame(rawPhotoBlob, corners);
+      setDetection(result);
+      setPhase('confirm-trim');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to trim puzzle');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handlePieceCapture = async (blob: Blob) => {
+    if (!puzzle) return;
+
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await processPiece(puzzle.puzzleId, blob);
+      addPiece(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to process piece');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRetake = () => {
+    setDetection(null);
+    setRawPhotoBlob(null);
+    setRawPhotoUrl(null);
+    setError(null);
+    setPhase('capture-puzzle');
+    setPuzzleCameraOpen(true);
+  };
+
+  const handleNewPuzzle = () => {
+    reset();
+    setDetection(null);
+    setRawPhotoBlob(null);
+    setRawPhotoUrl(null);
+    setPhase('capture-puzzle');
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      {/* Header */}
+      <header className="flex items-center justify-between border-b p-4">
+        <Link href="/">
+          <Button variant="ghost" size="icon">
+            <ArrowLeft className="h-5 w-5" />
+          </Button>
+        </Link>
+        <div className="text-center">
+          <h1 className="text-lg font-semibold">Solve Real Puzzle</h1>
+          <p className="text-muted-foreground text-sm">
+            {phase === 'solving'
+              ? `${pieces.length} ${pieces.length === 1 ? 'piece' : 'pieces'} captured`
+              : 'Photograph your puzzle to get started'}
+          </p>
+        </div>
+        <div className="w-10" />
+      </header>
+
+      {/* Content */}
+      <main className="mx-auto w-full max-w-2xl flex-1 p-4">
+        {error && (
+          <div className="bg-destructive/10 text-destructive mb-4 rounded-lg p-3 text-sm">
+            {error}
+          </div>
+        )}
+
+        {phase === 'capture-puzzle' && (
+          <Card>
+            <CardHeader className="text-center">
+              <CardTitle>Capture Your Puzzle</CardTitle>
+              <CardDescription>
+                Take a photo of the complete puzzle picture — the box lid or the finished puzzle. It
+                will be automatically trimmed to just the picture.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button
+                className="w-full gap-2"
+                size="lg"
+                onClick={() => setPuzzleCameraOpen(true)}
+                disabled={isLoading}
+              >
+                {isLoading ? (
+                  <Loader2 className="h-5 w-5 animate-spin" />
+                ) : (
+                  <Camera className="h-5 w-5" />
+                )}
+                {isLoading ? 'Detecting puzzle...' : 'Take Puzzle Photo'}
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
+        {phase === 'confirm-trim' && detection && (
+          <div className="space-y-4">
+            <div className="text-center">
+              <h2 className="text-lg font-semibold">Is this your puzzle?</h2>
+              <p className="text-muted-foreground text-sm">
+                The photo was trimmed to the detected puzzle picture.
+              </p>
+            </div>
+
+            {detection.confidence < LOW_CONFIDENCE_THRESHOLD && (
+              <div className="rounded-lg bg-yellow-500/10 p-3 text-sm text-yellow-600 dark:text-yellow-400">
+                Detection looks uncertain — consider adjusting the corners manually.
+              </div>
+            )}
+
+            <div className="flex justify-center">
+              <img
+                src={detection.trimmedImageUrl}
+                alt="Trimmed puzzle"
+                className="block h-auto max-h-[60vh] w-auto max-w-full rounded-lg"
+              />
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <Button
+                className="w-full gap-2"
+                size="lg"
+                onClick={() => void handleAcceptTrim()}
+                disabled={isLoading}
+              >
+                {isLoading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <ScanLine className="h-4 w-4" />
+                )}
+                Use This
+              </Button>
+              <div className="flex gap-3">
+                <Button
+                  variant="secondary"
+                  className="flex-1"
+                  onClick={() => setPhase('adjust-corners')}
+                  disabled={isLoading}
+                >
+                  Adjust Corners
+                </Button>
+                <Button
+                  variant="outline"
+                  className="flex-1 gap-2"
+                  onClick={handleRetake}
+                  disabled={isLoading}
+                >
+                  <RotateCcw className="h-4 w-4" />
+                  Retake
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {phase === 'adjust-corners' && detection && rawPhotoUrl && (
+          <CornerAdjust
+            imageUrl={rawPhotoUrl}
+            initialCorners={detection.corners}
+            onApply={(corners) => void handleApplyCorners(corners)}
+            onCancel={() => setPhase('confirm-trim')}
+            isLoading={isLoading}
+          />
+        )}
+
+        {phase === 'solving' && puzzle && puzzleImage && (
+          <div className="space-y-4">
+            <PuzzleDetail
+              puzzleImage={puzzleImage}
+              pieces={pieces}
+              pieceSizeRatio={PIECE_SIZE_RATIO}
+            />
+
+            <Button
+              className="w-full gap-2"
+              size="lg"
+              onClick={() => setPieceCameraOpen(true)}
+              disabled={isLoading}
+            >
+              {isLoading ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Plus className="h-4 w-4" />
+              )}
+              {isLoading ? 'Predicting position...' : 'Capture Piece'}
+            </Button>
+
+            {pieces.length > 0 && (
+              <div className="grid grid-cols-2 gap-3">
+                {pieces.map((piece, index) => (
+                  <PieceCard key={index} piece={piece} index={index} />
+                ))}
+              </div>
+            )}
+
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={handleNewPuzzle}
+              disabled={isLoading}
+            >
+              New Puzzle
+            </Button>
+          </div>
+        )}
+      </main>
+
+      {/* Puzzle photo camera */}
+      <CameraModal
+        open={puzzleCameraOpen}
+        onOpenChange={setPuzzleCameraOpen}
+        mode="puzzle"
+        onCapture={(blob) => void handlePuzzlePhoto(blob)}
+      />
+
+      {/* Piece capture camera with live piece-detection overlay */}
+      <CameraModal
+        open={pieceCameraOpen}
+        onOpenChange={setPieceCameraOpen}
+        mode="piece"
+        onCapture={(blob) => void handlePieceCapture(blob)}
+        livePieceDetection
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/auth-provider.tsx
+++ b/frontend/src/components/auth-provider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SessionProvider, useSession } from 'next-auth/react';
+import { SessionProvider, signOut, useSession } from 'next-auth/react';
 import { useEffect, type ReactNode } from 'react';
 import { useAuthStore } from '@/stores/auth-store';
 
@@ -27,6 +27,16 @@ function AuthSync() {
       setError(null);
 
       try {
+        // Token refresh failed server-side: the session can never authenticate again,
+        // so clear it to make the sign-in flow reachable (middleware redirects
+        // authenticated sessions away from /login).
+        const sessionError = (session as { error?: string }).error;
+        if (sessionError === 'RefreshTokenError') {
+          reset();
+          await signOut({ redirect: false });
+          return;
+        }
+
         // Exchange Google ID token for backend JWT
         const idToken = (session as { idToken?: string }).idToken;
         if (!idToken) {
@@ -40,6 +50,14 @@ function AuthSync() {
           },
           body: JSON.stringify({ id_token: idToken }),
         });
+
+        if (response.status === 401) {
+          // Stale or rejected Google token: drop the NextAuth session so the
+          // user can sign in fresh instead of being stuck in a redirect loop.
+          reset();
+          await signOut({ redirect: false });
+          return;
+        }
 
         if (!response.ok) {
           let message = 'Failed to authenticate with backend';

--- a/frontend/src/components/camera/camera-modal.tsx
+++ b/frontend/src/components/camera/camera-modal.tsx
@@ -12,6 +12,7 @@ interface CameraModalProps {
   mode: CameraMode;
   onCapture: (blob: Blob) => void;
   puzzleImageUrl?: string | null;
+  livePieceDetection?: boolean;
 }
 
 export function CameraModal({
@@ -20,6 +21,7 @@ export function CameraModal({
   mode,
   onCapture,
   puzzleImageUrl,
+  livePieceDetection = false,
 }: CameraModalProps) {
   const title = mode === 'puzzle' ? 'Capture Puzzle' : 'Capture Piece';
   const [isLandscape, setIsLandscape] = useState(false);
@@ -51,6 +53,7 @@ export function CameraModal({
           onCancel={() => onOpenChange(false)}
           onOrientationChange={handleOrientationChange}
           overlayImage={mode === 'piece' ? puzzleImageUrl : null}
+          livePieceDetection={mode === 'piece' && livePieceDetection}
           className="flex-1"
         />
       </DialogContent>

--- a/frontend/src/components/camera/camera-view.tsx
+++ b/frontend/src/components/camera/camera-view.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { Camera, Loader2, AlertCircle, Upload } from 'lucide-react';
 import { useCamera } from '@/hooks/use-camera';
 import { Button } from '@/components/ui/button';
-import { detectPieceRegion } from '@/lib/api';
+import { ApiError, detectPieceRegion } from '@/lib/api';
 import { cn } from '@/lib/utils';
 import type { PieceRegion } from '@/types';
 import { FileUpload } from './file-upload';
@@ -46,6 +46,7 @@ export function CameraView({
     if (!livePieceDetection || !isReady) return;
 
     let cancelled = false;
+    const controller = new AbortController();
     const canvas = document.createElement('canvas');
 
     const detectLoop = async () => {
@@ -66,11 +67,16 @@ export function CameraView({
               canvas.toBlob(resolve, 'image/jpeg', 0.7)
             );
             if (blob) {
-              const region = await detectPieceRegion(blob);
+              const region = await detectPieceRegion(blob, controller.signal);
               if (!cancelled) setPieceRegion(region);
             }
-          } catch {
-            // Keep the camera usable even if detection fails; try again next tick
+          } catch (err) {
+            // Cleanup aborted the in-flight request; stop silently
+            if (controller.signal.aborted) return;
+            // Auth expired: stop polling instead of hammering the endpoint
+            // (the auth provider handles re-authentication separately)
+            if (err instanceof ApiError && err.status === 401) return;
+            // Otherwise keep the camera usable and try again next tick
             if (!cancelled) setPieceRegion(null);
           }
         }
@@ -84,6 +90,7 @@ export function CameraView({
     void detectLoop();
     return () => {
       cancelled = true;
+      controller.abort();
       setPieceRegion(null);
     };
   }, [livePieceDetection, isReady, videoRef]);

--- a/frontend/src/components/camera/camera-view.tsx
+++ b/frontend/src/components/camera/camera-view.tsx
@@ -54,7 +54,11 @@ export function CameraView({
         const video = videoRef.current;
         if (video && video.videoWidth > 0) {
           try {
-            const scale = DETECT_FRAME_MAX_DIM / Math.max(video.videoWidth, video.videoHeight);
+            // Only ever downscale; never enlarge a stream smaller than the target
+            const scale = Math.min(
+              1,
+              DETECT_FRAME_MAX_DIM / Math.max(video.videoWidth, video.videoHeight)
+            );
             canvas.width = Math.max(1, Math.round(video.videoWidth * scale));
             canvas.height = Math.max(1, Math.round(video.videoHeight * scale));
             canvas.getContext('2d')?.drawImage(video, 0, 0, canvas.width, canvas.height);

--- a/frontend/src/components/camera/camera-view.tsx
+++ b/frontend/src/components/camera/camera-view.tsx
@@ -1,17 +1,25 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Camera, Loader2, AlertCircle, Upload } from 'lucide-react';
 import { useCamera } from '@/hooks/use-camera';
 import { Button } from '@/components/ui/button';
-import { FileUpload } from './file-upload';
+import { detectPieceRegion } from '@/lib/api';
 import { cn } from '@/lib/utils';
+import type { PieceRegion } from '@/types';
+import { FileUpload } from './file-upload';
+
+// Live piece detection: frames are downscaled to this size before upload
+const DETECT_FRAME_MAX_DIM = 320;
+// Minimum time between detection requests (the loop is also serialized on the response)
+const DETECT_INTERVAL_MS = 400;
 
 interface CameraViewProps {
   onCapture: (blob: Blob) => void;
   onCancel: () => void;
   onOrientationChange?: (isLandscape: boolean) => void;
   overlayImage?: string | null;
+  livePieceDetection?: boolean;
   className?: string;
 }
 
@@ -20,9 +28,11 @@ export function CameraView({
   onCancel,
   onOrientationChange,
   overlayImage,
+  livePieceDetection = false,
   className,
 }: CameraViewProps) {
   const { videoRef, isReady, isLoading, error, dimensions, start, stop, capture } = useCamera();
+  const [pieceRegion, setPieceRegion] = useState<PieceRegion | null>(null);
 
   useEffect(() => {
     void start();
@@ -30,6 +40,49 @@ export function CameraView({
       stop();
     };
   }, [start, stop]);
+
+  // Stream downscaled frames to the backend and overlay the detected piece outline
+  useEffect(() => {
+    if (!livePieceDetection || !isReady) return;
+
+    let cancelled = false;
+    const canvas = document.createElement('canvas');
+
+    const detectLoop = async () => {
+      while (!cancelled) {
+        const startedAt = Date.now();
+        const video = videoRef.current;
+        if (video && video.videoWidth > 0) {
+          try {
+            const scale = DETECT_FRAME_MAX_DIM / Math.max(video.videoWidth, video.videoHeight);
+            canvas.width = Math.max(1, Math.round(video.videoWidth * scale));
+            canvas.height = Math.max(1, Math.round(video.videoHeight * scale));
+            canvas.getContext('2d')?.drawImage(video, 0, 0, canvas.width, canvas.height);
+            const blob = await new Promise<Blob | null>((resolve) =>
+              canvas.toBlob(resolve, 'image/jpeg', 0.7)
+            );
+            if (blob) {
+              const region = await detectPieceRegion(blob);
+              if (!cancelled) setPieceRegion(region);
+            }
+          } catch {
+            // Keep the camera usable even if detection fails; try again next tick
+            if (!cancelled) setPieceRegion(null);
+          }
+        }
+        const elapsed = Date.now() - startedAt;
+        await new Promise((resolve) =>
+          setTimeout(resolve, Math.max(DETECT_INTERVAL_MS - elapsed, 100))
+        );
+      }
+    };
+
+    void detectLoop();
+    return () => {
+      cancelled = true;
+      setPieceRegion(null);
+    };
+  }, [livePieceDetection, isReady, videoRef]);
 
   // Notify parent of orientation changes
   useEffect(() => {
@@ -86,6 +139,39 @@ export function CameraView({
               className="h-full w-full object-contain opacity-30"
             />
           </div>
+        )}
+
+        {/* Live piece detection outline; slice mirrors the video's object-cover mapping */}
+        {livePieceDetection && isReady && dimensions && (
+          <>
+            {pieceRegion?.found && pieceRegion.polygon.length >= 3 && (
+              <svg
+                className="pointer-events-none absolute inset-0 h-full w-full"
+                viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+                preserveAspectRatio="xMidYMid slice"
+              >
+                <polygon
+                  points={pieceRegion.polygon
+                    .map((p) => `${p.x * dimensions.width},${p.y * dimensions.height}`)
+                    .join(' ')}
+                  fill="rgb(34 197 94 / 0.15)"
+                  stroke="rgb(34 197 94)"
+                  strokeWidth="2"
+                  vectorEffect="non-scaling-stroke"
+                />
+              </svg>
+            )}
+            <div className="pointer-events-none absolute top-3 left-1/2 -translate-x-1/2">
+              <span
+                className={cn(
+                  'rounded-full px-3 py-1 text-xs font-medium text-white',
+                  pieceRegion?.found ? 'bg-green-600/80' : 'bg-black/50'
+                )}
+              >
+                {pieceRegion?.found ? 'Piece detected' : 'Looking for piece…'}
+              </span>
+            </div>
+          </>
         )}
 
         {/* Loading overlay */}

--- a/frontend/src/components/puzzle/corner-adjust.test.tsx
+++ b/frontend/src/components/puzzle/corner-adjust.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CornerAdjust } from './corner-adjust';
+import type { QuadCorners } from '@/types';
+
+const CORNERS: QuadCorners = {
+  topLeft: { x: 0.1, y: 0.2 },
+  topRight: { x: 0.9, y: 0.2 },
+  bottomRight: { x: 0.9, y: 0.8 },
+  bottomLeft: { x: 0.1, y: 0.8 },
+};
+
+function renderCornerAdjust(overrides: Partial<Parameters<typeof CornerAdjust>[0]> = {}) {
+  const onApply = vi.fn();
+  const onCancel = vi.fn();
+  render(
+    <CornerAdjust
+      imageUrl="data:image/jpeg;base64,test"
+      initialCorners={CORNERS}
+      onApply={onApply}
+      onCancel={onCancel}
+      {...overrides}
+    />
+  );
+  return { onApply, onCancel };
+}
+
+describe('CornerAdjust', () => {
+  it('renders four corner handles at the initial positions', () => {
+    renderCornerAdjust();
+
+    const topLeft = screen.getByTestId('corner-handle-topLeft');
+    expect(topLeft).toHaveStyle({ left: '10%', top: '20%' });
+
+    const bottomRight = screen.getByTestId('corner-handle-bottomRight');
+    expect(bottomRight).toHaveStyle({ left: '90%', top: '80%' });
+
+    expect(screen.getByTestId('corner-handle-topRight')).toBeInTheDocument();
+    expect(screen.getByTestId('corner-handle-bottomLeft')).toBeInTheDocument();
+  });
+
+  it('calls onApply with the current corners', () => {
+    const { onApply } = renderCornerAdjust();
+
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(onApply).toHaveBeenCalledWith(CORNERS);
+  });
+
+  it('calls onCancel when cancelled', () => {
+    const { onCancel } = renderCornerAdjust();
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('disables buttons while loading', () => {
+    renderCornerAdjust({ isLoading: true });
+
+    expect(screen.getByRole('button', { name: /apply/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled();
+  });
+});

--- a/frontend/src/components/puzzle/corner-adjust.tsx
+++ b/frontend/src/components/puzzle/corner-adjust.tsx
@@ -99,9 +99,8 @@ export function CornerAdjust({
             <div
               key={name}
               data-testid={`corner-handle-${name}`}
-              role="slider"
-              aria-label={CORNER_LABELS[name]}
-              aria-valuetext={`${Math.round(corners[name].x * 100)}%, ${Math.round(corners[name].y * 100)}%`}
+              role="button"
+              aria-label={`${CORNER_LABELS[name]} at ${Math.round(corners[name].x * 100)}%, ${Math.round(corners[name].y * 100)}%`}
               className={cn(
                 'absolute h-8 w-8 -translate-x-1/2 -translate-y-1/2 cursor-grab rounded-full border-4 border-blue-500 bg-white/80 shadow-lg',
                 dragging === name && 'cursor-grabbing border-blue-600 bg-blue-100',

--- a/frontend/src/components/puzzle/corner-adjust.tsx
+++ b/frontend/src/components/puzzle/corner-adjust.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import type { PointerEvent } from 'react';
+import { useRef, useState } from 'react';
+import { Check, Loader2, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { Corner, QuadCorners } from '@/types';
+
+type CornerName = keyof QuadCorners;
+
+const CORNER_NAMES: CornerName[] = ['topLeft', 'topRight', 'bottomRight', 'bottomLeft'];
+
+const CORNER_LABELS: Record<CornerName, string> = {
+  topLeft: 'Top left corner',
+  topRight: 'Top right corner',
+  bottomRight: 'Bottom right corner',
+  bottomLeft: 'Bottom left corner',
+};
+
+interface CornerAdjustProps {
+  imageUrl: string; // the raw (untrimmed) photo
+  initialCorners: QuadCorners;
+  onApply: (corners: QuadCorners) => void;
+  onCancel: () => void;
+  isLoading?: boolean;
+  className?: string;
+}
+
+export function CornerAdjust({
+  imageUrl,
+  initialCorners,
+  onApply,
+  onCancel,
+  isLoading = false,
+  className,
+}: CornerAdjustProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [corners, setCorners] = useState<QuadCorners>(initialCorners);
+  const [dragging, setDragging] = useState<CornerName | null>(null);
+
+  const updateCorner = (name: CornerName, e: PointerEvent<HTMLDivElement>) => {
+    if (!containerRef.current) return;
+
+    const rect = containerRef.current.getBoundingClientRect();
+    const corner: Corner = {
+      x: Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)),
+      y: Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height)),
+    };
+    setCorners((prev) => ({ ...prev, [name]: corner }));
+  };
+
+  const handlePointerDown = (name: CornerName) => (e: PointerEvent<HTMLDivElement>) => {
+    if (isLoading) return;
+    e.currentTarget.setPointerCapture(e.pointerId);
+    setDragging(name);
+    updateCorner(name, e);
+  };
+
+  const handlePointerMove = (name: CornerName) => (e: PointerEvent<HTMLDivElement>) => {
+    if (dragging !== name) return;
+    updateCorner(name, e);
+  };
+
+  const handlePointerUp = () => setDragging(null);
+
+  const polygonPoints = CORNER_NAMES.map(
+    (name) => `${corners[name].x * 100},${corners[name].y * 100}`
+  ).join(' ');
+
+  return (
+    <div className={cn('flex flex-col gap-4', className)}>
+      <div className="flex justify-center">
+        <div ref={containerRef} className="relative touch-none overflow-hidden rounded-lg">
+          <img
+            src={imageUrl}
+            alt="Puzzle photo"
+            className="block h-auto max-h-[70vh] w-auto max-w-full select-none"
+            draggable={false}
+          />
+
+          {/* Quadrilateral outline */}
+          <svg
+            className="pointer-events-none absolute inset-0 h-full w-full"
+            viewBox="0 0 100 100"
+            preserveAspectRatio="none"
+          >
+            <polygon
+              points={polygonPoints}
+              fill="rgb(59 130 246 / 0.15)"
+              stroke="rgb(59 130 246)"
+              strokeWidth="0.5"
+              vectorEffect="non-scaling-stroke"
+            />
+          </svg>
+
+          {/* Draggable corner handles */}
+          {CORNER_NAMES.map((name) => (
+            <div
+              key={name}
+              data-testid={`corner-handle-${name}`}
+              role="slider"
+              aria-label={CORNER_LABELS[name]}
+              aria-valuetext={`${Math.round(corners[name].x * 100)}%, ${Math.round(corners[name].y * 100)}%`}
+              className={cn(
+                'absolute h-8 w-8 -translate-x-1/2 -translate-y-1/2 cursor-grab rounded-full border-4 border-blue-500 bg-white/80 shadow-lg',
+                dragging === name && 'cursor-grabbing border-blue-600 bg-blue-100',
+                isLoading && 'cursor-wait opacity-50'
+              )}
+              style={{
+                left: `${corners[name].x * 100}%`,
+                top: `${corners[name].y * 100}%`,
+              }}
+              onPointerDown={handlePointerDown(name)}
+              onPointerMove={handlePointerMove(name)}
+              onPointerUp={handlePointerUp}
+            />
+          ))}
+        </div>
+      </div>
+
+      <p className="text-muted-foreground text-center text-sm">
+        Drag the handles to the corners of the puzzle picture.
+      </p>
+
+      <div className="flex gap-3">
+        <Button variant="outline" className="flex-1 gap-2" onClick={onCancel} disabled={isLoading}>
+          <X className="h-4 w-4" />
+          Cancel
+        </Button>
+        <Button className="flex-1 gap-2" onClick={() => onApply(corners)} disabled={isLoading}>
+          {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
+          Apply
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/puzzle/corner-adjust.tsx
+++ b/frontend/src/components/puzzle/corner-adjust.tsx
@@ -39,7 +39,7 @@ export function CornerAdjust({
   const [corners, setCorners] = useState<QuadCorners>(initialCorners);
   const [dragging, setDragging] = useState<CornerName | null>(null);
 
-  const updateCorner = (name: CornerName, e: PointerEvent<HTMLDivElement>) => {
+  const updateCorner = (name: CornerName, e: PointerEvent<HTMLButtonElement>) => {
     if (!containerRef.current) return;
 
     const rect = containerRef.current.getBoundingClientRect();
@@ -50,19 +50,21 @@ export function CornerAdjust({
     setCorners((prev) => ({ ...prev, [name]: corner }));
   };
 
-  const handlePointerDown = (name: CornerName) => (e: PointerEvent<HTMLDivElement>) => {
+  const handlePointerDown = (name: CornerName) => (e: PointerEvent<HTMLButtonElement>) => {
     if (isLoading) return;
     e.currentTarget.setPointerCapture(e.pointerId);
     setDragging(name);
     updateCorner(name, e);
   };
 
-  const handlePointerMove = (name: CornerName) => (e: PointerEvent<HTMLDivElement>) => {
+  const handlePointerMove = (name: CornerName) => (e: PointerEvent<HTMLButtonElement>) => {
     if (dragging !== name) return;
     updateCorner(name, e);
   };
 
-  const handlePointerUp = () => setDragging(null);
+  // Reset on up, cancel, or lost capture so `dragging` can never get stuck
+  // (e.g. an OS gesture cancels the pointer or the window loses focus).
+  const handlePointerEnd = () => setDragging(null);
 
   const polygonPoints = CORNER_NAMES.map(
     (name) => `${corners[name].x * 100},${corners[name].y * 100}`
@@ -96,10 +98,11 @@ export function CornerAdjust({
 
           {/* Draggable corner handles */}
           {CORNER_NAMES.map((name) => (
-            <div
+            <button
               key={name}
+              type="button"
+              disabled={isLoading}
               data-testid={`corner-handle-${name}`}
-              role="button"
               aria-label={`${CORNER_LABELS[name]} at ${Math.round(corners[name].x * 100)}%, ${Math.round(corners[name].y * 100)}%`}
               className={cn(
                 'absolute h-8 w-8 -translate-x-1/2 -translate-y-1/2 cursor-grab rounded-full border-4 border-blue-500 bg-white/80 shadow-lg',
@@ -112,7 +115,9 @@ export function CornerAdjust({
               }}
               onPointerDown={handlePointerDown(name)}
               onPointerMove={handlePointerMove(name)}
-              onPointerUp={handlePointerUp}
+              onPointerUp={handlePointerEnd}
+              onPointerCancel={handlePointerEnd}
+              onLostPointerCapture={handlePointerEnd}
             />
           ))}
         </div>

--- a/frontend/src/components/puzzle/index.ts
+++ b/frontend/src/components/puzzle/index.ts
@@ -4,3 +4,4 @@ export { GridOverlay } from './grid-overlay';
 export { RotationSelector } from './rotation-selector';
 export { ClickPieceSelector } from './click-piece-selector';
 export { PieceModeToggle } from './piece-mode-toggle';
+export { CornerAdjust } from './corner-adjust';

--- a/frontend/src/components/puzzle/puzzle-detail.tsx
+++ b/frontend/src/components/puzzle/puzzle-detail.tsx
@@ -9,6 +9,7 @@ interface PuzzleDetailProps {
   puzzleImage: string;
   pieces: Piece[];
   gridSize?: GridSize;
+  pieceSizeRatio?: number; // 0-1 fraction of the puzzle size; overrides gridSize-based sizing
   onClick?: () => void;
   className?: string;
 }
@@ -17,11 +18,15 @@ export function PuzzleDetail({
   puzzleImage,
   pieces,
   gridSize = '3x3',
+  pieceSizeRatio,
   onClick,
   className,
 }: PuzzleDetailProps) {
   const { dimension } = GRID_DIMENSIONS[gridSize];
-  const pieceSize = useMemo(() => 100 / dimension, [dimension]);
+  const pieceSize = useMemo(
+    () => (pieceSizeRatio !== undefined ? pieceSizeRatio * 100 : 100 / dimension),
+    [pieceSizeRatio, dimension]
+  );
 
   return (
     <div

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,12 @@
-import type { Puzzle, Piece, GeneratedPiece, CutPuzzleResponse } from '@/types';
+import type {
+  Puzzle,
+  Piece,
+  GeneratedPiece,
+  CutPuzzleResponse,
+  QuadCorners,
+  DetectFrameResult,
+  PieceRegion,
+} from '@/types';
 import { useAuthStore } from '@/stores/auth-store';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
@@ -60,6 +68,84 @@ export async function uploadPuzzle(imageBlob: Blob): Promise<Puzzle> {
     puzzleId: data.puzzle_id,
     imageUrl: data.image_url,
   };
+}
+
+interface CornerApi {
+  x: number;
+  y: number;
+}
+
+interface DetectFrameApiResponse {
+  trimmed_image: string;
+  corners: {
+    top_left: CornerApi;
+    top_right: CornerApi;
+    bottom_right: CornerApi;
+    bottom_left: CornerApi;
+  };
+  confidence: number;
+}
+
+export async function detectFrame(
+  photoBlob: Blob,
+  corners?: QuadCorners
+): Promise<DetectFrameResult> {
+  const formData = new FormData();
+  formData.append('file', photoBlob, 'puzzle-photo.jpg');
+  if (corners) {
+    formData.append(
+      'corners',
+      JSON.stringify({
+        top_left: corners.topLeft,
+        top_right: corners.topRight,
+        bottom_right: corners.bottomRight,
+        bottom_left: corners.bottomLeft,
+      })
+    );
+  }
+
+  const res = await fetch(`${API_BASE}/api/v1/puzzle/detect-frame`, {
+    method: 'POST',
+    headers: getAuthHeaders(),
+    body: formData,
+  });
+
+  if (res.status === 401) {
+    throw new ApiError('Authentication required. Please sign in.', res.status);
+  }
+
+  if (!res.ok) {
+    throw new ApiError('Failed to detect puzzle frame', res.status);
+  }
+
+  const data: DetectFrameApiResponse = await res.json();
+  return {
+    trimmedImageUrl: data.trimmed_image,
+    corners: {
+      topLeft: data.corners.top_left,
+      topRight: data.corners.top_right,
+      bottomRight: data.corners.bottom_right,
+      bottomLeft: data.corners.bottom_left,
+    },
+    confidence: data.confidence,
+  };
+}
+
+export async function detectPieceRegion(frameBlob: Blob): Promise<PieceRegion> {
+  const formData = new FormData();
+  formData.append('file', frameBlob, 'frame.jpg');
+
+  const res = await fetch(`${API_BASE}/api/v1/piece/preview`, {
+    method: 'POST',
+    headers: getAuthHeaders(),
+    body: formData,
+  });
+
+  if (!res.ok) {
+    throw new ApiError('Failed to detect piece region', res.status);
+  }
+
+  return res.json();
 }
 
 interface PieceApiResponse {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -131,7 +131,10 @@ export async function detectFrame(
   };
 }
 
-export async function detectPieceRegion(frameBlob: Blob): Promise<PieceRegion> {
+export async function detectPieceRegion(
+  frameBlob: Blob,
+  signal?: AbortSignal
+): Promise<PieceRegion> {
   const formData = new FormData();
   formData.append('file', frameBlob, 'frame.jpg');
 
@@ -139,13 +142,18 @@ export async function detectPieceRegion(frameBlob: Blob): Promise<PieceRegion> {
     method: 'POST',
     headers: getAuthHeaders(),
     body: formData,
+    signal,
   });
+
+  if (res.status === 401) {
+    throw new ApiError('Authentication required. Please sign in.', res.status);
+  }
 
   if (!res.ok) {
     throw new ApiError('Failed to detect piece region', res.status);
   }
 
-  return res.json();
+  return res.json() as Promise<PieceRegion>;
 }
 
 interface PieceApiResponse {

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -7,6 +7,7 @@ declare module 'next-auth' {
   interface Session {
     accessToken?: string;
     idToken?: string;
+    error?: 'RefreshTokenError';
     user: {
       id: string;
       email: string;
@@ -20,6 +21,9 @@ declare module 'next-auth/jwt' {
   interface JWT {
     accessToken?: string;
     idToken?: string;
+    refreshToken?: string;
+    expiresAt?: number; // Unix seconds when the Google tokens expire
+    error?: 'RefreshTokenError';
   }
 }
 
@@ -60,8 +64,58 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   callbacks: {
     async jwt({ token, account }: { token: JWT; account?: Account | null }) {
       if (account) {
+        // Initial sign-in: store the Google tokens and their expiry
         token.accessToken = account.access_token;
         token.idToken = account.id_token;
+        token.refreshToken = account.refresh_token;
+        token.expiresAt = account.expires_at;
+        token.error = undefined;
+        return token;
+      }
+
+      // Google ID tokens expire after ~1 hour; refresh shortly before expiry so the
+      // backend exchange in AuthSync never receives an expired token.
+      const expiresAt = token.expiresAt ?? 0;
+      if (Date.now() < (expiresAt - 60) * 1000) {
+        return token;
+      }
+
+      if (!token.refreshToken) {
+        token.error = 'RefreshTokenError';
+        return token;
+      }
+
+      try {
+        const response = await fetch('https://oauth2.googleapis.com/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({
+            client_id: googleClientId,
+            client_secret: googleClientSecret,
+            grant_type: 'refresh_token',
+            refresh_token: token.refreshToken,
+          }),
+        });
+
+        const refreshed = (await response.json()) as {
+          access_token?: string;
+          id_token?: string;
+          expires_in?: number;
+          refresh_token?: string;
+          error?: string;
+        };
+        if (!response.ok || !refreshed.id_token) {
+          throw new Error(refreshed.error || 'Failed to refresh Google token');
+        }
+
+        token.accessToken = refreshed.access_token;
+        token.idToken = refreshed.id_token;
+        token.expiresAt = Math.floor(Date.now() / 1000) + (refreshed.expires_in ?? 3600);
+        // Google may or may not rotate the refresh token
+        token.refreshToken = refreshed.refresh_token ?? token.refreshToken;
+        token.error = undefined;
+      } catch {
+        token.error = 'RefreshTokenError';
       }
       return token;
     },
@@ -70,6 +124,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         ...session,
         accessToken: token.accessToken,
         idToken: token.idToken,
+        error: token.error,
       };
     },
   },

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -43,6 +43,32 @@ export const GRID_DIMENSIONS: Record<GridSize, { dimension: number; totalCells: 
 
 export type CameraMode = 'puzzle' | 'piece';
 
+// Real mode types for photographing a physical puzzle
+
+export interface Corner {
+  x: number; // 0-1 normalized
+  y: number; // 0-1 normalized
+}
+
+export interface QuadCorners {
+  topLeft: Corner;
+  topRight: Corner;
+  bottomRight: Corner;
+  bottomLeft: Corner;
+}
+
+export interface DetectFrameResult {
+  trimmedImageUrl: string; // data URL of the perspective-corrected crop
+  corners: QuadCorners;
+  confidence: number; // 0-1; 1.0 when corners were manually supplied
+}
+
+export interface PieceRegion {
+  found: boolean;
+  polygon: Corner[]; // outline of the detected piece, normalized 0-1
+  bbox?: { x: number; y: number; width: number; height: number } | null;
+}
+
 export type PieceSelectionMode = 'grid' | 'realistic';
 
 export interface GeneratedPiece {

--- a/uv.lock
+++ b/uv.lock
@@ -646,7 +646,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -677,43 +677,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -1738,7 +1738,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1777,7 +1777,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1789,7 +1789,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1819,9 +1819,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1833,7 +1833,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2257,6 +2257,7 @@ dependencies = [
     { name = "google-auth" },
     { name = "httpx" },
     { name = "numba" },
+    { name = "opencv-python-headless" },
     { name = "pillow" },
     { name = "puzzle-shapes" },
     { name = "pydantic" },
@@ -2305,6 +2306,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.26.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.13.2" },
     { name = "numba", specifier = ">=0.60.0" },
+    { name = "opencv-python-headless", specifier = ">=4.10.0" },
     { name = "pillow", specifier = ">=11.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.6.0" },
     { name = "puzzle-shapes", editable = "shared/puzzle_shapes" },


### PR DESCRIPTION
## Overview

Adds a third frontend mode — **Solve Real Puzzle** — that closes the loop for physical puzzles. You photograph the full puzzle picture (box lid or finished puzzle), the app auto-trims it to just the picture, and then you hold up physical pieces one at a time to get a predicted position + rotation overlaid on the trimmed image.

This complements the existing `/play` (drag-and-drop game) and `/test-mode` (bundled sample images) modes.

## What changed

### Backend
- **`puzzle_detector` service** (new, OpenCV): detects the puzzle picture's quadrilateral in a photo and perspective-corrects it. Layered detection — chroma-based background segmentation (tolerant of shadows) for photos on a uniform surface, with a **rembg salient-object fallback** for cluttered backgrounds (e.g. a puzzle held up in a room). Falls back to the full frame with confidence 0 when nothing is found.
- **`piece_detector` service** (new): segments the piece region in a live camera frame via rembg, returning an outline polygon + bounding box for the preview overlay. Also crops captured pieces to the segmented subject before CNN inference, so the piece fills the frame — much closer to the model's training distribution than a small cutout floating in a large white canvas.
- **New endpoints**: `POST /api/v1/puzzle/detect-frame` (stateless trim; accepts optional manual corners) and `POST /api/v1/piece/preview` (live region detection). Trimming happens before upload — the accepted trimmed image is uploaded through the existing upload endpoint, so it's exactly what the CNN sees, with no changes to the inference path.
- Adds `opencv-python-headless` to the backend workspace (root `uv.lock` updated).

### Frontend
- **New `/real` route** with a `capture → confirm-trim → (adjust-corners) → solving` flow, reusing `usePuzzleStore`, `PuzzleDetail`, `PieceCard`, and the camera components. Home page gains a "Solve Real Puzzle" nav button.
- **`CornerAdjust` component**: draggable corner handles for manually fixing the trim when auto-detection is off.
- **Live piece-detection overlay** in `CameraView`: streams downscaled frames to the backend (~2/s) and draws the detected piece outline on the live preview with a status chip, so you see what will be captured before pressing the button. The old ghost puzzle overlay is removed from real-mode piece capture.
- **Auth fix**: the Google ID token is now refreshed before its ~1h expiry, and a stale NextAuth session is cleared on refresh/backend-exchange failure. This fixes a redirect deadlock where an expired-but-cookie-valid session couldn't reach the sign-in page.

## Testing
- Backend: unit tests for both detector services (synthetic images + mocked rembg), endpoint tests, all passing (58 backend tests).
- Frontend: `CornerAdjust` render test; 19 unit tests passing.
- E2E: new `real-mode.spec.ts` covering the full happy path (UI + backend-gated flow), all 7 passing.
- Manually verified end-to-end in a real browser against the exp18 checkpoint, including the OpenCV-vs-rembg detection paths and the live piece overlay.

## Reviewer notes
- **Model accuracy caveat**: the CNN was trained on clean synthetic crops, so raw photos of physical pieces are out-of-distribution. The rembg segmentation + crop-to-subject step narrows the gap, but prediction quality (especially rotation) will be modest until a model is trained on realistic captures. Confidence values are surfaced honestly in the UI.
- **Piece detection is salient-object based**: if a hand/face dominates the frame, the outline covers them too — the live overlay makes this visible so the user can reframe.
- The pre-commit `pyright` hook couldn't be run in the authoring environment (binary not on PATH; only available via `uv run`); pyright was verified clean via `make check-backend` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)