### PR TITLE
Real mode: auto-capture pipeline with piece tracking and queue

### DIFF
--- a/frontend/e2e/real-mode.spec.ts
+++ b/frontend/e2e/real-mode.spec.ts
@@ -114,7 +114,7 @@ test.describe('Real Mode Flow with Backend', () => {
     });
   });
 
-  test('accepts trim and captures a piece', async ({ page }) => {
+  test('accepts trim and runs a piece through the capture queue', async ({ page }) => {
     await page.goto('/real');
 
     // Photograph the puzzle
@@ -125,20 +125,30 @@ test.describe('Real Mode Flow with Backend', () => {
       timeout: API_TIMEOUT,
     });
 
-    // Accept the trimmed image (uploads it as the puzzle)
+    // Accept the trimmed image (uploads it as the puzzle); the pipeline view
+    // appears: live capture area (or its no-camera fallback) plus empty queue
     await page.getByRole('button', { name: 'Use This' }).click();
-    await expect(page.getByRole('button', { name: 'Capture Piece' })).toBeVisible({
-      timeout: API_TIMEOUT,
-    });
+    await expect(
+      page.getByTestId('live-capture').or(page.getByTestId('live-capture-fallback'))
+    ).toBeVisible({ timeout: API_TIMEOUT });
     await expect(page.getByText('0 pieces captured')).toBeVisible();
+    await expect(page.getByTestId('piece-queue-empty')).toBeVisible();
 
-    // Capture a piece (any image works; the backend predicts regardless)
-    await page.getByRole('button', { name: 'Capture Piece' }).click();
-    await expect(page.getByRole('dialog')).toBeVisible();
+    // Add a piece via upload (any image works; the backend predicts regardless).
+    // With no camera in the test environment this exercises the fallback path;
+    // either way the upload is committed straight into the capture queue.
     await page.locator('input[type="file"]').setInputFiles(TEST_PUZZLE_PATH);
 
-    // The prediction is added to the overlay and the counter updates
-    await expect(page.getByText('1 piece captured')).toBeVisible({ timeout: PIECE_TIMEOUT });
-    await expect(page.getByText('Position:')).toBeVisible();
+    // The capture is committed to the queue immediately...
+    await expect(page.getByText('1 piece captured')).toBeVisible();
+    await expect(page.getByTestId('piece-queue')).toBeVisible();
+
+    // ...and the worker drains it through prediction to done
+    await expect(page.getByTestId('queue-entry-done')).toBeVisible({ timeout: PIECE_TIMEOUT });
+
+    // Deleting the piece removes it from the queue entirely
+    await page.getByTestId('queue-entry-delete').click();
+    await expect(page.getByTestId('piece-queue-empty')).toBeVisible();
+    await expect(page.getByText('0 pieces captured')).toBeVisible();
   });
 });

--- a/frontend/e2e/real-mode.spec.ts
+++ b/frontend/e2e/real-mode.spec.ts
@@ -144,10 +144,12 @@ test.describe('Real Mode Flow with Backend', () => {
     await expect(page.getByTestId('piece-queue')).toBeVisible();
 
     // ...and the worker drains it through prediction to done
-    await expect(page.getByTestId('queue-entry-done')).toBeVisible({ timeout: PIECE_TIMEOUT });
+    await expect(page.locator('[data-testid="queue-entry"][data-status="done"]').first()).toBeVisible({
+      timeout: PIECE_TIMEOUT,
+    });
 
     // Deleting the piece removes it from the queue entirely
-    await page.getByTestId('queue-entry-delete').click();
+    await page.getByTestId('queue-entry-delete-0').click();
     await expect(page.getByTestId('piece-queue-empty')).toBeVisible();
     await expect(page.getByText('0 pieces captured')).toBeVisible();
   });

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -175,3 +175,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Auto-capture pipeline animations (real mode) */
+@keyframes capture-flash {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes queue-pop {
+  0% {
+    transform: scale(0.5);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.08);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@layer utilities {
+  .animate-capture-flash {
+    animation: capture-flash 1.2s ease-out forwards;
+  }
+  .animate-queue-pop {
+    animation: queue-pop 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  }
+}

--- a/frontend/src/app/real/page.tsx
+++ b/frontend/src/app/real/page.tsx
@@ -114,8 +114,10 @@ export default function RealModePage() {
     // Read before removing: once removed the entry is gone from the store
     const entry = useCaptureQueueStore.getState().entries.find((e) => e.id === id);
     removeQueueEntry(id);
-    if (entry?.piece) {
-      removePiece(entry.piece);
+    // A predicted entry also has an overlay marker on the puzzle; drop it too.
+    // The piece carries the entry id, so remove by that id.
+    if (entry?.piece?.id) {
+      removePiece(entry.piece.id);
     }
   };
 

--- a/frontend/src/app/real/page.tsx
+++ b/frontend/src/app/real/page.tsx
@@ -2,14 +2,17 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { ArrowLeft, Camera, Loader2, Plus, RotateCcw, ScanLine } from 'lucide-react';
+import { ArrowLeft, Camera, Loader2, RotateCcw, ScanLine } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { CameraModal } from '@/components/camera';
-import { CornerAdjust, PieceCard, PuzzleDetail } from '@/components/puzzle';
+import { CameraModal, LivePieceCapture } from '@/components/camera';
+import { CornerAdjust, PieceQueue, PuzzleDetail } from '@/components/puzzle';
 import { usePuzzleStore } from '@/stores/puzzle-store';
-import { detectFrame, uploadPuzzle, processPiece } from '@/lib/api';
+import { useCaptureQueueStore } from '@/stores/capture-queue-store';
+import { usePredictionWorker } from '@/hooks/use-prediction-worker';
+import { detectFrame, uploadPuzzle } from '@/lib/api';
 import { blobToDataUrl, dataUrlToBlob } from '@/lib/image-utils';
+import { cn } from '@/lib/utils';
 import type { DetectFrameResult } from '@/types';
 
 type RealModePhase = 'capture-puzzle' | 'confirm-trim' | 'adjust-corners' | 'solving';
@@ -23,28 +26,27 @@ const LOW_CONFIDENCE_THRESHOLD = 0.4;
 export default function RealModePage() {
   const [phase, setPhase] = useState<RealModePhase>('capture-puzzle');
   const [puzzleCameraOpen, setPuzzleCameraOpen] = useState(false);
-  const [pieceCameraOpen, setPieceCameraOpen] = useState(false);
   const [rawPhotoBlob, setRawPhotoBlob] = useState<Blob | null>(null);
   const [rawPhotoUrl, setRawPhotoUrl] = useState<string | null>(null);
   const [detection, setDetection] = useState<DetectFrameResult | null>(null);
 
-  const {
-    puzzle,
-    puzzleImage,
-    pieces,
-    isLoading,
-    error,
-    setPuzzle,
-    addPiece,
-    setLoading,
-    setError,
-    reset,
-  } = usePuzzleStore();
+  const { puzzle, puzzleImage, pieces, isLoading, error, setPuzzle, setLoading, setError, reset } =
+    usePuzzleStore();
+  const removePiece = usePuzzleStore((s) => s.removePiece);
+
+  const queueEntries = useCaptureQueueStore((s) => s.entries);
+  const retryEntry = useCaptureQueueStore((s) => s.retry);
+  const removeQueueEntry = useCaptureQueueStore((s) => s.remove);
+  const clearQueue = useCaptureQueueStore((s) => s.clear);
+
+  // Drain captured pieces through prediction while a puzzle is active
+  usePredictionWorker(phase === 'solving' ? puzzle?.puzzleId : undefined);
 
   // Clean up shared store state when leaving the page
   useEffect(() => {
     return () => {
       reset();
+      useCaptureQueueStore.getState().clear();
     };
   }, [reset]);
 
@@ -99,21 +101,6 @@ export default function RealModePage() {
     }
   };
 
-  const handlePieceCapture = async (blob: Blob) => {
-    if (!puzzle) return;
-
-    setLoading(true);
-    setError(null);
-    try {
-      const result = await processPiece(puzzle.puzzleId, blob);
-      addPiece(result);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to process piece');
-    } finally {
-      setLoading(false);
-    }
-  };
-
   const handleRetake = () => {
     setDetection(null);
     setRawPhotoBlob(null);
@@ -123,8 +110,18 @@ export default function RealModePage() {
     setPuzzleCameraOpen(true);
   };
 
+  const handleDeleteEntry = (id: string) => {
+    // Read before removing: once removed the entry is gone from the store
+    const entry = useCaptureQueueStore.getState().entries.find((e) => e.id === id);
+    removeQueueEntry(id);
+    if (entry?.piece) {
+      removePiece(entry.piece);
+    }
+  };
+
   const handleNewPuzzle = () => {
     reset();
+    clearQueue();
     setDetection(null);
     setRawPhotoBlob(null);
     setRawPhotoUrl(null);
@@ -144,7 +141,10 @@ export default function RealModePage() {
           <h1 className="text-lg font-semibold">Solve Real Puzzle</h1>
           <p className="text-muted-foreground text-sm">
             {phase === 'solving'
-              ? `${pieces.length} ${pieces.length === 1 ? 'piece' : 'pieces'} captured`
+              ? `${queueEntries.length} ${queueEntries.length === 1 ? 'piece' : 'pieces'} captured` +
+                (queueEntries.length > pieces.length
+                  ? ` · ${queueEntries.length - pieces.length} in queue`
+                  : '')
               : 'Photograph your puzzle to get started'}
           </p>
         </div>
@@ -152,7 +152,9 @@ export default function RealModePage() {
       </header>
 
       {/* Content */}
-      <main className="mx-auto w-full max-w-2xl flex-1 p-4">
+      <main
+        className={cn('mx-auto w-full flex-1 p-4', phase === 'solving' ? 'max-w-6xl' : 'max-w-2xl')}
+      >
         {error && (
           <div className="bg-destructive/10 text-destructive mb-4 rounded-lg p-3 text-sm">
             {error}
@@ -258,33 +260,18 @@ export default function RealModePage() {
 
         {phase === 'solving' && puzzle && puzzleImage && (
           <div className="space-y-4">
-            <PuzzleDetail
-              puzzleImage={puzzleImage}
-              pieces={pieces}
-              pieceSizeRatio={PIECE_SIZE_RATIO}
-            />
+            {/* Pipeline view: puzzle with predictions beside the live camera */}
+            <div className="grid gap-4 lg:grid-cols-2">
+              <PuzzleDetail
+                puzzleImage={puzzleImage}
+                pieces={pieces}
+                pieceSizeRatio={PIECE_SIZE_RATIO}
+              />
+              <LivePieceCapture className="min-h-[320px]" />
+            </div>
 
-            <Button
-              className="w-full gap-2"
-              size="lg"
-              onClick={() => setPieceCameraOpen(true)}
-              disabled={isLoading}
-            >
-              {isLoading ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Plus className="h-4 w-4" />
-              )}
-              {isLoading ? 'Predicting position...' : 'Capture Piece'}
-            </Button>
-
-            {pieces.length > 0 && (
-              <div className="grid grid-cols-2 gap-3">
-                {pieces.map((piece, index) => (
-                  <PieceCard key={index} piece={piece} index={index} />
-                ))}
-              </div>
-            )}
+            {/* Capture queue: best frame per piece, flowing through prediction */}
+            <PieceQueue entries={queueEntries} onRetry={retryEntry} onDelete={handleDeleteEntry} />
 
             <Button
               variant="outline"
@@ -304,15 +291,6 @@ export default function RealModePage() {
         onOpenChange={setPuzzleCameraOpen}
         mode="puzzle"
         onCapture={(blob) => void handlePuzzlePhoto(blob)}
-      />
-
-      {/* Piece capture camera with live piece-detection overlay */}
-      <CameraModal
-        open={pieceCameraOpen}
-        onOpenChange={setPieceCameraOpen}
-        mode="piece"
-        onCapture={(blob) => void handlePieceCapture(blob)}
-        livePieceDetection
       />
     </div>
   );

--- a/frontend/src/components/camera/index.ts
+++ b/frontend/src/components/camera/index.ts
@@ -1,3 +1,4 @@
 export { CameraView } from './camera-view';
 export { CameraModal } from './camera-modal';
 export { FileUpload } from './file-upload';
+export { LivePieceCapture } from './live-piece-capture';

--- a/frontend/src/components/camera/live-piece-capture.tsx
+++ b/frontend/src/components/camera/live-piece-capture.tsx
@@ -1,0 +1,375 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { AlertCircle, Camera, Loader2, Upload } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useCamera } from '@/hooks/use-camera';
+import { ApiError, detectPieceRegion } from '@/lib/api';
+import { playCommitSound } from '@/lib/capture-sound';
+import { computeSharpness, computeSignature } from '@/lib/frame-quality';
+import { PieceTracker, type NormalizedBBox } from '@/lib/piece-tracker';
+import { useCaptureQueueStore } from '@/stores/capture-queue-store';
+import { cn } from '@/lib/utils';
+import type { PieceRegion } from '@/types';
+import { FileUpload } from './file-upload';
+
+// Live piece detection: frames are downscaled to this size before upload
+const DETECT_FRAME_MAX_DIM = 320;
+// Minimum time between detection requests (the loop is also serialized on the response)
+const DETECT_INTERVAL_MS = 400;
+// Analysis crop size for sharpness/signature computation
+const ANALYSIS_MAX_DIM = 96;
+// Long-side cap for the stored best-frame crop sent to prediction
+const SNAPSHOT_MAX_DIM = 800;
+// Extra context kept around the detected bbox, as a fraction of its size
+const BBOX_MARGIN = 0.12;
+// How long the "piece captured" confirmation stays visible
+const FLASH_MS = 1200;
+
+interface LivePieceCaptureProps {
+  className?: string;
+}
+
+interface CropRect {
+  sx: number;
+  sy: number;
+  sw: number;
+  sh: number;
+}
+
+function bboxToCrop(bbox: NormalizedBBox, videoWidth: number, videoHeight: number): CropRect {
+  const mx = bbox.width * BBOX_MARGIN;
+  const my = bbox.height * BBOX_MARGIN;
+  const x1 = Math.max(0, bbox.x - mx);
+  const y1 = Math.max(0, bbox.y - my);
+  const x2 = Math.min(1, bbox.x + bbox.width + mx);
+  const y2 = Math.min(1, bbox.y + bbox.height + my);
+  return {
+    sx: Math.round(x1 * videoWidth),
+    sy: Math.round(y1 * videoHeight),
+    sw: Math.max(1, Math.round((x2 - x1) * videoWidth)),
+    sh: Math.max(1, Math.round((y2 - y1) * videoHeight)),
+  };
+}
+
+/**
+ * Embedded camera with the auto-capture pipeline: continuously detects the
+ * piece held in front of the camera, keeps the sharpest view of it, and when
+ * the piece leaves the frame (or is swapped for another) commits that best
+ * frame to the capture queue with a sound + visual confirmation.
+ */
+export function LivePieceCapture({ className }: LivePieceCaptureProps) {
+  const { videoRef, isReady, isLoading, error, dimensions, start, stop, capture } = useCamera();
+  const [pieceRegion, setPieceRegion] = useState<PieceRegion | null>(null);
+  const [tracking, setTracking] = useState(false);
+  const [flash, setFlash] = useState(false);
+  const enqueue = useCaptureQueueStore((s) => s.enqueue);
+
+  const flashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    void start();
+    return () => {
+      stop();
+    };
+  }, [start, stop]);
+
+  useEffect(() => {
+    return () => {
+      if (flashTimeoutRef.current) clearTimeout(flashTimeoutRef.current);
+    };
+  }, []);
+
+  const commitBlob = (blob: Blob) => {
+    enqueue({
+      id: typeof crypto !== 'undefined' ? crypto.randomUUID() : `capture-${Date.now()}`,
+      blob,
+      imageUrl: URL.createObjectURL(blob),
+      capturedAt: Date.now(),
+    });
+    playCommitSound();
+    setFlash(true);
+    if (flashTimeoutRef.current) clearTimeout(flashTimeoutRef.current);
+    flashTimeoutRef.current = setTimeout(() => setFlash(false), FLASH_MS);
+  };
+  const commitBlobRef = useRef(commitBlob);
+  commitBlobRef.current = commitBlob;
+
+  // Set by the capture loop; drops the active track and its pending snapshot
+  const abandonTrackRef = useRef<() => void>(() => {});
+
+  // The auto-capture loop: stream downscaled frames to the piece detector,
+  // track the piece across responses, and keep its best full-res crop.
+  useEffect(() => {
+    if (!isReady) return;
+
+    let cancelled = false;
+    const controller = new AbortController();
+    const tracker = new PieceTracker();
+    // Full-res copy of the frame that was sent for detection, so the returned
+    // bbox is cropped from the exact pixels it was computed on
+    const frameCanvas = document.createElement('canvas');
+    const detectCanvas = document.createElement('canvas');
+    const analysisCanvas = document.createElement('canvas');
+    // Best-frame snapshot per track id (only the active track accumulates)
+    const snapshots = new Map<string, HTMLCanvasElement>();
+
+    abandonTrackRef.current = () => {
+      tracker.abandon();
+      snapshots.clear();
+    };
+
+    const commitSnapshot = (trackId: string) => {
+      const canvas = snapshots.get(trackId);
+      snapshots.delete(trackId);
+      if (!canvas) return;
+      canvas.toBlob(
+        (blob) => {
+          if (blob && !cancelled) commitBlobRef.current(blob);
+        },
+        'image/jpeg',
+        0.92
+      );
+    };
+
+    const detectLoop = async () => {
+      while (!cancelled) {
+        const startedAt = Date.now();
+        const video = videoRef.current;
+        if (video && video.videoWidth > 0) {
+          try {
+            frameCanvas.width = video.videoWidth;
+            frameCanvas.height = video.videoHeight;
+            frameCanvas.getContext('2d')?.drawImage(video, 0, 0);
+
+            // Only ever downscale; never enlarge a stream smaller than the target
+            const scale = Math.min(
+              1,
+              DETECT_FRAME_MAX_DIM / Math.max(video.videoWidth, video.videoHeight)
+            );
+            detectCanvas.width = Math.max(1, Math.round(video.videoWidth * scale));
+            detectCanvas.height = Math.max(1, Math.round(video.videoHeight * scale));
+            detectCanvas
+              .getContext('2d')
+              ?.drawImage(video, 0, 0, detectCanvas.width, detectCanvas.height);
+            const blob = await new Promise<Blob | null>((resolve) =>
+              detectCanvas.toBlob(resolve, 'image/jpeg', 0.7)
+            );
+            if (blob) {
+              const region = await detectPieceRegion(blob, controller.signal);
+              if (cancelled) return;
+              setPieceRegion(region);
+
+              // Measure the detected crop for quality + appearance
+              let bbox: NormalizedBBox | undefined;
+              let sharpness: number | undefined;
+              let signature: number[] | undefined;
+              if (region.found && region.bbox) {
+                bbox = region.bbox;
+                const crop = bboxToCrop(bbox, frameCanvas.width, frameCanvas.height);
+                const aScale = Math.min(1, ANALYSIS_MAX_DIM / Math.max(crop.sw, crop.sh));
+                analysisCanvas.width = Math.max(1, Math.round(crop.sw * aScale));
+                analysisCanvas.height = Math.max(1, Math.round(crop.sh * aScale));
+                const actx = analysisCanvas.getContext('2d', { willReadFrequently: true });
+                actx?.drawImage(
+                  frameCanvas,
+                  crop.sx,
+                  crop.sy,
+                  crop.sw,
+                  crop.sh,
+                  0,
+                  0,
+                  analysisCanvas.width,
+                  analysisCanvas.height
+                );
+                const pixels = actx?.getImageData(
+                  0,
+                  0,
+                  analysisCanvas.width,
+                  analysisCanvas.height
+                );
+                if (pixels) {
+                  sharpness = computeSharpness(pixels);
+                  signature = computeSignature(pixels);
+                }
+              }
+
+              const result = tracker.update({
+                timestamp: Date.now(),
+                found: Boolean(bbox),
+                bbox,
+                sharpness,
+                signature,
+              });
+
+              for (const event of result.events) {
+                if (event.type === 'committed') commitSnapshot(event.trackId);
+                if (event.type === 'discarded') snapshots.delete(event.trackId);
+              }
+
+              if (result.snapshotRequested && result.activeTrackId && bbox) {
+                const crop = bboxToCrop(bbox, frameCanvas.width, frameCanvas.height);
+                let snapshot = snapshots.get(result.activeTrackId);
+                if (!snapshot) {
+                  snapshot = document.createElement('canvas');
+                  snapshots.set(result.activeTrackId, snapshot);
+                }
+                const sScale = Math.min(1, SNAPSHOT_MAX_DIM / Math.max(crop.sw, crop.sh));
+                snapshot.width = Math.max(1, Math.round(crop.sw * sScale));
+                snapshot.height = Math.max(1, Math.round(crop.sh * sScale));
+                snapshot
+                  .getContext('2d')
+                  ?.drawImage(
+                    frameCanvas,
+                    crop.sx,
+                    crop.sy,
+                    crop.sw,
+                    crop.sh,
+                    0,
+                    0,
+                    snapshot.width,
+                    snapshot.height
+                  );
+              }
+
+              setTracking(result.activeTrackId !== null);
+            }
+          } catch (err) {
+            // Cleanup aborted the in-flight request; stop silently
+            if (controller.signal.aborted) return;
+            // Auth expired: stop polling instead of hammering the endpoint
+            if (err instanceof ApiError && err.status === 401) return;
+            // Otherwise keep the camera usable and try again next tick
+            if (!cancelled) setPieceRegion(null);
+          }
+        }
+        const elapsed = Date.now() - startedAt;
+        await new Promise((resolve) =>
+          setTimeout(resolve, Math.max(DETECT_INTERVAL_MS - elapsed, 100))
+        );
+      }
+    };
+
+    void detectLoop();
+    return () => {
+      // Unmounting mid-track: the best frame is dropped rather than committed
+      // (committing from a torn-down camera view surprises more than it helps)
+      cancelled = true;
+      controller.abort();
+      setPieceRegion(null);
+      setTracking(false);
+    };
+  }, [isReady, videoRef]);
+
+  // Manual shutter: enqueue the current frame directly and reset the track so
+  // the same piece doesn't get auto-committed a second time
+  const handleManualCapture = async () => {
+    const blob = await capture();
+    if (blob) {
+      abandonTrackRef.current();
+      commitBlob(blob);
+    }
+  };
+
+  if (error) {
+    return (
+      <div
+        className={cn('flex flex-col items-center justify-center gap-4 p-8', className)}
+        data-testid="live-capture-fallback"
+      >
+        <AlertCircle className="text-destructive h-12 w-12" />
+        <p className="text-destructive text-center">{error}</p>
+        <p className="text-muted-foreground text-center text-sm">
+          You can upload piece images instead — each upload is added to the queue.
+        </p>
+        <div className="flex flex-col gap-2">
+          <FileUpload onFileSelect={commitBlob}>
+            <Button className="gap-2">
+              <Upload className="h-4 w-4" />
+              Upload Piece Image
+            </Button>
+          </FileUpload>
+          <Button variant="secondary" onClick={() => void start()}>
+            Retry Camera
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('relative flex flex-col', className)} data-testid="live-capture">
+      <div className="relative flex-1 overflow-hidden rounded-lg bg-black">
+        <video ref={videoRef} autoPlay playsInline muted className="h-full w-full object-cover" />
+
+        {/* Live piece detection outline; slice mirrors the video's object-cover mapping */}
+        {isReady && dimensions && (
+          <>
+            {pieceRegion?.found && pieceRegion.polygon.length >= 3 && (
+              <svg
+                className="pointer-events-none absolute inset-0 h-full w-full"
+                viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+                preserveAspectRatio="xMidYMid slice"
+              >
+                <polygon
+                  points={pieceRegion.polygon
+                    .map((p) => `${p.x * dimensions.width},${p.y * dimensions.height}`)
+                    .join(' ')}
+                  fill="rgb(34 197 94 / 0.15)"
+                  stroke="rgb(34 197 94)"
+                  strokeWidth="2"
+                  vectorEffect="non-scaling-stroke"
+                />
+              </svg>
+            )}
+            <div className="pointer-events-none absolute top-3 left-1/2 -translate-x-1/2">
+              <span
+                className={cn(
+                  'rounded-full px-3 py-1 text-xs font-medium whitespace-nowrap text-white',
+                  flash ? 'bg-primary/90' : tracking ? 'bg-green-600/80' : 'bg-black/50'
+                )}
+              >
+                {flash
+                  ? 'Piece captured!'
+                  : tracking
+                    ? 'Tracking piece — set it aside when done'
+                    : 'Hold a piece up to the camera'}
+              </span>
+            </div>
+          </>
+        )}
+
+        {/* Commit confirmation flash */}
+        {flash && (
+          <div className="animate-capture-flash pointer-events-none absolute inset-0 bg-green-400/40" />
+        )}
+
+        {/* Loading overlay */}
+        {isLoading && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/50">
+            <Loader2 className="h-8 w-8 animate-spin text-white" />
+          </div>
+        )}
+      </div>
+
+      {/* Controls: manual shutter as fallback, plus file upload */}
+      <div className="flex items-center justify-center gap-4 p-3">
+        <Button
+          size="lg"
+          variant="secondary"
+          className="h-12 w-12 rounded-full"
+          onClick={() => void handleManualCapture()}
+          disabled={!isReady || isLoading}
+          title="Capture manually"
+        >
+          <Camera className="h-5 w-5" />
+        </Button>
+        <FileUpload onFileSelect={commitBlob}>
+          <Button variant="outline" size="icon" className="h-10 w-10" title="Upload piece image">
+            <Upload className="h-4 w-4" />
+          </Button>
+        </FileUpload>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/camera/live-piece-capture.tsx
+++ b/frontend/src/components/camera/live-piece-capture.tsx
@@ -82,7 +82,10 @@ export function LivePieceCapture({ className }: LivePieceCaptureProps) {
 
   const commitBlob = (blob: Blob) => {
     enqueue({
-      id: typeof crypto !== 'undefined' ? crypto.randomUUID() : `capture-${Date.now()}`,
+      id:
+        typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+          ? crypto.randomUUID()
+          : `capture-${Date.now()}`,
       blob,
       imageUrl: URL.createObjectURL(blob),
       capturedAt: Date.now(),

--- a/frontend/src/components/camera/live-piece-capture.tsx
+++ b/frontend/src/components/camera/live-piece-capture.tsx
@@ -363,10 +363,12 @@ export function LivePieceCapture({ className }: LivePieceCaptureProps) {
           title="Capture manually"
         >
           <Camera className="h-5 w-5" />
+          <span className="sr-only">Capture piece manually</span>
         </Button>
         <FileUpload onFileSelect={commitBlob}>
           <Button variant="outline" size="icon" className="h-10 w-10" title="Upload piece image">
             <Upload className="h-4 w-4" />
+            <span className="sr-only">Upload piece image</span>
           </Button>
         </FileUpload>
       </div>

--- a/frontend/src/components/puzzle/index.ts
+++ b/frontend/src/components/puzzle/index.ts
@@ -1,5 +1,6 @@
 export { PuzzleDetail } from './puzzle-detail';
 export { PieceCard } from './piece-card';
+export { PieceQueue } from './piece-queue';
 export { GridOverlay } from './grid-overlay';
 export { RotationSelector } from './rotation-selector';
 export { ClickPieceSelector } from './click-piece-selector';

--- a/frontend/src/components/puzzle/piece-queue.tsx
+++ b/frontend/src/components/puzzle/piece-queue.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { AlertCircle, Check, Loader2, RotateCcw, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { CaptureEntry } from '@/stores/capture-queue-store';
+import { cn } from '@/lib/utils';
+
+interface PieceQueueProps {
+  entries: CaptureEntry[];
+  onRetry: (id: string) => void;
+  onDelete: (id: string) => void;
+  className?: string;
+}
+
+/**
+ * Horizontal strip of captured pieces flowing through the prediction
+ * pipeline: queued → predicting → done (or error with retry). New captures
+ * pop in so an auto-commit is clearly visible.
+ */
+export function PieceQueue({ entries, onRetry, onDelete, className }: PieceQueueProps) {
+  if (entries.length === 0) {
+    return (
+      <div
+        className={cn(
+          'text-muted-foreground rounded-lg border border-dashed p-4 text-center text-sm',
+          className
+        )}
+        data-testid="piece-queue-empty"
+      >
+        Captured pieces appear here — hold a piece up to the camera.
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('overflow-x-auto', className)} data-testid="piece-queue">
+      <div className="flex gap-3 pb-2">
+        {entries.map((entry, index) => (
+          <div
+            key={entry.id}
+            className={cn(
+              'animate-queue-pop relative w-24 shrink-0 overflow-hidden rounded-lg border-2',
+              entry.status === 'done' && 'border-green-500',
+              entry.status === 'error' && 'border-destructive',
+              (entry.status === 'queued' || entry.status === 'predicting') && 'border-border'
+            )}
+            data-testid={`queue-entry-${entry.status}`}
+          >
+            <img
+              src={entry.piece?.imageData ?? entry.imageUrl}
+              alt={`Captured piece ${index + 1}`}
+              className="bg-muted aspect-square w-full object-cover"
+            />
+
+            {/* Status overlay */}
+            <div className="bg-background/85 absolute inset-x-0 bottom-0 flex h-6 items-center justify-center gap-1 text-[10px] font-medium">
+              {entry.status === 'queued' && <span className="text-muted-foreground">Queued</span>}
+              {entry.status === 'predicting' && (
+                <>
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  <span>Predicting…</span>
+                </>
+              )}
+              {entry.status === 'done' && entry.piece && (
+                <>
+                  <Check className="h-3 w-3 text-green-600" />
+                  <span>
+                    ({(entry.piece.position.x * 100).toFixed(0)}%,{' '}
+                    {(entry.piece.position.y * 100).toFixed(0)}%)
+                  </span>
+                </>
+              )}
+              {entry.status === 'error' && (
+                <>
+                  <AlertCircle className="text-destructive h-3 w-3" />
+                  <span className="text-destructive">Failed</span>
+                </>
+              )}
+            </div>
+
+            {/* Retry failed predictions + delete, laid out side by side so they don't overlap */}
+            <div className="absolute top-1 right-1 flex gap-1">
+              {entry.status === 'error' && (
+                <Button
+                  size="icon"
+                  variant="secondary"
+                  className="h-6 w-6"
+                  onClick={() => onRetry(entry.id)}
+                  title="Retry prediction"
+                >
+                  <RotateCcw className="h-3 w-3" />
+                </Button>
+              )}
+              <Button
+                size="icon"
+                variant="secondary"
+                className="h-6 w-6"
+                onClick={() => onDelete(entry.id)}
+                title="Remove piece"
+                data-testid="queue-entry-delete"
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/puzzle/piece-queue.tsx
+++ b/frontend/src/components/puzzle/piece-queue.tsx
@@ -44,7 +44,8 @@ export function PieceQueue({ entries, onRetry, onDelete, className }: PieceQueue
               entry.status === 'error' && 'border-destructive',
               (entry.status === 'queued' || entry.status === 'predicting') && 'border-border'
             )}
-            data-testid={`queue-entry-${entry.status}`}
+            data-testid="queue-entry"
+            data-status={entry.status}
           >
             <img
               src={entry.piece?.imageData ?? entry.imageUrl}
@@ -89,6 +90,7 @@ export function PieceQueue({ entries, onRetry, onDelete, className }: PieceQueue
                   title="Retry prediction"
                 >
                   <RotateCcw className="h-3 w-3" />
+                  <span className="sr-only">Retry prediction</span>
                 </Button>
               )}
               <Button
@@ -97,9 +99,10 @@ export function PieceQueue({ entries, onRetry, onDelete, className }: PieceQueue
                 className="h-6 w-6"
                 onClick={() => onDelete(entry.id)}
                 title="Remove piece"
-                data-testid="queue-entry-delete"
+                data-testid={`queue-entry-delete-${index}`}
               >
                 <X className="h-3 w-3" />
+                <span className="sr-only">Remove piece</span>
               </Button>
             </div>
           </div>

--- a/frontend/src/hooks/use-prediction-worker.ts
+++ b/frontend/src/hooks/use-prediction-worker.ts
@@ -25,12 +25,15 @@ export function usePredictionWorker(puzzleId: string | undefined): void {
     const store = useCaptureQueueStore.getState();
     if (store.isProcessing) return;
     const next = store.entries.find((e) => e.status === 'queued');
-    if (!next) return;
+    // A queued entry always carries its blob; the guard also narrows the
+    // optional type for processPiece below.
+    if (!next || !next.blob) return;
+    const blob = next.blob;
 
     store.setProcessing(true);
     store.setStatus(next.id, 'predicting');
 
-    void processPiece(puzzleId, next.blob)
+    void processPiece(puzzleId, blob)
       .then((piece) => {
         // The queue may have been cleared (new puzzle / page left) meanwhile;
         // in that case the result belongs to nothing and is dropped.

--- a/frontend/src/hooks/use-prediction-worker.ts
+++ b/frontend/src/hooks/use-prediction-worker.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { processPiece } from '@/lib/api';
 import { useCaptureQueueStore } from '@/stores/capture-queue-store';
 import { usePuzzleStore } from '@/stores/puzzle-store';
@@ -19,6 +19,17 @@ export function usePredictionWorker(puzzleId: string | undefined): void {
   // below so re-renders and strict-mode double-invocation can't double-send.
   const entries = useCaptureQueueStore((s) => s.entries);
   const isProcessing = useCaptureQueueStore((s) => s.isProcessing);
+  const controllerRef = useRef<AbortController | null>(null);
+
+  // Cancel any in-flight prediction when the puzzle changes or the component
+  // unmounts. Keyed on puzzleId only, so an ordinary queue change (a new
+  // capture arriving) never aborts a request that is already mid-flight.
+  useEffect(() => {
+    return () => {
+      controllerRef.current?.abort();
+      controllerRef.current = null;
+    };
+  }, [puzzleId]);
 
   useEffect(() => {
     if (!puzzleId) return;
@@ -30,24 +41,32 @@ export function usePredictionWorker(puzzleId: string | undefined): void {
     if (!next || !next.blob) return;
     const blob = next.blob;
 
+    const controller = new AbortController();
+    controllerRef.current = controller;
     store.setProcessing(true);
     store.setStatus(next.id, 'predicting');
 
-    void processPiece(puzzleId, blob)
+    void processPiece(puzzleId, blob, controller.signal)
       .then((piece) => {
         // The queue may have been cleared (new puzzle / page left) meanwhile;
         // in that case the result belongs to nothing and is dropped.
         const live = useCaptureQueueStore.getState();
         if (!live.entries.some((e) => e.id === next.id)) return;
-        live.setResult(next.id, piece);
-        usePuzzleStore.getState().addPiece(piece);
+        // Stamp the entry id so the overlay piece can be removed by id later.
+        const stored = { ...piece, id: next.id };
+        live.setResult(next.id, stored);
+        usePuzzleStore.getState().addPiece(stored);
       })
       .catch((err: unknown) => {
+        // Aborted because the puzzle changed / the page was left: the entry is
+        // being discarded, so don't surface an error for it.
+        if (controller.signal.aborted) return;
         const live = useCaptureQueueStore.getState();
         if (!live.entries.some((e) => e.id === next.id)) return;
         live.setError(next.id, err instanceof Error ? err.message : 'Prediction failed');
       })
       .finally(() => {
+        if (controllerRef.current === controller) controllerRef.current = null;
         // Always release the lock so the queue keeps draining (or retries)
         useCaptureQueueStore.getState().setProcessing(false);
       });

--- a/frontend/src/hooks/use-prediction-worker.ts
+++ b/frontend/src/hooks/use-prediction-worker.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect } from 'react';
+import { processPiece } from '@/lib/api';
+import { useCaptureQueueStore } from '@/stores/capture-queue-store';
+import { usePuzzleStore } from '@/stores/puzzle-store';
+
+/**
+ * Drains the capture queue serially against the backend.
+ *
+ * Whenever an entry is 'queued' and nothing is in flight, sends it to
+ * `processPiece` (background removal + CNN prediction). Successful results
+ * are stored on the entry and appended to the puzzle store so they appear on
+ * the puzzle overlay. One request at a time: rembg is the slow step and the
+ * backend shouldn't be hammered with concurrent segmentations.
+ */
+export function usePredictionWorker(puzzleId: string | undefined): void {
+  // Subscriptions only re-trigger the drain; all decisions read live state
+  // below so re-renders and strict-mode double-invocation can't double-send.
+  const entries = useCaptureQueueStore((s) => s.entries);
+  const isProcessing = useCaptureQueueStore((s) => s.isProcessing);
+
+  useEffect(() => {
+    if (!puzzleId) return;
+    const store = useCaptureQueueStore.getState();
+    if (store.isProcessing) return;
+    const next = store.entries.find((e) => e.status === 'queued');
+    if (!next) return;
+
+    store.setProcessing(true);
+    store.setStatus(next.id, 'predicting');
+
+    void processPiece(puzzleId, next.blob)
+      .then((piece) => {
+        // The queue may have been cleared (new puzzle / page left) meanwhile;
+        // in that case the result belongs to nothing and is dropped.
+        const live = useCaptureQueueStore.getState();
+        if (!live.entries.some((e) => e.id === next.id)) return;
+        live.setResult(next.id, piece);
+        usePuzzleStore.getState().addPiece(piece);
+      })
+      .catch((err: unknown) => {
+        const live = useCaptureQueueStore.getState();
+        if (!live.entries.some((e) => e.id === next.id)) return;
+        live.setError(next.id, err instanceof Error ? err.message : 'Prediction failed');
+      })
+      .finally(() => {
+        // Always release the lock so the queue keeps draining (or retries)
+        useCaptureQueueStore.getState().setProcessing(false);
+      });
+  }, [puzzleId, entries, isProcessing]);
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -164,7 +164,11 @@ interface PieceApiResponse {
   cleaned_image?: string; // Base64 PNG with background removed
 }
 
-export async function processPiece(puzzleId: string, pieceBlob: Blob): Promise<Piece> {
+export async function processPiece(
+  puzzleId: string,
+  pieceBlob: Blob,
+  signal?: AbortSignal
+): Promise<Piece> {
   const formData = new FormData();
   formData.append('file', pieceBlob, 'piece.jpg');
 
@@ -172,6 +176,7 @@ export async function processPiece(puzzleId: string, pieceBlob: Blob): Promise<P
     method: 'POST',
     headers: getAuthHeaders(),
     body: formData,
+    signal,
   });
 
   if (res.status === 401) {

--- a/frontend/src/lib/capture-sound.ts
+++ b/frontend/src/lib/capture-sound.ts
@@ -1,0 +1,44 @@
+/**
+ * Short confirmation blip played when a piece capture is auto-committed.
+ * Synthesized with WebAudio so no asset is needed. Fails silently where
+ * audio is unavailable or blocked (e.g. before any user gesture).
+ */
+
+let audioContext: AudioContext | null = null;
+
+function getContext(): AudioContext | null {
+  if (typeof window === 'undefined' || !('AudioContext' in window)) return null;
+  audioContext ??= new AudioContext();
+  return audioContext;
+}
+
+export function playCommitSound(): void {
+  try {
+    const ctx = getContext();
+    if (!ctx) return;
+    if (ctx.state === 'suspended') {
+      void ctx.resume();
+    }
+
+    // Two quick ascending tones — a friendly "got it" chirp
+    const tones: Array<{ freq: number; at: number }> = [
+      { freq: 880, at: 0 },
+      { freq: 1318.5, at: 0.09 },
+    ];
+    for (const { freq, at } of tones) {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      const start = ctx.currentTime + at;
+      osc.type = 'sine';
+      osc.frequency.value = freq;
+      gain.gain.setValueAtTime(0, start);
+      gain.gain.linearRampToValueAtTime(0.18, start + 0.015);
+      gain.gain.exponentialRampToValueAtTime(0.001, start + 0.12);
+      osc.connect(gain).connect(ctx.destination);
+      osc.start(start);
+      osc.stop(start + 0.14);
+    }
+  } catch {
+    // Audio is a nicety; never let it break the capture flow
+  }
+}

--- a/frontend/src/lib/frame-quality.test.ts
+++ b/frontend/src/lib/frame-quality.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeSharpness,
+  computeSignature,
+  signatureDistance,
+  blendSignature,
+  SIGNATURE_SIZE,
+  type PixelData,
+} from './frame-quality';
+
+function makeImage(
+  width: number,
+  height: number,
+  fill: (x: number, y: number) => [number, number, number]
+): PixelData {
+  const data = new Uint8ClampedArray(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const [r, g, b] = fill(x, y);
+      const p = (y * width + x) * 4;
+      data[p] = r;
+      data[p + 1] = g;
+      data[p + 2] = b;
+      data[p + 3] = 255;
+    }
+  }
+  return { data, width, height };
+}
+
+const solidGray = (w: number, h: number) => makeImage(w, h, () => [128, 128, 128]);
+const checkerboard = (w: number, h: number) =>
+  makeImage(w, h, (x, y) => ((x + y) % 2 === 0 ? [255, 255, 255] : [0, 0, 0]));
+const solidRed = (w: number, h: number) => makeImage(w, h, () => [220, 30, 30]);
+const solidBlue = (w: number, h: number) => makeImage(w, h, () => [30, 30, 220]);
+
+describe('computeSharpness', () => {
+  it('is zero for a flat image', () => {
+    expect(computeSharpness(solidGray(16, 16))).toBe(0);
+  });
+
+  it('is higher for high-frequency content than for flat content', () => {
+    const sharp = computeSharpness(checkerboard(16, 16));
+    const flat = computeSharpness(solidGray(16, 16));
+    expect(sharp).toBeGreaterThan(flat);
+    expect(sharp).toBeGreaterThan(1000);
+  });
+
+  it('returns 0 for degenerate tiny images', () => {
+    expect(computeSharpness(solidGray(2, 2))).toBe(0);
+  });
+});
+
+describe('computeSignature', () => {
+  it('has the documented size and sums to ~1', () => {
+    const sig = computeSignature(solidRed(8, 8));
+    expect(sig).toHaveLength(SIGNATURE_SIZE);
+    const sum = sig.reduce((a, b) => a + b, 0);
+    expect(sum).toBeCloseTo(1, 5);
+  });
+
+  it('is identical for identical images', () => {
+    const a = computeSignature(solidRed(8, 8));
+    const b = computeSignature(solidRed(8, 8));
+    expect(signatureDistance(a, b)).toBeCloseTo(0, 10);
+  });
+
+  it('separates differently colored pieces', () => {
+    const red = computeSignature(solidRed(8, 8));
+    const blue = computeSignature(solidBlue(8, 8));
+    expect(signatureDistance(red, blue)).toBeGreaterThan(0.8);
+  });
+
+  it('bins gray pixels separately from colored ones', () => {
+    const gray = computeSignature(solidGray(8, 8));
+    const red = computeSignature(solidRed(8, 8));
+    expect(signatureDistance(gray, red)).toBeGreaterThan(0.8);
+  });
+
+  it('is rotation invariant', () => {
+    // Half red / half blue image, horizontal vs vertical split (a 90° rotation)
+    const horizontal = makeImage(8, 8, (_x, y) => (y < 4 ? [220, 30, 30] : [30, 30, 220]));
+    const vertical = makeImage(8, 8, (x) => (x < 4 ? [220, 30, 30] : [30, 30, 220]));
+    expect(signatureDistance(computeSignature(horizontal), computeSignature(vertical))).toBeCloseTo(
+      0,
+      10
+    );
+  });
+});
+
+describe('signatureDistance', () => {
+  it('is 1 for disjoint distributions', () => {
+    const a = new Array(SIGNATURE_SIZE).fill(0);
+    const b = new Array(SIGNATURE_SIZE).fill(0);
+    a[0] = 1;
+    b[1] = 1;
+    expect(signatureDistance(a, b)).toBe(1);
+  });
+});
+
+describe('blendSignature', () => {
+  it('moves the running signature toward the new one by alpha', () => {
+    const running = [1, 0];
+    const next = [0, 1];
+    expect(blendSignature(running, next, 0.25)).toEqual([0.75, 0.25]);
+  });
+});

--- a/frontend/src/lib/frame-quality.ts
+++ b/frontend/src/lib/frame-quality.ts
@@ -1,0 +1,123 @@
+/**
+ * Frame quality and appearance measures for the live piece-capture pipeline.
+ *
+ * All functions operate on a structural `PixelData` (compatible with
+ * `ImageData`) so they stay pure and unit-testable without a DOM canvas.
+ */
+
+export interface PixelData {
+  data: Uint8ClampedArray;
+  width: number;
+  height: number;
+}
+
+// Signature layout: 8 hue bins x 3 saturation bins + 4 value bins for
+// low-saturation (gray-ish) pixels. Coarse on purpose — it only needs to
+// tell "different piece" apart from "same piece, moved/rotated".
+const HUE_BINS = 8;
+const SAT_BINS = 3;
+const GRAY_VALUE_BINS = 4;
+// Pixels below this saturation carry no reliable hue; bin them by value instead
+const GRAY_SAT_THRESHOLD = 0.15;
+
+export const SIGNATURE_SIZE = HUE_BINS * SAT_BINS + GRAY_VALUE_BINS;
+
+/**
+ * Sharpness as the variance of a 4-neighbour Laplacian on the grayscale image.
+ * Higher is sharper. Only comparable between frames of similar content/scale,
+ * which is exactly how the tracker uses it (within one piece track).
+ */
+export function computeSharpness(image: PixelData): number {
+  const { data, width, height } = image;
+  if (width < 3 || height < 3) return 0;
+
+  // Grayscale plane
+  const gray = new Float32Array(width * height);
+  for (let i = 0, p = 0; i < gray.length; i++, p += 4) {
+    gray[i] = 0.299 * data[p] + 0.587 * data[p + 1] + 0.114 * data[p + 2];
+  }
+
+  let sum = 0;
+  let sumSq = 0;
+  const count = (width - 2) * (height - 2);
+  for (let y = 1; y < height - 1; y++) {
+    const row = y * width;
+    for (let x = 1; x < width - 1; x++) {
+      const i = row + x;
+      const lap = gray[i - width] + gray[i + width] + gray[i - 1] + gray[i + 1] - 4 * gray[i];
+      sum += lap;
+      sumSq += lap * lap;
+    }
+  }
+  const mean = sum / count;
+  return sumSq / count - mean * mean;
+}
+
+/**
+ * Rotation-invariant appearance signature: an L1-normalized coarse HSV
+ * histogram. Two crops of the same piece (moved, rotated, slightly blurred)
+ * land close together; a different piece usually does not.
+ */
+export function computeSignature(image: PixelData): number[] {
+  const { data } = image;
+  const hist = new Array<number>(SIGNATURE_SIZE).fill(0);
+  const pixelCount = data.length / 4;
+  if (pixelCount === 0) return hist;
+
+  for (let p = 0; p < data.length; p += 4) {
+    const r = data[p] / 255;
+    const g = data[p + 1] / 255;
+    const b = data[p + 2] / 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const delta = max - min;
+    const sat = max === 0 ? 0 : delta / max;
+
+    if (sat < GRAY_SAT_THRESHOLD) {
+      const vBin = Math.min(GRAY_VALUE_BINS - 1, Math.floor(max * GRAY_VALUE_BINS));
+      hist[HUE_BINS * SAT_BINS + vBin] += 1;
+      continue;
+    }
+
+    let hue: number;
+    if (max === r) {
+      hue = ((g - b) / delta) % 6;
+    } else if (max === g) {
+      hue = (b - r) / delta + 2;
+    } else {
+      hue = (r - g) / delta + 4;
+    }
+    hue = (hue + 6) % 6; // 0..6
+    const hBin = Math.min(HUE_BINS - 1, Math.floor((hue / 6) * HUE_BINS));
+    // Remaining saturation range mapped onto SAT_BINS
+    const satNorm = (sat - GRAY_SAT_THRESHOLD) / (1 - GRAY_SAT_THRESHOLD);
+    const sBin = Math.min(SAT_BINS - 1, Math.floor(satNorm * SAT_BINS));
+    hist[hBin * SAT_BINS + sBin] += 1;
+  }
+
+  for (let i = 0; i < hist.length; i++) {
+    hist[i] /= pixelCount;
+  }
+  return hist;
+}
+
+/**
+ * Total-variation distance between two signatures, in [0, 1].
+ * 0 = identical distributions, 1 = disjoint.
+ */
+export function signatureDistance(a: number[], b: number[]): number {
+  const len = Math.min(a.length, b.length);
+  let sum = 0;
+  for (let i = 0; i < len; i++) {
+    sum += Math.abs(a[i] - b[i]);
+  }
+  return sum / 2;
+}
+
+/**
+ * Blend a new signature into a running (exponential moving average) signature.
+ * Keeps the track's identity reference stable against per-frame noise.
+ */
+export function blendSignature(running: number[], next: number[], alpha: number): number[] {
+  return running.map((v, i) => v * (1 - alpha) + (next[i] ?? 0) * alpha);
+}

--- a/frontend/src/lib/piece-tracker.test.ts
+++ b/frontend/src/lib/piece-tracker.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PieceTracker,
+  bboxIoU,
+  type TrackerObservation,
+  type NormalizedBBox,
+} from './piece-tracker';
+
+const BOX: NormalizedBBox = { x: 0.4, y: 0.4, width: 0.2, height: 0.2 };
+// Signatures: piece A concentrated in bin 0, piece B in bin 1 (max distance)
+const SIG_A = [1, 0, 0, 0];
+const SIG_B = [0, 1, 0, 0];
+
+function obs(overrides: Partial<TrackerObservation> & { timestamp: number }): TrackerObservation {
+  return { found: true, bbox: BOX, signature: SIG_A, sharpness: 100, ...overrides };
+}
+
+function makeTracker() {
+  return new PieceTracker({
+    gapCommitMs: 1000,
+    minFrames: 3,
+    iouBreakThreshold: 0.05,
+    signatureBreakThreshold: 0.4,
+    breakFrames: 2,
+    signatureAlpha: 0.3,
+  });
+}
+
+describe('bboxIoU', () => {
+  it('is 1 for identical boxes and 0 for disjoint boxes', () => {
+    expect(bboxIoU(BOX, BOX)).toBeCloseTo(1);
+    expect(bboxIoU(BOX, { x: 0.8, y: 0.8, width: 0.1, height: 0.1 })).toBe(0);
+  });
+});
+
+describe('PieceTracker', () => {
+  it('starts a track and requests a snapshot on first detection', () => {
+    const tracker = makeTracker();
+    const result = tracker.update(obs({ timestamp: 0 }));
+    expect(result.events).toEqual([{ type: 'started', trackId: 'track-1' }]);
+    expect(result.snapshotRequested).toBe(true);
+    expect(result.activeTrackId).toBe('track-1');
+  });
+
+  it('requests a snapshot only when frame quality improves', () => {
+    const tracker = makeTracker();
+    tracker.update(obs({ timestamp: 0, sharpness: 100 }));
+    const worse = tracker.update(obs({ timestamp: 400, sharpness: 50 }));
+    expect(worse.snapshotRequested).toBe(false);
+    const better = tracker.update(obs({ timestamp: 800, sharpness: 200 }));
+    expect(better.snapshotRequested).toBe(true);
+  });
+
+  it('commits the track after a sustained detection gap', () => {
+    const tracker = makeTracker();
+    tracker.update(obs({ timestamp: 0 }));
+    tracker.update(obs({ timestamp: 400 }));
+    tracker.update(obs({ timestamp: 800 }));
+    // Gap shorter than gapCommitMs: track stays alive
+    const early = tracker.update({ timestamp: 1400, found: false });
+    expect(early.events).toEqual([]);
+    expect(early.activeTrackId).toBe('track-1');
+    // Sustained gap: committed
+    const late = tracker.update({ timestamp: 1900, found: false });
+    expect(late.events).toEqual([
+      { type: 'committed', trackId: 'track-1', frames: 3, bestScore: expect.any(Number) },
+    ]);
+    expect(late.activeTrackId).toBeNull();
+  });
+
+  it('discards tracks with too few frames instead of committing', () => {
+    const tracker = makeTracker();
+    tracker.update(obs({ timestamp: 0 }));
+    const result = tracker.update({ timestamp: 1200, found: false });
+    expect(result.events).toEqual([
+      { type: 'discarded', trackId: 'track-1', reason: 'too-few-frames' },
+    ]);
+  });
+
+  it('cuts to a new track on a sustained signature break (piece swap without gap)', () => {
+    const tracker = makeTracker();
+    tracker.update(obs({ timestamp: 0 }));
+    tracker.update(obs({ timestamp: 400 }));
+    tracker.update(obs({ timestamp: 800 }));
+
+    // First divergent frame: hysteresis holds the old track
+    const first = tracker.update(obs({ timestamp: 1200, signature: SIG_B }));
+    expect(first.events).toEqual([]);
+    expect(first.activeTrackId).toBe('track-1');
+
+    // Second consecutive divergent frame: old track commits, new one starts
+    const second = tracker.update(obs({ timestamp: 1600, signature: SIG_B }));
+    expect(second.events).toEqual([
+      { type: 'committed', trackId: 'track-1', frames: 3, bestScore: expect.any(Number) },
+      { type: 'started', trackId: 'track-2' },
+    ]);
+    expect(second.snapshotRequested).toBe(true);
+    expect(second.activeTrackId).toBe('track-2');
+  });
+
+  it('does not split a track on a single-frame appearance flash', () => {
+    const tracker = makeTracker();
+    tracker.update(obs({ timestamp: 0 }));
+    tracker.update(obs({ timestamp: 400 }));
+    tracker.update(obs({ timestamp: 800, signature: SIG_B })); // flash
+    const recovered = tracker.update(obs({ timestamp: 1200, signature: SIG_A }));
+    expect(recovered.events).toEqual([]);
+    expect(recovered.activeTrackId).toBe('track-1');
+  });
+
+  it('cuts to a new track when the bbox jumps without overlap', () => {
+    const tracker = makeTracker();
+    tracker.update(obs({ timestamp: 0 }));
+    tracker.update(obs({ timestamp: 400 }));
+    tracker.update(obs({ timestamp: 800 }));
+    const far: NormalizedBBox = { x: 0.05, y: 0.05, width: 0.1, height: 0.1 };
+    tracker.update(obs({ timestamp: 1200, bbox: far }));
+    const second = tracker.update(obs({ timestamp: 1600, bbox: far }));
+    expect(second.events[0]).toEqual({
+      type: 'committed',
+      trackId: 'track-1',
+      frames: 3,
+      bestScore: expect.any(Number),
+    });
+    expect(second.activeTrackId).toBe('track-2');
+  });
+
+  it('flush commits the active track immediately', () => {
+    const tracker = makeTracker();
+    tracker.update(obs({ timestamp: 0 }));
+    tracker.update(obs({ timestamp: 400 }));
+    tracker.update(obs({ timestamp: 800 }));
+    expect(tracker.flush()).toEqual([
+      { type: 'committed', trackId: 'track-1', frames: 3, bestScore: expect.any(Number) },
+    ]);
+    expect(tracker.flush()).toEqual([]);
+  });
+
+  it('abandon drops the active track without events', () => {
+    const tracker = makeTracker();
+    tracker.update(obs({ timestamp: 0 }));
+    tracker.abandon();
+    expect(tracker.flush()).toEqual([]);
+    // Next detection starts a fresh track
+    const next = tracker.update(obs({ timestamp: 400 }));
+    expect(next.events).toEqual([{ type: 'started', trackId: 'track-2' }]);
+  });
+
+  it('a larger, equally sharp view of the piece scores better', () => {
+    const tracker = makeTracker();
+    tracker.update(obs({ timestamp: 0, bbox: { x: 0.45, y: 0.45, width: 0.1, height: 0.1 } }));
+    const bigger = tracker.update(
+      obs({ timestamp: 400, bbox: { x: 0.4, y: 0.4, width: 0.2, height: 0.2 } })
+    );
+    expect(bigger.snapshotRequested).toBe(true);
+  });
+});

--- a/frontend/src/lib/piece-tracker.test.ts
+++ b/frontend/src/lib/piece-tracker.test.ts
@@ -108,6 +108,24 @@ describe('PieceTracker', () => {
     expect(recovered.activeTrackId).toBe('track-1');
   });
 
+  it('learns a signature that only becomes available after the track starts', () => {
+    // A track whose first frames carried no signature must adopt the first one
+    // it sees, so appearance-based swap detection works for the rest of it.
+    const tracker = makeTracker();
+    tracker.update(obs({ timestamp: 0, signature: undefined }));
+    tracker.update(obs({ timestamp: 400, signature: SIG_A })); // signature learned here
+    tracker.update(obs({ timestamp: 800, signature: SIG_A }));
+
+    // A sustained swap to a different piece must now be detected
+    tracker.update(obs({ timestamp: 1200, signature: SIG_B }));
+    const swap = tracker.update(obs({ timestamp: 1600, signature: SIG_B }));
+    expect(swap.events).toEqual([
+      { type: 'committed', trackId: 'track-1', frames: 3, bestScore: expect.any(Number) },
+      { type: 'started', trackId: 'track-2' },
+    ]);
+    expect(swap.activeTrackId).toBe('track-2');
+  });
+
   it('cuts to a new track when the bbox jumps without overlap', () => {
     const tracker = makeTracker();
     tracker.update(obs({ timestamp: 0 }));

--- a/frontend/src/lib/piece-tracker.ts
+++ b/frontend/src/lib/piece-tracker.ts
@@ -1,0 +1,212 @@
+/**
+ * Piece track lifecycle for the live capture pipeline.
+ *
+ * Consumes one observation per detection tick (piece found or not, plus
+ * quality/appearance measures) and decides when a physical piece's "track"
+ * starts, when the current frame is its best capture so far, and when the
+ * track ends and should be committed to the capture queue.
+ *
+ * Identity layers:
+ *  - Temporal continuity: consecutive detections that overlap (bbox IoU) are
+ *    the same piece; a detection gap ends the track.
+ *  - Appearance: a running HSV-histogram signature per track. If the observed
+ *    signature diverges for `breakFrames` consecutive ticks (hysteresis, so a
+ *    hand or rotation flash doesn't split a track), the old track is
+ *    committed and a new one starts — this catches quick piece swaps that
+ *    never produce a detection gap.
+ *
+ * Pure logic: timestamps are injected, no DOM or timers, unit-testable.
+ */
+
+import { blendSignature, signatureDistance } from './frame-quality';
+
+export interface NormalizedBBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface TrackerObservation {
+  timestamp: number; // ms
+  found: boolean;
+  bbox?: NormalizedBBox;
+  signature?: number[];
+  sharpness?: number;
+}
+
+export type TrackerEvent =
+  | { type: 'started'; trackId: string }
+  | { type: 'committed'; trackId: string; frames: number; bestScore: number }
+  | { type: 'discarded'; trackId: string; reason: 'too-few-frames' };
+
+export interface TrackerUpdateResult {
+  events: TrackerEvent[];
+  /** True when the current observation is the new best frame of the active track — snapshot it. */
+  snapshotRequested: boolean;
+  activeTrackId: string | null;
+}
+
+export interface TrackerConfig {
+  /** Piece unseen for this long ends the track (ms). */
+  gapCommitMs: number;
+  /** Minimum observed frames for a track to be committed instead of discarded. */
+  minFrames: number;
+  /** BBox IoU below this counts toward an identity break. */
+  iouBreakThreshold: number;
+  /** Signature distance above this counts toward an identity break. */
+  signatureBreakThreshold: number;
+  /** Consecutive break ticks required before cutting to a new track. */
+  breakFrames: number;
+  /** EMA rate for the running track signature. */
+  signatureAlpha: number;
+}
+
+export const DEFAULT_TRACKER_CONFIG: TrackerConfig = {
+  gapCommitMs: 1000,
+  minFrames: 3,
+  iouBreakThreshold: 0.05,
+  signatureBreakThreshold: 0.4,
+  breakFrames: 2,
+  signatureAlpha: 0.3,
+};
+
+export function bboxIoU(a: NormalizedBBox, b: NormalizedBBox): number {
+  const x1 = Math.max(a.x, b.x);
+  const y1 = Math.max(a.y, b.y);
+  const x2 = Math.min(a.x + a.width, b.x + b.width);
+  const y2 = Math.min(a.y + a.height, b.y + b.height);
+  const inter = Math.max(0, x2 - x1) * Math.max(0, y2 - y1);
+  const union = a.width * a.height + b.width * b.height - inter;
+  return union <= 0 ? 0 : inter / union;
+}
+
+/** Frame quality: sharpness weighted by how large the piece is in frame. */
+function frameScore(obs: TrackerObservation): number {
+  const area = obs.bbox ? obs.bbox.width * obs.bbox.height : 0;
+  return (obs.sharpness ?? 0) * Math.sqrt(area);
+}
+
+interface ActiveTrack {
+  id: string;
+  frames: number;
+  lastSeenAt: number;
+  lastBBox: NormalizedBBox;
+  signature: number[];
+  bestScore: number;
+  breakStreak: number;
+}
+
+export class PieceTracker {
+  private config: TrackerConfig;
+  private track: ActiveTrack | null = null;
+  private nextId = 1;
+
+  constructor(config: Partial<TrackerConfig> = {}) {
+    this.config = { ...DEFAULT_TRACKER_CONFIG, ...config };
+  }
+
+  get activeTrackId(): string | null {
+    return this.track?.id ?? null;
+  }
+
+  update(obs: TrackerObservation): TrackerUpdateResult {
+    const events: TrackerEvent[] = [];
+    let snapshotRequested = false;
+
+    if (!obs.found || !obs.bbox) {
+      // Piece not visible: end the track after a sustained gap
+      if (this.track && obs.timestamp - this.track.lastSeenAt >= this.config.gapCommitMs) {
+        events.push(this.finalize(this.track));
+        this.track = null;
+      }
+      return { events, snapshotRequested: false, activeTrackId: this.activeTrackId };
+    }
+
+    if (!this.track) {
+      this.track = this.startTrack(obs);
+      events.push({ type: 'started', trackId: this.track.id });
+      this.track.bestScore = frameScore(obs);
+      snapshotRequested = true;
+      return { events, snapshotRequested, activeTrackId: this.track.id };
+    }
+
+    // Identity check against the active track
+    const iou = bboxIoU(this.track.lastBBox, obs.bbox);
+    const sigDist = obs.signature ? signatureDistance(this.track.signature, obs.signature) : 0;
+    const isBreak =
+      iou < this.config.iouBreakThreshold || sigDist > this.config.signatureBreakThreshold;
+
+    if (isBreak) {
+      this.track.breakStreak += 1;
+      if (this.track.breakStreak >= this.config.breakFrames) {
+        // Sustained identity change: this is a different piece
+        events.push(this.finalize(this.track));
+        this.track = this.startTrack(obs);
+        events.push({ type: 'started', trackId: this.track.id });
+        this.track.bestScore = frameScore(obs);
+        snapshotRequested = true;
+      }
+      // Within hysteresis: hold the track unchanged (don't pollute its
+      // signature or best frame with what may be a different piece)
+      return { events, snapshotRequested, activeTrackId: this.track.id };
+    }
+
+    // Same piece: fold the observation into the track
+    this.track.breakStreak = 0;
+    this.track.frames += 1;
+    this.track.lastSeenAt = obs.timestamp;
+    this.track.lastBBox = obs.bbox;
+    if (obs.signature) {
+      this.track.signature = blendSignature(
+        this.track.signature,
+        obs.signature,
+        this.config.signatureAlpha
+      );
+    }
+    const score = frameScore(obs);
+    if (score > this.track.bestScore) {
+      this.track.bestScore = score;
+      snapshotRequested = true;
+    }
+
+    return { events, snapshotRequested, activeTrackId: this.track.id };
+  }
+
+  /** End the active track immediately (e.g. camera stopping). */
+  flush(): TrackerEvent[] {
+    if (!this.track) return [];
+    const event = this.finalize(this.track);
+    this.track = null;
+    return [event];
+  }
+
+  /** Drop the active track without committing (e.g. after a manual capture). */
+  abandon(): void {
+    this.track = null;
+  }
+
+  private startTrack(obs: TrackerObservation): ActiveTrack {
+    return {
+      id: `track-${this.nextId++}`,
+      frames: 1,
+      lastSeenAt: obs.timestamp,
+      lastBBox: obs.bbox as NormalizedBBox,
+      signature: obs.signature ? [...obs.signature] : [],
+      bestScore: 0,
+      breakStreak: 0,
+    };
+  }
+
+  private finalize(track: ActiveTrack): TrackerEvent {
+    if (track.frames < this.config.minFrames) {
+      return { type: 'discarded', trackId: track.id, reason: 'too-few-frames' };
+    }
+    return {
+      type: 'committed',
+      trackId: track.id,
+      frames: track.frames,
+      bestScore: track.bestScore,
+    };
+  }
+}

--- a/frontend/src/lib/piece-tracker.ts
+++ b/frontend/src/lib/piece-tracker.ts
@@ -131,9 +131,13 @@ export class PieceTracker {
       return { events, snapshotRequested, activeTrackId: this.track.id };
     }
 
-    // Identity check against the active track
+    // Identity check against the active track. The signature only contributes
+    // once the track has actually learned one; comparing against an empty
+    // running signature would always yield distance 0 and silently disable
+    // appearance-based swap detection.
     const iou = bboxIoU(this.track.lastBBox, obs.bbox);
-    const sigDist = obs.signature ? signatureDistance(this.track.signature, obs.signature) : 0;
+    const hasSignatures = this.track.signature.length > 0 && Boolean(obs.signature?.length);
+    const sigDist = hasSignatures ? signatureDistance(this.track.signature, obs.signature!) : 0;
     const isBreak =
       iou < this.config.iouBreakThreshold || sigDist > this.config.signatureBreakThreshold;
 
@@ -157,12 +161,14 @@ export class PieceTracker {
     this.track.frames += 1;
     this.track.lastSeenAt = obs.timestamp;
     this.track.lastBBox = obs.bbox;
-    if (obs.signature) {
-      this.track.signature = blendSignature(
-        this.track.signature,
-        obs.signature,
-        this.config.signatureAlpha
-      );
+    if (obs.signature?.length) {
+      // Adopt the first available signature outright; a track that started
+      // before any signature was computed would otherwise stay empty forever
+      // (blending into an empty array keeps it empty).
+      this.track.signature =
+        this.track.signature.length === 0
+          ? [...obs.signature]
+          : blendSignature(this.track.signature, obs.signature, this.config.signatureAlpha);
     }
     const score = frameScore(obs);
     if (score > this.track.bestScore) {

--- a/frontend/src/stores/capture-queue-store.test.ts
+++ b/frontend/src/stores/capture-queue-store.test.ts
@@ -1,16 +1,32 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useCaptureQueueStore } from './capture-queue-store';
 
 describe('CaptureQueueStore', () => {
   // jsdom doesn't implement the Blob URL APIs; spy on them (rather than
   // replacing the global URL constructor wholesale) so revoke calls in the
   // store can be observed without leaking a stubbed URL into other tests.
-  if (typeof URL.createObjectURL !== 'function') {
-    (URL as unknown as Record<string, unknown>).createObjectURL = () => '';
-  }
-  if (typeof URL.revokeObjectURL !== 'function') {
-    (URL as unknown as Record<string, unknown>).revokeObjectURL = () => {};
-  }
+  const urlRecord = URL as unknown as Record<string, unknown>;
+  const polyfilled: string[] = [];
+
+  beforeAll(() => {
+    // Add the missing methods so vi.spyOn has something to wrap, remembering
+    // which ones we added so they can be removed again in afterAll.
+    if (typeof URL.createObjectURL !== 'function') {
+      urlRecord.createObjectURL = () => '';
+      polyfilled.push('createObjectURL');
+    }
+    if (typeof URL.revokeObjectURL !== 'function') {
+      urlRecord.revokeObjectURL = () => {};
+      polyfilled.push('revokeObjectURL');
+    }
+  });
+
+  afterAll(() => {
+    // Drop any methods we polyfilled so they don't leak into other test files
+    for (const name of polyfilled) {
+      delete urlRecord[name];
+    }
+  });
 
   let revokeObjectURL: ReturnType<typeof vi.spyOn>;
 

--- a/frontend/src/stores/capture-queue-store.test.ts
+++ b/frontend/src/stores/capture-queue-store.test.ts
@@ -1,21 +1,27 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { useCaptureQueueStore } from './capture-queue-store';
 
 describe('CaptureQueueStore', () => {
-  // jsdom doesn't implement the Blob URL APIs; stub them so revoke calls in
-  // the store can be observed without throwing. Kept as standalone spies
-  // (rather than reading them off `URL` in assertions) to avoid unbound-method
-  // lint warnings.
-  const revokeObjectURL = vi.fn();
+  // jsdom doesn't implement the Blob URL APIs; spy on them (rather than
+  // replacing the global URL constructor wholesale) so revoke calls in the
+  // store can be observed without leaking a stubbed URL into other tests.
+  if (typeof URL.createObjectURL !== 'function') {
+    (URL as unknown as Record<string, unknown>).createObjectURL = () => '';
+  }
+  if (typeof URL.revokeObjectURL !== 'function') {
+    (URL as unknown as Record<string, unknown>).revokeObjectURL = () => {};
+  }
+
+  let revokeObjectURL: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    revokeObjectURL.mockClear();
-    vi.stubGlobal('URL', {
-      ...URL,
-      createObjectURL: vi.fn(() => 'blob:mock-url'),
-      revokeObjectURL,
-    });
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-url');
+    revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
     useCaptureQueueStore.setState({ entries: [], isProcessing: false });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   const makeBlob = () => new Blob(['data'], { type: 'image/png' });

--- a/frontend/src/stores/capture-queue-store.test.ts
+++ b/frontend/src/stores/capture-queue-store.test.ts
@@ -133,6 +133,26 @@ describe('CaptureQueueStore', () => {
     expect(entry.blob).toBeDefined();
   });
 
+  it('does not revoke the cleaned data URL when removing a predicted entry', () => {
+    useCaptureQueueStore
+      .getState()
+      .enqueue({ id: '1', blob: makeBlob(), imageUrl: 'blob:raw', capturedAt: 1 });
+    useCaptureQueueStore.getState().setResult('1', {
+      position: { x: 0.4, y: 0.6, normalized: true },
+      positionConfidence: 0.9,
+      rotation: 0,
+      rotationConfidence: 0.9,
+      imageData: 'data:image/png;base64,cleaned',
+    });
+    // setResult already revoked the raw blob URL
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+
+    // Removing now must NOT try to revoke the data: URL that replaced it
+    useCaptureQueueStore.getState().remove('1');
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).not.toHaveBeenCalledWith('data:image/png;base64,cleaned');
+  });
+
   it('retry should only affect entries in the error status', () => {
     useCaptureQueueStore
       .getState()

--- a/frontend/src/stores/capture-queue-store.test.ts
+++ b/frontend/src/stores/capture-queue-store.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useCaptureQueueStore } from './capture-queue-store';
+
+describe('CaptureQueueStore', () => {
+  // jsdom doesn't implement the Blob URL APIs; stub them so revoke calls in
+  // the store can be observed without throwing. Kept as standalone spies
+  // (rather than reading them off `URL` in assertions) to avoid unbound-method
+  // lint warnings.
+  const revokeObjectURL = vi.fn();
+
+  beforeEach(() => {
+    revokeObjectURL.mockClear();
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:mock-url'),
+      revokeObjectURL,
+    });
+    useCaptureQueueStore.setState({ entries: [], isProcessing: false });
+  });
+
+  const makeBlob = () => new Blob(['data'], { type: 'image/png' });
+
+  it('should have initial state', () => {
+    const state = useCaptureQueueStore.getState();
+    expect(state.entries).toEqual([]);
+    expect(state.isProcessing).toBe(false);
+  });
+
+  it('should enqueue an entry as queued', () => {
+    useCaptureQueueStore
+      .getState()
+      .enqueue({ id: '1', blob: makeBlob(), imageUrl: 'blob:1', capturedAt: 123 });
+
+    const { entries } = useCaptureQueueStore.getState();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: '1',
+      imageUrl: 'blob:1',
+      capturedAt: 123,
+      status: 'queued',
+    });
+  });
+
+  it('should remove an entry and revoke its object URL', () => {
+    useCaptureQueueStore
+      .getState()
+      .enqueue({ id: '1', blob: makeBlob(), imageUrl: 'blob:1', capturedAt: 1 });
+    useCaptureQueueStore
+      .getState()
+      .enqueue({ id: '2', blob: makeBlob(), imageUrl: 'blob:2', capturedAt: 2 });
+
+    useCaptureQueueStore.getState().remove('1');
+
+    const { entries } = useCaptureQueueStore.getState();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].id).toBe('2');
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:1');
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  it('should be a no-op when removing an id that does not exist', () => {
+    useCaptureQueueStore
+      .getState()
+      .enqueue({ id: '1', blob: makeBlob(), imageUrl: 'blob:1', capturedAt: 1 });
+
+    useCaptureQueueStore.getState().remove('missing');
+
+    expect(useCaptureQueueStore.getState().entries).toHaveLength(1);
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('retry should only affect entries in the error status', () => {
+    useCaptureQueueStore
+      .getState()
+      .enqueue({ id: '1', blob: makeBlob(), imageUrl: 'blob:1', capturedAt: 1 });
+    useCaptureQueueStore
+      .getState()
+      .enqueue({ id: '2', blob: makeBlob(), imageUrl: 'blob:2', capturedAt: 2 });
+
+    useCaptureQueueStore.getState().setError('1', 'boom');
+    useCaptureQueueStore.getState().setStatus('2', 'predicting');
+
+    // Retrying the queued/predicting entry should have no effect
+    useCaptureQueueStore.getState().retry('2');
+    expect(useCaptureQueueStore.getState().entries.find((e) => e.id === '2')?.status).toBe(
+      'predicting'
+    );
+
+    // Retrying the error entry resets it to queued and clears the error
+    useCaptureQueueStore.getState().retry('1');
+    const entry1 = useCaptureQueueStore.getState().entries.find((e) => e.id === '1');
+    expect(entry1?.status).toBe('queued');
+    expect(entry1?.error).toBeUndefined();
+  });
+
+  it('clear should revoke all object URLs and reset state', () => {
+    useCaptureQueueStore
+      .getState()
+      .enqueue({ id: '1', blob: makeBlob(), imageUrl: 'blob:1', capturedAt: 1 });
+    useCaptureQueueStore
+      .getState()
+      .enqueue({ id: '2', blob: makeBlob(), imageUrl: 'blob:2', capturedAt: 2 });
+    useCaptureQueueStore.getState().setProcessing(true);
+
+    useCaptureQueueStore.getState().clear();
+
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:1');
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:2');
+    expect(revokeObjectURL).toHaveBeenCalledTimes(2);
+
+    const state = useCaptureQueueStore.getState();
+    expect(state.entries).toEqual([]);
+    expect(state.isProcessing).toBe(false);
+  });
+});

--- a/frontend/src/stores/capture-queue-store.test.ts
+++ b/frontend/src/stores/capture-queue-store.test.ts
@@ -91,6 +91,48 @@ describe('CaptureQueueStore', () => {
     expect(revokeObjectURL).not.toHaveBeenCalled();
   });
 
+  it('setResult releases the raw capture once a cleaned image is available', () => {
+    useCaptureQueueStore
+      .getState()
+      .enqueue({ id: '1', blob: makeBlob(), imageUrl: 'blob:raw', capturedAt: 1 });
+
+    useCaptureQueueStore.getState().setResult('1', {
+      position: { x: 0.4, y: 0.6, normalized: true },
+      positionConfidence: 0.9,
+      rotation: 0,
+      rotationConfidence: 0.9,
+      imageData: 'data:image/png;base64,cleaned',
+    });
+
+    const entry = useCaptureQueueStore.getState().entries[0];
+    expect(entry.status).toBe('done');
+    // Raw object URL revoked and blob dropped so it can be garbage-collected
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:raw');
+    expect(entry.blob).toBeUndefined();
+    // The entry now points at the cleaned image for rendering
+    expect(entry.imageUrl).toBe('data:image/png;base64,cleaned');
+  });
+
+  it('setResult keeps the raw capture when no cleaned image is returned', () => {
+    useCaptureQueueStore
+      .getState()
+      .enqueue({ id: '1', blob: makeBlob(), imageUrl: 'blob:raw', capturedAt: 1 });
+
+    useCaptureQueueStore.getState().setResult('1', {
+      position: { x: 0.4, y: 0.6, normalized: true },
+      positionConfidence: 0.9,
+      rotation: 0,
+      rotationConfidence: 0.9,
+      // no imageData
+    });
+
+    const entry = useCaptureQueueStore.getState().entries[0];
+    expect(entry.status).toBe('done');
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+    expect(entry.imageUrl).toBe('blob:raw');
+    expect(entry.blob).toBeDefined();
+  });
+
   it('retry should only affect entries in the error status', () => {
     useCaptureQueueStore
       .getState()

--- a/frontend/src/stores/capture-queue-store.ts
+++ b/frontend/src/stores/capture-queue-store.ts
@@ -18,7 +18,7 @@ export interface CaptureEntry {
   id: string;
   /** Object URL of the best raw camera crop; swapped for the cleaned image once done */
   imageUrl: string;
-  /** Raw capture blob, needed until prediction runs; released once done */
+  /** Raw capture blob; released once a cleaned image replaces it, kept otherwise (e.g. for retries) */
   blob?: Blob;
   status: CaptureStatus;
   capturedAt: number;

--- a/frontend/src/stores/capture-queue-store.ts
+++ b/frontend/src/stores/capture-queue-store.ts
@@ -3,6 +3,17 @@ import type { Piece } from '@/types';
 
 export type CaptureStatus = 'queued' | 'predicting' | 'done' | 'error';
 
+/**
+ * Revoke a URL only if it is a blob: object URL this store created. Once an
+ * entry is predicted its imageUrl becomes a data: URL (the cleaned image),
+ * which URL.revokeObjectURL is not meant for.
+ */
+function revokeIfObjectUrl(url: string): void {
+  if (url.startsWith('blob:')) {
+    URL.revokeObjectURL(url);
+  }
+}
+
 export interface CaptureEntry {
   id: string;
   /** Object URL of the best raw camera crop; swapped for the cleaned image once done */
@@ -53,7 +64,7 @@ export const useCaptureQueueStore = create<CaptureQueueState>((set, get) => ({
         // the raw capture, so release the raw object URL and blob — otherwise
         // hundreds of captures would pin their blobs in memory for the session.
         if (piece.imageData) {
-          URL.revokeObjectURL(e.imageUrl);
+          revokeIfObjectUrl(e.imageUrl);
           return {
             ...e,
             status: 'done' as const,
@@ -88,7 +99,7 @@ export const useCaptureQueueStore = create<CaptureQueueState>((set, get) => ({
     // Release the removed entry's object URL before dropping it
     const entry = get().entries.find((e) => e.id === id);
     if (entry) {
-      URL.revokeObjectURL(entry.imageUrl);
+      revokeIfObjectUrl(entry.imageUrl);
     }
     set((state) => ({ entries: state.entries.filter((e) => e.id !== id) }));
   },
@@ -98,7 +109,7 @@ export const useCaptureQueueStore = create<CaptureQueueState>((set, get) => ({
   clear: () => {
     // Release the object URLs owned by the queue before dropping the entries
     for (const entry of get().entries) {
-      URL.revokeObjectURL(entry.imageUrl);
+      revokeIfObjectUrl(entry.imageUrl);
     }
     set({ entries: [], isProcessing: false });
   },

--- a/frontend/src/stores/capture-queue-store.ts
+++ b/frontend/src/stores/capture-queue-store.ts
@@ -1,0 +1,88 @@
+import { create } from 'zustand';
+import type { Piece } from '@/types';
+
+export type CaptureStatus = 'queued' | 'predicting' | 'done' | 'error';
+
+export interface CaptureEntry {
+  id: string;
+  /** Object URL of the best raw camera crop for this piece */
+  imageUrl: string;
+  blob: Blob;
+  status: CaptureStatus;
+  capturedAt: number;
+  /** Prediction result (includes the background-removed image) once done */
+  piece?: Piece;
+  error?: string;
+}
+
+interface CaptureQueueState {
+  entries: CaptureEntry[];
+  /** True while a prediction request is in flight (queue drains serially) */
+  isProcessing: boolean;
+
+  enqueue: (entry: { id: string; blob: Blob; imageUrl: string; capturedAt: number }) => void;
+  setStatus: (id: string, status: CaptureStatus) => void;
+  setResult: (id: string, piece: Piece) => void;
+  setError: (id: string, error: string) => void;
+  retry: (id: string) => void;
+  remove: (id: string) => void;
+  setProcessing: (isProcessing: boolean) => void;
+  clear: () => void;
+}
+
+export const useCaptureQueueStore = create<CaptureQueueState>((set, get) => ({
+  entries: [],
+  isProcessing: false,
+
+  enqueue: ({ id, blob, imageUrl, capturedAt }) =>
+    set((state) => ({
+      entries: [...state.entries, { id, blob, imageUrl, capturedAt, status: 'queued' as const }],
+    })),
+
+  setStatus: (id, status) =>
+    set((state) => ({
+      entries: state.entries.map((e) => (e.id === id ? { ...e, status } : e)),
+    })),
+
+  setResult: (id, piece) =>
+    set((state) => ({
+      entries: state.entries.map((e) =>
+        e.id === id ? { ...e, status: 'done' as const, piece, error: undefined } : e
+      ),
+    })),
+
+  setError: (id, error) =>
+    set((state) => ({
+      entries: state.entries.map((e) =>
+        e.id === id ? { ...e, status: 'error' as const, error } : e
+      ),
+    })),
+
+  retry: (id) =>
+    set((state) => ({
+      entries: state.entries.map((e) =>
+        e.id === id && e.status === 'error'
+          ? { ...e, status: 'queued' as const, error: undefined }
+          : e
+      ),
+    })),
+
+  remove: (id) => {
+    // Release the removed entry's object URL before dropping it
+    const entry = get().entries.find((e) => e.id === id);
+    if (entry) {
+      URL.revokeObjectURL(entry.imageUrl);
+    }
+    set((state) => ({ entries: state.entries.filter((e) => e.id !== id) }));
+  },
+
+  setProcessing: (isProcessing) => set({ isProcessing }),
+
+  clear: () => {
+    // Release the object URLs owned by the queue before dropping the entries
+    for (const entry of get().entries) {
+      URL.revokeObjectURL(entry.imageUrl);
+    }
+    set({ entries: [], isProcessing: false });
+  },
+}));

--- a/frontend/src/stores/capture-queue-store.ts
+++ b/frontend/src/stores/capture-queue-store.ts
@@ -5,9 +5,10 @@ export type CaptureStatus = 'queued' | 'predicting' | 'done' | 'error';
 
 export interface CaptureEntry {
   id: string;
-  /** Object URL of the best raw camera crop for this piece */
+  /** Object URL of the best raw camera crop; swapped for the cleaned image once done */
   imageUrl: string;
-  blob: Blob;
+  /** Raw capture blob, needed until prediction runs; released once done */
+  blob?: Blob;
   status: CaptureStatus;
   capturedAt: number;
   /** Prediction result (includes the background-removed image) once done */
@@ -46,9 +47,25 @@ export const useCaptureQueueStore = create<CaptureQueueState>((set, get) => ({
 
   setResult: (id, piece) =>
     set((state) => ({
-      entries: state.entries.map((e) =>
-        e.id === id ? { ...e, status: 'done' as const, piece, error: undefined } : e
-      ),
+      entries: state.entries.map((e) => {
+        if (e.id !== id) return e;
+        // Once the cleaned image is available the UI renders that instead of
+        // the raw capture, so release the raw object URL and blob — otherwise
+        // hundreds of captures would pin their blobs in memory for the session.
+        if (piece.imageData) {
+          URL.revokeObjectURL(e.imageUrl);
+          return {
+            ...e,
+            status: 'done' as const,
+            piece,
+            error: undefined,
+            imageUrl: piece.imageData,
+            blob: undefined,
+          };
+        }
+        // No cleaned image came back; keep the raw capture so the UI can show it.
+        return { ...e, status: 'done' as const, piece, error: undefined };
+      }),
     })),
 
   setError: (id, error) =>

--- a/frontend/src/stores/puzzle-store.test.ts
+++ b/frontend/src/stores/puzzle-store.test.ts
@@ -52,6 +52,46 @@ describe('PuzzleStore', () => {
     expect(usePuzzleStore.getState().pieces[1]).toEqual(piece2);
   });
 
+  it('should remove a piece by reference identity', () => {
+    const piece1 = {
+      position: { x: 0.5, y: 0.5, normalized: true },
+      positionConfidence: 0.9,
+      rotation: 0 as const,
+      rotationConfidence: 0.95,
+    };
+    const piece2 = {
+      position: { x: 0.3, y: 0.7, normalized: true },
+      positionConfidence: 0.85,
+      rotation: 90 as const,
+      rotationConfidence: 0.92,
+    };
+
+    usePuzzleStore.getState().addPiece(piece1);
+    usePuzzleStore.getState().addPiece(piece2);
+    expect(usePuzzleStore.getState().pieces).toHaveLength(2);
+
+    usePuzzleStore.getState().removePiece(piece1);
+
+    const { pieces } = usePuzzleStore.getState();
+    expect(pieces).toHaveLength(1);
+    expect(pieces[0]).toBe(piece2);
+  });
+
+  it('should not remove anything for a piece not in the store (identity mismatch)', () => {
+    const piece1 = {
+      position: { x: 0.5, y: 0.5, normalized: true },
+      positionConfidence: 0.9,
+      rotation: 0 as const,
+      rotationConfidence: 0.95,
+    };
+    const lookalike = { ...piece1 };
+
+    usePuzzleStore.getState().addPiece(piece1);
+    usePuzzleStore.getState().removePiece(lookalike);
+
+    expect(usePuzzleStore.getState().pieces).toHaveLength(1);
+  });
+
   it('should set grid size', () => {
     usePuzzleStore.getState().setGridSize('2x2');
     expect(usePuzzleStore.getState().gridSize).toBe('2x2');

--- a/frontend/src/stores/puzzle-store.test.ts
+++ b/frontend/src/stores/puzzle-store.test.ts
@@ -52,14 +52,16 @@ describe('PuzzleStore', () => {
     expect(usePuzzleStore.getState().pieces[1]).toEqual(piece2);
   });
 
-  it('should remove a piece by reference identity', () => {
+  it('should remove a piece by id', () => {
     const piece1 = {
+      id: 'piece-1',
       position: { x: 0.5, y: 0.5, normalized: true },
       positionConfidence: 0.9,
       rotation: 0 as const,
       rotationConfidence: 0.95,
     };
     const piece2 = {
+      id: 'piece-2',
       position: { x: 0.3, y: 0.7, normalized: true },
       positionConfidence: 0.85,
       rotation: 90 as const,
@@ -70,24 +72,41 @@ describe('PuzzleStore', () => {
     usePuzzleStore.getState().addPiece(piece2);
     expect(usePuzzleStore.getState().pieces).toHaveLength(2);
 
-    usePuzzleStore.getState().removePiece(piece1);
+    usePuzzleStore.getState().removePiece('piece-1');
 
     const { pieces } = usePuzzleStore.getState();
     expect(pieces).toHaveLength(1);
     expect(pieces[0]).toBe(piece2);
   });
 
-  it('should not remove anything for a piece not in the store (identity mismatch)', () => {
+  it('removing an id works on a cloned piece object (not just the original reference)', () => {
     const piece1 = {
+      id: 'piece-1',
       position: { x: 0.5, y: 0.5, normalized: true },
       positionConfidence: 0.9,
       rotation: 0 as const,
       rotationConfidence: 0.95,
     };
-    const lookalike = { ...piece1 };
 
     usePuzzleStore.getState().addPiece(piece1);
-    usePuzzleStore.getState().removePiece(lookalike);
+    // Removing by id succeeds even though this is a different object than stored
+    const clone = { ...piece1 };
+    usePuzzleStore.getState().removePiece(clone.id);
+
+    expect(usePuzzleStore.getState().pieces).toHaveLength(0);
+  });
+
+  it('should not remove anything for an id not in the store', () => {
+    const piece1 = {
+      id: 'piece-1',
+      position: { x: 0.5, y: 0.5, normalized: true },
+      positionConfidence: 0.9,
+      rotation: 0 as const,
+      rotationConfidence: 0.95,
+    };
+
+    usePuzzleStore.getState().addPiece(piece1);
+    usePuzzleStore.getState().removePiece('nonexistent');
 
     expect(usePuzzleStore.getState().pieces).toHaveLength(1);
   });

--- a/frontend/src/stores/puzzle-store.ts
+++ b/frontend/src/stores/puzzle-store.ts
@@ -11,6 +11,7 @@ interface PuzzleState {
 
   setPuzzle: (puzzle: Puzzle, imageUrl: string) => void;
   addPiece: (piece: Piece) => void;
+  removePiece: (piece: Piece) => void;
   setGridSize: (gridSize: GridSize) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
@@ -27,6 +28,7 @@ export const usePuzzleStore = create<PuzzleState>((set) => ({
 
   setPuzzle: (puzzle, imageUrl) => set({ puzzle, puzzleImage: imageUrl, pieces: [], error: null }),
   addPiece: (piece) => set((state) => ({ pieces: [...state.pieces, piece] })),
+  removePiece: (piece) => set((state) => ({ pieces: state.pieces.filter((p) => p !== piece) })),
   setGridSize: (gridSize) => set({ gridSize }),
   setLoading: (isLoading) => set({ isLoading }),
   setError: (error) => set({ error }),

--- a/frontend/src/stores/puzzle-store.ts
+++ b/frontend/src/stores/puzzle-store.ts
@@ -11,7 +11,7 @@ interface PuzzleState {
 
   setPuzzle: (puzzle: Puzzle, imageUrl: string) => void;
   addPiece: (piece: Piece) => void;
-  removePiece: (piece: Piece) => void;
+  removePiece: (id: string) => void;
   setGridSize: (gridSize: GridSize) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
@@ -28,7 +28,9 @@ export const usePuzzleStore = create<PuzzleState>((set) => ({
 
   setPuzzle: (puzzle, imageUrl) => set({ puzzle, puzzleImage: imageUrl, pieces: [], error: null }),
   addPiece: (piece) => set((state) => ({ pieces: [...state.pieces, piece] })),
-  removePiece: (piece) => set((state) => ({ pieces: state.pieces.filter((p) => p !== piece) })),
+  // Remove by stable id (pieces from the capture queue carry the entry id),
+  // rather than object identity which would silently no-op on any clone.
+  removePiece: (id) => set((state) => ({ pieces: state.pieces.filter((p) => p.id !== id) })),
   setGridSize: (gridSize) => set({ gridSize }),
   setLoading: (isLoading) => set({ isLoading }),
   setError: (error) => set({ error }),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -13,6 +13,7 @@ export interface Position {
 }
 
 export interface Piece {
+  id?: string; // stable identifier when the piece originates from the capture queue
   position: Position;
   positionConfidence: number; // 0-1
   rotation: 0 | 90 | 180 | 270;


### PR DESCRIPTION
## Summary

Turns real mode into a continuous **capture pipeline**. Instead of a one-shot camera modal, the piece camera is embedded in a split-screen solving view — the puzzle with prediction overlays on one side, the live camera on the other, and a capture queue below.

Hold a piece up to the camera; when you set it aside, its **best frame is captured automatically** and flows through the prediction queue onto the puzzle.

## How it works

- **Piece tracking** (`lib/piece-tracker.ts`): a pure state machine fed one observation per detection tick. Temporal continuity (bbox-overlap IoU + a ~1s detection gap) starts/ends a track; a coarse HSV-histogram appearance signature with 2-frame hysteresis catches a quick piece **swap** that never leaves the frame, cutting to a new piece.
- **Best-frame selection** (`lib/frame-quality.ts`): each frame is scored by sharpness (variance of Laplacian) × piece size in frame; the sharpest, largest view of a piece wins.
- **Capture queue** (`stores/capture-queue-store.ts` + `hooks/use-prediction-worker.ts`): committed frames drain serially through the existing background-removal + CNN prediction endpoint (`queued → predicting → done/error`), with retry and delete.
- **Feedback**: each auto-commit plays a short synthesized blip (`lib/capture-sound.ts`) and flashes the camera, and the queue entry pops in.
- **Delete**: removing a done entry also removes its marker from the puzzle overlay.

## Testing

- New unit tests: frame-quality math, tracker lifecycle (start / improve / gap-commit / swap-cut / flash-immunity / discard), queue store (enqueue/remove/retry/clear with object-URL revocation).
- Extended real-mode e2e: capture → predict → **delete** round trip.
- `bun run check` (oxlint + tsc + prettier) and all 48 unit tests pass; full Playwright e2e suite green against a local backend.

## Notes

- **Known limitation (follow-up):** the live detector currently latches onto a face when no piece is present, so those false positives get queued. Being addressed separately by improving the backend piece/not-piece detector; queue delete is the interim mitigation.
- Layer 2 identity (CNN embedding-based dedup) is deferred; this PR ships the cheap client-side histogram approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)