### PR TITLE
feat(real): reuse previously photographed puzzles from local device

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -32,6 +32,7 @@
         "@vitejs/plugin-react": "^5.1.2",
         "eslint": "^9",
         "eslint-config-next": "16.2.10",
+        "fake-indexeddb": "^6.2.5",
         "husky": "^9.1.7",
         "jsdom": "^29.1.1",
         "lint-staged": "^17.0.8",
@@ -755,6 +756,8 @@
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fake-indexeddb": ["fake-indexeddb@6.2.5", "", {}, "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "@vitejs/plugin-react": "^5.1.2",
     "eslint": "^9",
     "eslint-config-next": "16.2.10",
+    "fake-indexeddb": "^6.2.5",
     "husky": "^9.1.7",
     "jsdom": "^29.1.1",
     "lint-staged": "^17.0.8",

--- a/frontend/src/app/real/page.tsx
+++ b/frontend/src/app/real/page.tsx
@@ -6,11 +6,13 @@ import { ArrowLeft, Camera, Loader2, RotateCcw, ScanLine } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { CameraModal, LivePieceCapture } from '@/components/camera';
-import { CornerAdjust, PieceQueue, PuzzleDetail } from '@/components/puzzle';
+import { CornerAdjust, PieceQueue, PuzzleDetail, SavedPuzzleGallery } from '@/components/puzzle';
 import { usePuzzleStore } from '@/stores/puzzle-store';
 import { useCaptureQueueStore } from '@/stores/capture-queue-store';
 import { usePredictionWorker } from '@/hooks/use-prediction-worker';
+import { useSavedPuzzles } from '@/hooks/use-saved-puzzles';
 import { detectFrame, uploadPuzzle } from '@/lib/api';
+import { getPuzzleBlob } from '@/lib/puzzle-library';
 import { blobToDataUrl, dataUrlToBlob } from '@/lib/image-utils';
 import { cn } from '@/lib/utils';
 import type { DetectFrameResult } from '@/types';
@@ -33,6 +35,12 @@ export default function RealModePage() {
   const { puzzle, puzzleImage, pieces, isLoading, error, setPuzzle, setLoading, setError, reset } =
     usePuzzleStore();
   const removePiece = usePuzzleStore((s) => s.removePiece);
+
+  const {
+    puzzles: savedPuzzles,
+    save: saveSavedPuzzle,
+    remove: removeSavedPuzzle,
+  } = useSavedPuzzles();
 
   const queueEntries = useCaptureQueueStore((s) => s.entries);
   const retryEntry = useCaptureQueueStore((s) => s.retry);
@@ -78,8 +86,37 @@ export default function RealModePage() {
       const result = await uploadPuzzle(trimmedBlob);
       setPuzzle(result, detection.trimmedImageUrl);
       setPhase('solving');
+      // Persist for reuse so this puzzle need not be re-photographed next time.
+      // A storage failure must not block solving, so swallow it.
+      try {
+        await saveSavedPuzzle(trimmedBlob, `Puzzle ${savedPuzzles.length + 1}`);
+      } catch {
+        // Ignore — the current session still works without a saved copy.
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to upload puzzle');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSelectSaved = async (id: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const blob = await getPuzzleBlob(id);
+      if (!blob) {
+        setError('That saved puzzle could not be found. It may have been removed.');
+        return;
+      }
+      // Re-upload to get a fresh puzzle_id (backend storage is not durable),
+      // then skip straight to solving — no re-photographing or trimming.
+      const dataUrl = await blobToDataUrl(blob);
+      const result = await uploadPuzzle(blob);
+      setPuzzle(result, dataUrl);
+      setPhase('solving');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load saved puzzle');
     } finally {
       setLoading(false);
     }
@@ -164,30 +201,51 @@ export default function RealModePage() {
         )}
 
         {phase === 'capture-puzzle' && (
-          <Card>
-            <CardHeader className="text-center">
-              <CardTitle>Capture Your Puzzle</CardTitle>
-              <CardDescription>
-                Take a photo of the complete puzzle picture — the box lid or the finished puzzle. It
-                will be automatically trimmed to just the picture.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Button
-                className="w-full gap-2"
-                size="lg"
-                onClick={() => setPuzzleCameraOpen(true)}
-                disabled={isLoading}
-              >
-                {isLoading ? (
-                  <Loader2 className="h-5 w-5 animate-spin" />
-                ) : (
-                  <Camera className="h-5 w-5" />
-                )}
-                {isLoading ? 'Detecting puzzle...' : 'Take Puzzle Photo'}
-              </Button>
-            </CardContent>
-          </Card>
+          <div className="space-y-4">
+            <Card>
+              <CardHeader className="text-center">
+                <CardTitle>Capture Your Puzzle</CardTitle>
+                <CardDescription>
+                  Take a photo of the complete puzzle picture — the box lid or the finished puzzle.
+                  It will be automatically trimmed to just the picture.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Button
+                  className="w-full gap-2"
+                  size="lg"
+                  onClick={() => setPuzzleCameraOpen(true)}
+                  disabled={isLoading}
+                >
+                  {isLoading ? (
+                    <Loader2 className="h-5 w-5 animate-spin" />
+                  ) : (
+                    <Camera className="h-5 w-5" />
+                  )}
+                  {isLoading ? 'Detecting puzzle...' : 'Take Puzzle Photo'}
+                </Button>
+              </CardContent>
+            </Card>
+
+            {savedPuzzles.length > 0 && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Or reuse a saved puzzle</CardTitle>
+                  <CardDescription>
+                    Puzzles you have photographed before, stored on this device.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <SavedPuzzleGallery
+                    puzzles={savedPuzzles}
+                    onSelect={(id) => void handleSelectSaved(id)}
+                    onDelete={(id) => void removeSavedPuzzle(id)}
+                    disabled={isLoading}
+                  />
+                </CardContent>
+              </Card>
+            )}
+          </div>
         )}
 
         {phase === 'confirm-trim' && detection && (

--- a/frontend/src/app/real/page.tsx
+++ b/frontend/src/app/real/page.tsx
@@ -122,6 +122,14 @@ export default function RealModePage() {
     }
   };
 
+  const handleDeleteSaved = (id: string) => {
+    // Surface delete failures (quota, blocked DB) instead of dropping them on
+    // the floor as an unhandled rejection.
+    void removeSavedPuzzle(id).catch((err) => {
+      setError(err instanceof Error ? err.message : 'Failed to delete saved puzzle');
+    });
+  };
+
   const handleApplyCorners = async (corners: DetectFrameResult['corners']) => {
     if (!rawPhotoBlob) return;
 
@@ -239,7 +247,7 @@ export default function RealModePage() {
                   <SavedPuzzleGallery
                     puzzles={savedPuzzles}
                     onSelect={(id) => void handleSelectSaved(id)}
-                    onDelete={(id) => void removeSavedPuzzle(id)}
+                    onDelete={handleDeleteSaved}
                     disabled={isLoading}
                   />
                 </CardContent>

--- a/frontend/src/app/real/page.tsx
+++ b/frontend/src/app/real/page.tsx
@@ -86,13 +86,12 @@ export default function RealModePage() {
       const result = await uploadPuzzle(trimmedBlob);
       setPuzzle(result, detection.trimmedImageUrl);
       setPhase('solving');
-      // Persist for reuse so this puzzle need not be re-photographed next time.
-      // A storage failure must not block solving, so swallow it.
-      try {
-        await saveSavedPuzzle(trimmedBlob, `Puzzle ${savedPuzzles.length + 1}`);
-      } catch {
+      // Persist for reuse (fire-and-forget): the save must never block or fail
+      // solving, so we don't await it — isLoading clears immediately below —
+      // and any storage error is swallowed.
+      void saveSavedPuzzle(trimmedBlob, `Puzzle ${savedPuzzles.length + 1}`).catch(() => {
         // Ignore — the current session still works without a saved copy.
-      }
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to upload puzzle');
     } finally {

--- a/frontend/src/components/puzzle/index.ts
+++ b/frontend/src/components/puzzle/index.ts
@@ -6,3 +6,4 @@ export { RotationSelector } from './rotation-selector';
 export { ClickPieceSelector } from './click-piece-selector';
 export { PieceModeToggle } from './piece-mode-toggle';
 export { CornerAdjust } from './corner-adjust';
+export { SavedPuzzleGallery } from './saved-puzzle-gallery';

--- a/frontend/src/components/puzzle/saved-puzzle-gallery.tsx
+++ b/frontend/src/components/puzzle/saved-puzzle-gallery.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { SavedPuzzleMeta } from '@/lib/puzzle-library';
+
+interface SavedPuzzleGalleryProps {
+  puzzles: SavedPuzzleMeta[];
+  onSelect: (id: string) => void;
+  onDelete: (id: string) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Grid of previously captured real puzzles. Selecting a card reuses that
+ * puzzle's stored image instead of photographing a new one.
+ */
+export function SavedPuzzleGallery({
+  puzzles,
+  onSelect,
+  onDelete,
+  disabled = false,
+}: SavedPuzzleGalleryProps) {
+  if (puzzles.length === 0) return null;
+
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+      {puzzles.map((puzzle) => (
+        <div key={puzzle.id} className="group relative">
+          <button
+            type="button"
+            onClick={() => onSelect(puzzle.id)}
+            disabled={disabled}
+            className="hover:border-primary focus-visible:ring-ring block w-full overflow-hidden rounded-lg border transition-shadow hover:shadow-md focus-visible:ring-2 focus-visible:outline-none disabled:opacity-50"
+          >
+            <img
+              src={puzzle.thumbnail}
+              alt={puzzle.name}
+              className="aspect-square w-full object-cover"
+            />
+            <span className="block truncate px-2 py-1.5 text-left text-sm font-medium">
+              {puzzle.name}
+            </span>
+          </button>
+          <Button
+            variant="secondary"
+            size="icon"
+            onClick={() => onDelete(puzzle.id)}
+            disabled={disabled}
+            aria-label={`Delete ${puzzle.name}`}
+            className="absolute top-1.5 right-1.5 h-7 w-7 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/puzzle/saved-puzzle-gallery.tsx
+++ b/frontend/src/components/puzzle/saved-puzzle-gallery.tsx
@@ -48,7 +48,9 @@ export function SavedPuzzleGallery({
             onClick={() => onDelete(puzzle.id)}
             disabled={disabled}
             aria-label={`Delete ${puzzle.name}`}
-            className="absolute top-1.5 right-1.5 h-7 w-7 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+            // Visible by default so touch devices (no hover) can delete;
+            // fades to hover-reveal only on larger, pointer-capable screens.
+            className="absolute top-1.5 right-1.5 h-7 w-7 opacity-100 transition-opacity focus-visible:opacity-100 sm:opacity-0 sm:group-hover:opacity-100"
           >
             <Trash2 className="h-3.5 w-3.5" />
           </Button>

--- a/frontend/src/hooks/use-saved-puzzles.ts
+++ b/frontend/src/hooks/use-saved-puzzles.ts
@@ -32,7 +32,15 @@ export function useSavedPuzzles(): UseSavedPuzzles {
     let cancelled = false;
     listPuzzles()
       .then((list) => {
-        if (!cancelled) setPuzzles(list);
+        if (cancelled) return;
+        // Merge rather than overwrite: a save/remove/rename may have landed
+        // before this initial load resolved. Keep that newer state and append
+        // only the stored puzzles it doesn't already contain.
+        setPuzzles((prev) => {
+          if (prev.length === 0) return list;
+          const seen = new Set(prev.map((p) => p.id));
+          return [...prev, ...list.filter((p) => !seen.has(p.id))];
+        });
       })
       .catch(() => {
         // A blocked/unavailable IndexedDB simply yields an empty gallery.

--- a/frontend/src/hooks/use-saved-puzzles.ts
+++ b/frontend/src/hooks/use-saved-puzzles.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  deletePuzzle,
+  listPuzzles,
+  renamePuzzle,
+  savePuzzle,
+  type SavedPuzzleMeta,
+} from '@/lib/puzzle-library';
+
+interface UseSavedPuzzles {
+  puzzles: SavedPuzzleMeta[];
+  isReady: boolean; // initial load has completed (IndexedDB is async)
+  save: (blob: Blob, name: string) => Promise<SavedPuzzleMeta>;
+  remove: (id: string) => Promise<void>;
+  rename: (id: string, name: string) => Promise<void>;
+}
+
+/**
+ * React access to the on-device library of saved real puzzles.
+ *
+ * Loads the gallery on mount and keeps local state in sync as puzzles are
+ * saved, renamed, or removed. IndexedDB is unavailable during SSR, so the list
+ * stays empty until the effect runs on the client.
+ */
+export function useSavedPuzzles(): UseSavedPuzzles {
+  const [puzzles, setPuzzles] = useState<SavedPuzzleMeta[]>([]);
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    listPuzzles()
+      .then((list) => {
+        if (!cancelled) setPuzzles(list);
+      })
+      .catch(() => {
+        // A blocked/unavailable IndexedDB simply yields an empty gallery.
+      })
+      .finally(() => {
+        if (!cancelled) setIsReady(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const save = useCallback(async (blob: Blob, name: string) => {
+    const meta = await savePuzzle(blob, name);
+    setPuzzles((prev) => [meta, ...prev]);
+    return meta;
+  }, []);
+
+  const remove = useCallback(async (id: string) => {
+    await deletePuzzle(id);
+    setPuzzles((prev) => prev.filter((p) => p.id !== id));
+  }, []);
+
+  const rename = useCallback(async (id: string, name: string) => {
+    await renamePuzzle(id, name);
+    setPuzzles((prev) => prev.map((p) => (p.id === id ? { ...p, name } : p)));
+  }, []);
+
+  return { puzzles, isReady, save, remove, rename };
+}

--- a/frontend/src/lib/puzzle-library.test.ts
+++ b/frontend/src/lib/puzzle-library.test.ts
@@ -1,0 +1,85 @@
+import 'fake-indexeddb/auto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IDBFactory } from 'fake-indexeddb';
+
+// savePuzzle generates a thumbnail via canvas/createImageBitmap, which jsdom
+// does not implement. Stub the image helpers so the tests exercise the real
+// IndexedDB logic (the point of this module) rather than canvas rendering.
+vi.mock('./image-utils', () => ({
+  compressImage: (blob: Blob) => Promise.resolve(blob),
+  blobToDataUrl: () => Promise.resolve('data:image/jpeg;base64,dGh1bWI='),
+}));
+
+import {
+  deletePuzzle,
+  getPuzzleBlob,
+  listPuzzles,
+  renamePuzzle,
+  savePuzzle,
+} from './puzzle-library';
+
+const blob = (marker: string) => new Blob([marker], { type: 'image/jpeg' });
+
+describe('puzzle-library', () => {
+  beforeEach(() => {
+    // Fresh, isolated IndexedDB per test.
+    indexedDB = new IDBFactory();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('saves a puzzle and returns metadata with a thumbnail', async () => {
+    const meta = await savePuzzle(blob('a'), 'Puzzle 1');
+    expect(meta.name).toBe('Puzzle 1');
+    expect(meta.id).toBeTruthy();
+    expect(meta.thumbnail).toContain('data:image/jpeg');
+    expect(typeof meta.createdAt).toBe('number');
+  });
+
+  it('lists saved puzzles newest first', async () => {
+    const now = vi.spyOn(Date, 'now');
+    now.mockReturnValue(1000);
+    const first = await savePuzzle(blob('a'), 'First');
+    now.mockReturnValue(2000);
+    const second = await savePuzzle(blob('b'), 'Second');
+
+    const list = await listPuzzles();
+    expect(list.map((p) => p.id)).toEqual([second.id, first.id]);
+    // Metadata list carries no image blob.
+    expect(list[0]).not.toHaveProperty('blob');
+  });
+
+  it('retrieves the stored image for a known id', async () => {
+    const meta = await savePuzzle(blob('hello'), 'P');
+    // The image lives in a separate store keyed by the same id; a known id
+    // round-trips a value, an unknown one (below) yields null.
+    expect(await getPuzzleBlob(meta.id)).not.toBeNull();
+  });
+
+  it('returns null for an unknown blob id', async () => {
+    expect(await getPuzzleBlob('does-not-exist')).toBeNull();
+  });
+
+  it('renames a saved puzzle', async () => {
+    const meta = await savePuzzle(blob('a'), 'Old');
+    await renamePuzzle(meta.id, 'New');
+    const list = await listPuzzles();
+    expect(list.find((p) => p.id === meta.id)?.name).toBe('New');
+  });
+
+  it('no-ops when renaming an unknown id', async () => {
+    await savePuzzle(blob('a'), 'Keep');
+    await expect(renamePuzzle('missing', 'X')).resolves.toBeUndefined();
+    const list = await listPuzzles();
+    expect(list.map((p) => p.name)).toEqual(['Keep']);
+  });
+
+  it('deletes both metadata and image', async () => {
+    const meta = await savePuzzle(blob('a'), 'P');
+    await deletePuzzle(meta.id);
+    expect(await listPuzzles()).toEqual([]);
+    expect(await getPuzzleBlob(meta.id)).toBeNull();
+  });
+});

--- a/frontend/src/lib/puzzle-library.test.ts
+++ b/frontend/src/lib/puzzle-library.test.ts
@@ -5,7 +5,7 @@ import { IDBFactory } from 'fake-indexeddb';
 // savePuzzle generates a thumbnail via canvas/createImageBitmap, which jsdom
 // does not implement. Stub the image helpers so the tests exercise the real
 // IndexedDB logic (the point of this module) rather than canvas rendering.
-vi.mock('./image-utils', () => ({
+vi.mock('@/lib/image-utils', () => ({
   compressImage: (blob: Blob) => Promise.resolve(blob),
   blobToDataUrl: () => Promise.resolve('data:image/jpeg;base64,dGh1bWI='),
 }));

--- a/frontend/src/lib/puzzle-library.ts
+++ b/frontend/src/lib/puzzle-library.ts
@@ -34,6 +34,17 @@ interface ImageRecord {
   blob: Blob;
 }
 
+/**
+ * Generate a unique id, falling back when `crypto.randomUUID` is unavailable
+ * (older browsers or insecure/non-HTTPS contexts) so saving never throws.
+ */
+function generateId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `puzzle-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 function openDb(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, DB_VERSION);
@@ -77,7 +88,7 @@ export async function savePuzzle(blob: Blob, name: string): Promise<SavedPuzzleM
   const thumbnailBlob = await compressImage(blob, THUMBNAIL_MAX_WIDTH, THUMBNAIL_QUALITY);
   const thumbnail = await blobToDataUrl(thumbnailBlob);
   const meta: SavedPuzzleMeta = {
-    id: crypto.randomUUID(),
+    id: generateId(),
     name,
     thumbnail,
     createdAt: Date.now(),

--- a/frontend/src/lib/puzzle-library.ts
+++ b/frontend/src/lib/puzzle-library.ts
@@ -1,0 +1,156 @@
+/**
+ * Client-side library of previously captured real puzzles.
+ *
+ * Persists the trimmed puzzle image on the device (IndexedDB) so that, in real
+ * mode, a user can re-select a puzzle they already photographed instead of
+ * re-taking the photo. Blobs live in a separate object store from the light
+ * metadata so listing the gallery never has to pull full-resolution images
+ * into memory.
+ *
+ * Storage is per-device/per-browser. The saved image is re-uploaded to the
+ * backend on reuse to obtain a fresh puzzle_id, so a persisted entry keeps
+ * working across backend restarts and redeploys.
+ */
+import { blobToDataUrl, compressImage } from '@/lib/image-utils';
+
+const DB_NAME = 'pussel';
+const DB_VERSION = 1;
+const META_STORE = 'puzzle-meta';
+const IMAGE_STORE = 'puzzle-images';
+
+const THUMBNAIL_MAX_WIDTH = 320;
+const THUMBNAIL_QUALITY = 0.6;
+
+/** Lightweight record used to render the gallery (no full image). */
+export interface SavedPuzzleMeta {
+  id: string;
+  name: string;
+  thumbnail: string; // small data URL for the gallery card
+  createdAt: number; // epoch ms
+}
+
+interface ImageRecord {
+  id: string;
+  blob: Blob;
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(META_STORE)) {
+        db.createObjectStore(META_STORE, { keyPath: 'id' });
+      }
+      if (!db.objectStoreNames.contains(IMAGE_STORE)) {
+        db.createObjectStore(IMAGE_STORE, { keyPath: 'id' });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function promisifyTx(tx: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  });
+}
+
+function promisifyRequest<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/**
+ * Persist a trimmed puzzle image and return its gallery metadata.
+ *
+ * @param blob - The trimmed puzzle image to store (as uploaded to the backend).
+ * @param name - Display name for the gallery card.
+ * @returns The saved metadata, including a generated thumbnail.
+ */
+export async function savePuzzle(blob: Blob, name: string): Promise<SavedPuzzleMeta> {
+  const thumbnailBlob = await compressImage(blob, THUMBNAIL_MAX_WIDTH, THUMBNAIL_QUALITY);
+  const thumbnail = await blobToDataUrl(thumbnailBlob);
+  const meta: SavedPuzzleMeta = {
+    id: crypto.randomUUID(),
+    name,
+    thumbnail,
+    createdAt: Date.now(),
+  };
+
+  const db = await openDb();
+  try {
+    const tx = db.transaction([META_STORE, IMAGE_STORE], 'readwrite');
+    tx.objectStore(META_STORE).put(meta);
+    tx.objectStore(IMAGE_STORE).put({ id: meta.id, blob } satisfies ImageRecord);
+    await promisifyTx(tx);
+  } finally {
+    db.close();
+  }
+
+  return meta;
+}
+
+/** List saved puzzles, newest first. Reads metadata only (no image blobs). */
+export async function listPuzzles(): Promise<SavedPuzzleMeta[]> {
+  const db = await openDb();
+  try {
+    const tx = db.transaction(META_STORE, 'readonly');
+    const all = await promisifyRequest(
+      tx.objectStore(META_STORE).getAll() as IDBRequest<SavedPuzzleMeta[]>
+    );
+    return all.sort((a, b) => b.createdAt - a.createdAt);
+  } finally {
+    db.close();
+  }
+}
+
+/** Fetch the full-resolution image blob for a saved puzzle, or null if missing. */
+export async function getPuzzleBlob(id: string): Promise<Blob | null> {
+  const db = await openDb();
+  try {
+    const tx = db.transaction(IMAGE_STORE, 'readonly');
+    const record = await promisifyRequest(
+      tx.objectStore(IMAGE_STORE).get(id) as IDBRequest<ImageRecord | undefined>
+    );
+    return record?.blob ?? null;
+  } finally {
+    db.close();
+  }
+}
+
+/** Delete a saved puzzle (both metadata and image). */
+export async function deletePuzzle(id: string): Promise<void> {
+  const db = await openDb();
+  try {
+    const tx = db.transaction([META_STORE, IMAGE_STORE], 'readwrite');
+    tx.objectStore(META_STORE).delete(id);
+    tx.objectStore(IMAGE_STORE).delete(id);
+    await promisifyTx(tx);
+  } finally {
+    db.close();
+  }
+}
+
+/** Rename a saved puzzle. No-op if the id is unknown. */
+export async function renamePuzzle(id: string, name: string): Promise<void> {
+  const db = await openDb();
+  try {
+    const tx = db.transaction(META_STORE, 'readwrite');
+    const store = tx.objectStore(META_STORE);
+    const existing = await promisifyRequest(
+      store.get(id) as IDBRequest<SavedPuzzleMeta | undefined>
+    );
+    if (existing) {
+      store.put({ ...existing, name });
+    }
+    await promisifyTx(tx);
+  } finally {
+    db.close();
+  }
+}


### PR DESCRIPTION
## Summary

Real mode required re-photographing the full puzzle every session. This persists the trimmed puzzle image **client-side (IndexedDB)** so users can pick a previously captured puzzle from a gallery instead of taking a new photo.

When entering **Solve Real Puzzle**, if you've captured puzzles before, an **"Or reuse a saved puzzle"** gallery appears under the camera button. Tapping a thumbnail re-uploads the stored image and jumps straight to solving — no camera, trim, or corner steps. New captures are saved automatically after a successful upload.

## Changes

- **`frontend/src/lib/puzzle-library.ts`** — dependency-free IndexedDB wrapper. Light metadata store (`id`/`name`/`thumbnail`/`createdAt`) kept separate from full-resolution image blobs, so listing the gallery never pulls megabytes into memory. Exposes `save`/`list`/`getBlob`/`delete`/`rename`.
- **`frontend/src/hooks/use-saved-puzzles.ts`** — hook that loads the gallery on mount and stays in sync on save/rename/delete.
- **`frontend/src/components/puzzle/saved-puzzle-gallery.tsx`** — thumbnail grid with hover-to-delete.
- **`frontend/src/app/real/page.tsx`** — saves the trimmed puzzle after a successful upload; `handleSelectSaved` loads the blob, re-uploads it, and goes to solving.

## Design decisions

- **IndexedDB, not localStorage** — the trimmed image can approach the 10 MB upload cap; localStorage's ~5 MB string limit is too small.
- **Re-upload on reuse** — the backend's `puzzle_images` map is in-memory and `uploads/` is ephemeral on Azure, so a persisted `puzzle_id` would 404 after a restart. Re-uploading the stored blob (a few hundred KB, instant) sidesteps that and needs **zero backend changes**.
- **Non-blocking save** — if IndexedDB is unavailable/full, solving still proceeds; the save just no-ops.
- **Trade-off:** saved puzzles are per-device/per-browser (no cross-device sync). The gallery UI is source-agnostic, so a future backend-backed source can drop in without UI changes.

## Testing

- `bun run check` (oxlint type-aware + tsc + prettier) passes.
- Verified end-to-end in the browser: capture → save; gallery lists the saved puzzle; selecting it re-uploads and lands in solving with the piece-prediction pipeline running; delete works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)