### PR TITLE
Wire backend to exp20 4x4 checkpoint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
       - id: backend-pyright
         name: backend pyright type checking
         description: Run pyright type checking for backend
-        entry: bash -c 'cd backend && pyright .'
+        entry: bash -c 'cd backend && uv run pyright .'
         language: system
         files: ^backend/.*\.py$
         pass_filenames: false

--- a/backend/app/models/model.py
+++ b/backend/app/models/model.py
@@ -1,21 +1,79 @@
-"""FastBackboneModel for 3x3 grid puzzle piece matching.
+"""FastBackboneModel for 4x4 grid puzzle piece matching (exp20).
 
-This model predicts both position (which of 9 cells) and rotation of a puzzle piece
-by comparing the piece features with puzzle features using ShuffleNetV2_x0.5 backbone.
+Vendored from ``network/experiments/exp20_realistic_pieces/model.py`` so the
+backend can load the exp20 checkpoint. The model predicts a continuous
+position ``(x, y) in [0, 1]`` plus a 4-class rotation by comparing piece and
+puzzle features with a ShuffleNetV2_x0.5 backbone.
 
-Architecture:
-- Dual ShuffleNetV2_x0.5 backbones (piece + puzzle)
-- Spatial correlation for position prediction
-- Rotation correlation for rotation prediction (0/90/180/270)
-
-Performance: 82% cell accuracy, 95% rotation accuracy on 3x3 grids.
+Key features:
+- 4x4 grid (16 cells) trained on realistic puzzle pieces
+- predict_cell() maps the continuous position to a 16-class cell index
+- Coordinate regression (continuous x, y output)
 """
 
+from typing import Literal
+
+import timm  # type: ignore
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torchvision import models
 from torchvision.models import ShuffleNet_V2_X0_5_Weights
+
+BackboneType = Literal["repvgg_a0", "mobileone_s0", "shufflenet_v2_x0_5", "mobilenet_v3_small"]
+
+
+def get_backbone(backbone_name: BackboneType, pretrained: bool = True) -> tuple[nn.Module, int]:
+    """Create a backbone network and return it with its feature dimension.
+
+    Args:
+        backbone_name: Name of the backbone to use.
+        pretrained: Whether to use pretrained weights.
+
+    Returns:
+        Tuple of (backbone_module, feature_dim).
+    """
+    if backbone_name == "repvgg_a0":
+        model = timm.create_model("repvgg_a0", pretrained=pretrained, features_only=True)
+        with torch.no_grad():
+            dummy = torch.zeros(1, 3, 224, 224)
+            features = model(dummy)[-1]
+            feature_dim = features.shape[1]
+        return model, feature_dim
+
+    elif backbone_name == "mobileone_s0":
+        model = timm.create_model("mobileone_s0", pretrained=pretrained, features_only=True)
+        with torch.no_grad():
+            dummy = torch.zeros(1, 3, 224, 224)
+            features = model(dummy)[-1]
+            feature_dim = features.shape[1]
+        return model, feature_dim
+
+    elif backbone_name == "shufflenet_v2_x0_5":
+        weights = ShuffleNet_V2_X0_5_Weights.IMAGENET1K_V1 if pretrained else None
+        full_model = models.shufflenet_v2_x0_5(weights=weights)
+        backbone = nn.Sequential(
+            full_model.conv1,
+            full_model.maxpool,
+            full_model.stage2,
+            full_model.stage3,
+            full_model.stage4,
+            full_model.conv5,
+        )
+        feature_dim = 1024
+        return backbone, feature_dim
+
+    elif backbone_name == "mobilenet_v3_small":
+        from torchvision.models import MobileNet_V3_Small_Weights
+
+        weights = MobileNet_V3_Small_Weights.IMAGENET1K_V1 if pretrained else None
+        full_model = models.mobilenet_v3_small(weights=weights)
+        backbone = full_model.features
+        feature_dim = 576
+        return backbone, feature_dim
+
+    else:
+        raise ValueError(f"Unknown backbone: {backbone_name}")
 
 
 class SpatialCorrelationModule(nn.Module):
@@ -23,17 +81,11 @@ class SpatialCorrelationModule(nn.Module):
 
     def __init__(
         self,
-        feature_dim: int = 1024,
+        feature_dim: int = 576,
         correlation_dim: int = 128,
         dropout: float = 0.1,
     ):
-        """Initialize the spatial correlation module.
-
-        Args:
-            feature_dim: Feature dimension from backbones.
-            correlation_dim: Reduced dimension for correlation computation.
-            dropout: Dropout rate for regularization.
-        """
+        """Initialize the spatial correlation module."""
         super().__init__()
 
         self.piece_proj = nn.Sequential(
@@ -49,17 +101,7 @@ class SpatialCorrelationModule(nn.Module):
         self.temperature = nn.Parameter(torch.ones(1) * (correlation_dim**0.5))
 
     def forward(self, piece_feat: torch.Tensor, puzzle_feat_map: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        """Compute spatial correlation between piece and puzzle.
-
-        Args:
-            piece_feat: Piece feature vector (B, feature_dim).
-            puzzle_feat_map: Puzzle spatial features (B, feature_dim, H, W).
-
-        Returns:
-            Tuple of:
-                - attention_map: Softmax attention over puzzle locations (B, 1, H, W)
-                - expected_position: Weighted average position (B, 2)
-        """
+        """Compute spatial correlation between piece and puzzle."""
         batch_size = piece_feat.shape[0]
         _, _, h, w = puzzle_feat_map.shape
 
@@ -88,28 +130,15 @@ class SpatialCorrelationModule(nn.Module):
 
 
 class RotationCorrelationModule(nn.Module):
-    """Rotation prediction via correlation between piece and puzzle.
-
-    For each rotation r in [0, 90, 180, 270]:
-        1. Rotate the piece feature map by r degrees
-        2. Extract the puzzle region at the predicted position
-        3. Compute similarity between rotated piece and puzzle region
-        4. The rotation with highest similarity is the prediction
-    """
+    """Rotation prediction via correlation between piece and puzzle."""
 
     def __init__(
         self,
-        feature_dim: int = 1024,
+        feature_dim: int = 576,
         hidden_dim: int = 128,
         dropout: float = 0.2,
     ):
-        """Initialize the rotation correlation module.
-
-        Args:
-            feature_dim: Feature dimension from backbones.
-            hidden_dim: Hidden dimension for comparison network.
-            dropout: Dropout rate for regularization.
-        """
+        """Initialize the rotation correlation module."""
         super().__init__()
         self.feature_dim = feature_dim
 
@@ -141,15 +170,7 @@ class RotationCorrelationModule(nn.Module):
         )
 
     def _rotate_feature_map(self, feat_map: torch.Tensor, rotation_idx: int) -> torch.Tensor:
-        """Rotate a feature map by 0, 90, 180, or 270 degrees.
-
-        Args:
-            feat_map: Feature map of shape (B, C, H, W).
-            rotation_idx: Rotation index (0=0deg, 1=90deg, 2=180deg, 3=270deg).
-
-        Returns:
-            Rotated feature map of shape (B, C, H, W).
-        """
+        """Rotate a feature map by 0, 90, 180, or 270 degrees."""
         if rotation_idx == 0:
             return feat_map
         elif rotation_idx == 1:
@@ -164,17 +185,15 @@ class RotationCorrelationModule(nn.Module):
         puzzle_feat_map: torch.Tensor,
         position: torch.Tensor,
         target_size: tuple[int, int],
-        grid_size: int = 3,
+        grid_size: int = 4,  # Changed from 3 to 4 for exp20
     ) -> torch.Tensor:
         """Extract puzzle region at the predicted position using grid indexing.
-
-        For 3x3 grid, this extracts the cell at the predicted position.
 
         Args:
             puzzle_feat_map: Feature map of the puzzle [B, C, H, W].
             position: Predicted position [B, 2] with (x, y) in [0, 1].
             target_size: Target size (h, w) for the extracted region.
-            grid_size: Grid size (3 for 3x3 grid).
+            grid_size: Grid size (4 for 4x4 grid).
 
         Returns:
             Extracted regions [B, C, h, w].
@@ -183,7 +202,6 @@ class RotationCorrelationModule(nn.Module):
         _, c, h_puzzle, w_puzzle = puzzle_feat_map.shape
         h_piece, w_piece = target_size
 
-        # Compute grid cell indices from position
         x_idx = torch.clamp((position[:, 0] * grid_size).long(), 0, grid_size - 1)
         y_idx = torch.clamp((position[:, 1] * grid_size).long(), 0, grid_size - 1)
 
@@ -219,16 +237,7 @@ class RotationCorrelationModule(nn.Module):
         puzzle_feat_map: torch.Tensor,
         position: torch.Tensor,
     ) -> torch.Tensor:
-        """Compute rotation scores by comparing piece to puzzle.
-
-        Args:
-            piece_feat_map: Piece spatial features (B, C, H_piece, W_piece).
-            puzzle_feat_map: Puzzle spatial features (B, C, H_puzzle, W_puzzle).
-            position: Predicted position (B, 2) in [0, 1] coords.
-
-        Returns:
-            Rotation logits (B, 4) for rotations [0, 90, 180, 270].
-        """
+        """Compute rotation scores by comparing piece to puzzle."""
         _, _, h_piece, w_piece = piece_feat_map.shape
 
         puzzle_region = self._extract_region(puzzle_feat_map, position, (h_piece, w_piece))
@@ -247,13 +256,17 @@ class RotationCorrelationModule(nn.Module):
 
 
 class FastBackboneModel(nn.Module):
-    """Model with ShuffleNetV2_x0.5 backbone for 3x3 grid puzzle solving.
+    """Model with configurable fast backbone for experimentation.
 
-    Achieves 82% cell accuracy and 95% rotation accuracy on 3x3 grids.
+    Supports multiple backbone architectures for speed comparison while
+    maintaining the rotation correlation architecture.
+
+    Adapted for 4x4 grid (16 cells) in exp20.
     """
 
     def __init__(
         self,
+        backbone_name: BackboneType = "shufflenet_v2_x0_5",
         pretrained: bool = True,
         correlation_dim: int = 128,
         rotation_hidden_dim: int = 128,
@@ -261,9 +274,10 @@ class FastBackboneModel(nn.Module):
         dropout: float = 0.1,
         rotation_dropout: float = 0.2,
     ):
-        """Initialize the model with ShuffleNetV2_x0.5 backbone.
+        """Initialize the model with specified backbone.
 
         Args:
+            backbone_name: Which backbone to use.
             pretrained: Whether to use pretrained weights.
             correlation_dim: Dimension for position correlation.
             rotation_hidden_dim: Hidden dimension for rotation comparison.
@@ -272,31 +286,12 @@ class FastBackboneModel(nn.Module):
             rotation_dropout: Dropout rate for rotation head.
         """
         super().__init__()
+        self.backbone_name = backbone_name
         self.freeze_backbone_flag = freeze_backbone
-        self.feature_dim = 1024  # ShuffleNetV2 x0.5 final conv outputs 1024 channels
 
-        # Create ShuffleNetV2 backbones
-        weights = ShuffleNet_V2_X0_5_Weights.IMAGENET1K_V1 if pretrained else None
-        piece_model = models.shufflenet_v2_x0_5(weights=weights)
-        puzzle_model = models.shufflenet_v2_x0_5(weights=weights)
-
-        # Extract feature extractor (everything before final FC)
-        self.piece_backbone = nn.Sequential(
-            piece_model.conv1,
-            piece_model.maxpool,
-            piece_model.stage2,
-            piece_model.stage3,
-            piece_model.stage4,
-            piece_model.conv5,
-        )
-        self.puzzle_backbone = nn.Sequential(
-            puzzle_model.conv1,
-            puzzle_model.maxpool,
-            puzzle_model.stage2,
-            puzzle_model.stage3,
-            puzzle_model.stage4,
-            puzzle_model.conv5,
-        )
+        # Create backbone
+        self.piece_backbone, self.feature_dim = get_backbone(backbone_name, pretrained)
+        self.puzzle_backbone, _ = get_backbone(backbone_name, pretrained)
 
         # Global pooling
         self.piece_pool = nn.AdaptiveAvgPool2d(1)
@@ -336,22 +331,30 @@ class FastBackboneModel(nn.Module):
         for param in self.puzzle_backbone.parameters():
             param.requires_grad = False
 
+    def _extract_features(self, backbone: nn.Module, x: torch.Tensor) -> torch.Tensor:
+        """Extract features from backbone, handling different output formats."""
+        if self.backbone_name in ["repvgg_a0", "mobileone_s0"]:
+            features = backbone(x)
+            return features[-1]
+        else:
+            return backbone(x)
+
     def forward(self, piece: torch.Tensor, puzzle: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Forward pass.
 
         Args:
-            piece: Piece image tensor of shape (batch, 3, 128, 128).
-            puzzle: Puzzle image tensor of shape (batch, 3, 256, 256).
+            piece: Piece image tensor [B, 3, H, W].
+            puzzle: Puzzle image tensor [B, 3, H, W].
 
         Returns:
-            Tuple of:
-                - position: Predicted (cx, cy) coordinates (batch, 2) in [0, 1]
-                - rotation_logits: Rotation class logits (batch, 4)
-                - attention_map: Correlation map over puzzle (batch, 1, H, W)
+            Tuple of (position, rotation_logits, attention_map).
+            - position: Continuous (x, y) coordinates in [0, 1]
+            - rotation_logits: Logits for 4-class rotation classification
+            - attention_map: Spatial attention over puzzle
         """
         # Extract spatial features
-        puzzle_feat_map = self.puzzle_backbone(puzzle)
-        piece_feat_map = self.piece_backbone(piece)
+        puzzle_feat_map = self._extract_features(self.puzzle_backbone, puzzle)
+        piece_feat_map = self._extract_features(self.piece_backbone, piece)
 
         # Pool piece features for position correlation
         piece_feat = self.piece_pool(piece_feat_map).flatten(1)
@@ -372,20 +375,112 @@ class FastBackboneModel(nn.Module):
 
         return position, rotation_logits, attention_map
 
-    def predict_cell(self, piece: torch.Tensor, puzzle: torch.Tensor, grid_size: int = 3) -> torch.Tensor:
+    @staticmethod
+    def positions_to_cells(position: torch.Tensor, grid_size: int = 4) -> torch.Tensor:
+        """Convert predicted (cx, cy) positions to grid cell indices.
+
+        Args:
+            position: Tensor of shape (batch, 2) with normalized (cx, cy).
+            grid_size: Size of the grid (4 for 4x4 grid).
+
+        Returns:
+            Cell indices (0 to grid_size*grid_size - 1).
+        """
+        cx, cy = position[:, 0], position[:, 1]
+        col_idx = torch.clamp((cx * grid_size).long(), 0, grid_size - 1)
+        row_idx = torch.clamp((cy * grid_size).long(), 0, grid_size - 1)
+        return row_idx * grid_size + col_idx
+
+    def predict_cell(self, piece: torch.Tensor, puzzle: torch.Tensor, grid_size: int = 4) -> torch.Tensor:
         """Predict which cell the piece belongs to in a grid.
 
         Args:
             piece: Piece image tensor.
             puzzle: Puzzle image tensor.
-            grid_size: Size of the grid (3 for 3x3 grid).
+            grid_size: Size of the grid (4 for 4x4 grid).
 
         Returns:
             Cell indices (0 to grid_size*grid_size - 1).
         """
         position, _, _ = self.forward(piece, puzzle)
-        cx, cy = position[:, 0], position[:, 1]
-        col_idx = torch.clamp((cx * grid_size).long(), 0, grid_size - 1)
-        row_idx = torch.clamp((cy * grid_size).long(), 0, grid_size - 1)
-        cell = row_idx * grid_size + col_idx
-        return cell
+        return self.positions_to_cells(position, grid_size)
+
+    def get_parameter_groups(
+        self,
+        backbone_lr: float = 1e-5,
+        head_lr: float = 1e-3,
+        weight_decay: float = 1e-4,
+    ) -> list[dict]:
+        """Get parameter groups with differential learning rates."""
+        backbone_params = [p for p in self.piece_backbone.parameters() if p.requires_grad]
+        backbone_params += [p for p in self.puzzle_backbone.parameters() if p.requires_grad]
+
+        head_params = [p for p in self.spatial_correlation.parameters() if p.requires_grad]
+        head_params += [p for p in self.refinement.parameters() if p.requires_grad]
+        head_params += [p for p in self.rotation_correlation.parameters() if p.requires_grad]
+
+        param_groups = []
+        if backbone_params:
+            param_groups.append(
+                {
+                    "params": backbone_params,
+                    "lr": backbone_lr,
+                    "weight_decay": weight_decay,
+                    "name": "backbone",
+                }
+            )
+        if head_params:
+            param_groups.append(
+                {
+                    "params": head_params,
+                    "lr": head_lr,
+                    "weight_decay": weight_decay,
+                    "name": "heads",
+                }
+            )
+
+        return param_groups
+
+
+def count_parameters(model: nn.Module, trainable_only: bool = True) -> int:
+    """Count parameters in the model."""
+    if trainable_only:
+        return sum(p.numel() for p in model.parameters() if p.requires_grad)
+    return sum(p.numel() for p in model.parameters())
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("Fast Backbone Model Test (Exp20 - 4x4 Grid)")
+    print("=" * 60)
+
+    batch_size = 4
+    piece_size = 128
+    puzzle_size = 256
+
+    dummy_piece = torch.randn(batch_size, 3, piece_size, piece_size)
+    dummy_puzzle = torch.randn(batch_size, 3, puzzle_size, puzzle_size)
+
+    # Test default backbone (ShuffleNetV2)
+    backbone_name: BackboneType = "shufflenet_v2_x0_5"
+    print(f"\n--- {backbone_name} ---")
+
+    model = FastBackboneModel(backbone_name=backbone_name, pretrained=True)
+    total_params = count_parameters(model, trainable_only=False)
+    trainable_params = count_parameters(model, trainable_only=True)
+
+    print(f"Feature dimension: {model.feature_dim}")
+    print(f"Total parameters: {total_params:,}")
+    print(f"Trainable parameters: {trainable_params:,}")
+
+    # Test forward pass
+    position, rotation_logits, attention = model(dummy_piece, dummy_puzzle)
+    print(f"Position shape: {position.shape}")
+    print(f"Rotation logits shape: {rotation_logits.shape}")
+    print(f"Attention shape: {attention.shape}")
+
+    # Test cell prediction for 4x4 grid
+    cells = model.predict_cell(dummy_piece, dummy_puzzle, grid_size=4)
+    print(f"Predicted cells: {cells.tolist()}")
+    print("Cell range: 0-15 (4x4 grid)")
+    print("Forward pass: OK")

--- a/backend/app/models/model.py
+++ b/backend/app/models/model.py
@@ -333,7 +333,7 @@ class FastBackboneModel(nn.Module):
 
     def _extract_features(self, backbone: nn.Module, x: torch.Tensor) -> torch.Tensor:
         """Extract features from backbone, handling different output formats."""
-        if self.backbone_name in ["repvgg_a0", "mobileone_s0"]:
+        if self.backbone_name in ("repvgg_a0", "mobileone_s0"):
             features = backbone(x)
             return features[-1]
         else:
@@ -405,82 +405,5 @@ class FastBackboneModel(nn.Module):
         position, _, _ = self.forward(piece, puzzle)
         return self.positions_to_cells(position, grid_size)
 
-    def get_parameter_groups(
-        self,
-        backbone_lr: float = 1e-5,
-        head_lr: float = 1e-3,
-        weight_decay: float = 1e-4,
-    ) -> list[dict]:
-        """Get parameter groups with differential learning rates."""
-        backbone_params = [p for p in self.piece_backbone.parameters() if p.requires_grad]
-        backbone_params += [p for p in self.puzzle_backbone.parameters() if p.requires_grad]
-
-        head_params = [p for p in self.spatial_correlation.parameters() if p.requires_grad]
-        head_params += [p for p in self.refinement.parameters() if p.requires_grad]
-        head_params += [p for p in self.rotation_correlation.parameters() if p.requires_grad]
-
-        param_groups = []
-        if backbone_params:
-            param_groups.append(
-                {
-                    "params": backbone_params,
-                    "lr": backbone_lr,
-                    "weight_decay": weight_decay,
-                    "name": "backbone",
-                }
-            )
-        if head_params:
-            param_groups.append(
-                {
-                    "params": head_params,
-                    "lr": head_lr,
-                    "weight_decay": weight_decay,
-                    "name": "heads",
-                }
-            )
-
-        return param_groups
-
-
-def count_parameters(model: nn.Module, trainable_only: bool = True) -> int:
-    """Count parameters in the model."""
-    if trainable_only:
-        return sum(p.numel() for p in model.parameters() if p.requires_grad)
-    return sum(p.numel() for p in model.parameters())
-
-
-if __name__ == "__main__":
-    print("=" * 60)
-    print("Fast Backbone Model Test (Exp20 - 4x4 Grid)")
-    print("=" * 60)
-
-    batch_size = 4
-    piece_size = 128
-    puzzle_size = 256
-
-    dummy_piece = torch.randn(batch_size, 3, piece_size, piece_size)
-    dummy_puzzle = torch.randn(batch_size, 3, puzzle_size, puzzle_size)
-
-    # Test default backbone (ShuffleNetV2)
-    backbone_name: BackboneType = "shufflenet_v2_x0_5"
-    print(f"\n--- {backbone_name} ---")
-
-    model = FastBackboneModel(backbone_name=backbone_name, pretrained=True)
-    total_params = count_parameters(model, trainable_only=False)
-    trainable_params = count_parameters(model, trainable_only=True)
-
-    print(f"Feature dimension: {model.feature_dim}")
-    print(f"Total parameters: {total_params:,}")
-    print(f"Trainable parameters: {trainable_params:,}")
-
-    # Test forward pass
-    position, rotation_logits, attention = model(dummy_piece, dummy_puzzle)
-    print(f"Position shape: {position.shape}")
-    print(f"Rotation logits shape: {rotation_logits.shape}")
-    print(f"Attention shape: {attention.shape}")
-
-    # Test cell prediction for 4x4 grid
-    cells = model.predict_cell(dummy_piece, dummy_puzzle, grid_size=4)
-    print(f"Predicted cells: {cells.tolist()}")
     print("Cell range: 0-15 (4x4 grid)")
     print("Forward pass: OK")

--- a/backend/app/models/model.py
+++ b/backend/app/models/model.py
@@ -13,7 +13,7 @@ Key features:
 
 from typing import Literal
 
-import timm  # type: ignore
+import timm  # type: ignore[import-untyped]
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/backend/app/services/image_processor.py
+++ b/backend/app/services/image_processor.py
@@ -8,7 +8,7 @@ import base64
 import io
 import os
 from pathlib import Path
-from typing import Optional, cast
+from typing import Any, Optional, cast
 from uuid import UUID
 
 import torch
@@ -38,6 +38,43 @@ CHECKPOINT_PATH = os.environ.get("MODEL_CHECKPOINT_PATH", DEFAULT_CHECKPOINT_PAT
 # Image sizes expected by the model
 PIECE_SIZE = 128
 PUZZLE_SIZE = 256
+
+
+def _extract_state_dict(checkpoint: Any) -> Any:
+    """Return the model weights from a loaded checkpoint.
+
+    Supports both a raw ``state_dict`` (exp20's ``checkpoint_best.pt``) and a
+    ``{"model_state_dict": ...}`` wrapper (exp18-style checkpoints).
+
+    Args:
+        checkpoint: The object returned by ``torch.load``.
+
+    Returns:
+        The model ``state_dict`` mapping.
+    """
+    if isinstance(checkpoint, dict) and "model_state_dict" in checkpoint:
+        return checkpoint["model_state_dict"]
+    return checkpoint
+
+
+def _load_checkpoint(path: str, device: torch.device) -> Any:
+    """Load a checkpoint file, preferring the safe ``weights_only`` path.
+
+    Modern checkpoints (including exp20's raw tensor ``state_dict``) load with
+    ``weights_only=True``, which avoids arbitrary pickle execution. Legacy
+    checkpoints that pickle non-tensor objects fall back to a full load.
+
+    Args:
+        path: Filesystem path to the checkpoint.
+        device: Device to map tensors onto.
+
+    Returns:
+        The loaded checkpoint object.
+    """
+    try:
+        return torch.load(path, map_location=device, weights_only=True)
+    except Exception:  # noqa: BLE001 - fall back for legacy pickled checkpoints
+        return torch.load(path, map_location=device, weights_only=False)
 
 
 class ImageProcessor:
@@ -79,9 +116,9 @@ class ImageProcessor:
 
         Returns:
             The loaded model in evaluation mode, or None when no checkpoint is
-            available. Without a model, ``process_piece`` returns a neutral
-            fallback prediction so the app still runs (e.g. in CI, where the
-            checkpoint is not committed).
+            available or fails to load. Without a model, ``process_piece``
+            returns a neutral fallback prediction so the app still runs (e.g. in
+            CI, where the checkpoint is not committed).
         """
         if not os.path.exists(CHECKPOINT_PATH):
             print(f"Model checkpoint not found at {CHECKPOINT_PATH}; predictions will use a neutral fallback")
@@ -98,11 +135,17 @@ class ImageProcessor:
             rotation_dropout=0.2,
         )
 
-        # Load checkpoint. Some checkpoints wrap the weights in a "model_state_dict"
-        # key (exp18-style); exp20's checkpoint_best.pt is a raw state dict.
-        checkpoint = torch.load(CHECKPOINT_PATH, map_location=self.device, weights_only=False)
-        state_dict = checkpoint["model_state_dict"] if "model_state_dict" in checkpoint else checkpoint
-        model.load_state_dict(state_dict)
+        # Load onto CPU first, then move the whole model to the target device in
+        # one transfer. A corrupt or incompatible checkpoint falls back to the
+        # neutral prediction path rather than crashing ImageProcessor init.
+        try:
+            checkpoint = _load_checkpoint(CHECKPOINT_PATH, torch.device("cpu"))
+            model.load_state_dict(_extract_state_dict(checkpoint))
+        except Exception as exc:  # noqa: BLE001 - degrade gracefully on any load failure
+            print(
+                f"Failed to load model checkpoint at {CHECKPOINT_PATH} ({exc}); predictions will use a neutral fallback"
+            )
+            return None
 
         model.to(self.device)
         model.eval()

--- a/backend/app/services/image_processor.py
+++ b/backend/app/services/image_processor.py
@@ -1,7 +1,7 @@
 """Service module for processing puzzle pieces and matching them to puzzles.
 
 Uses FastBackboneModel that compares piece features with puzzle features
-to predict position (3x3 grid) and rotation.
+to predict position (4x4 grid) and rotation.
 """
 
 import base64
@@ -24,12 +24,12 @@ from app.models.puzzle_model import PieceResponse, Position
 from app.services.background_remover import get_background_remover
 from app.services.piece_detector import crop_to_alpha_region
 
-# Path to checkpoint (3x3 grid model with 82% cell accuracy, 95% rotation accuracy)
+# Path to checkpoint (exp20 4x4 grid model, realistic pieces, ~72.9% cell accuracy)
 DEFAULT_CHECKPOINT_PATH = str(
     Path(__file__).resolve().parents[3]
     / "network"
     / "experiments"
-    / "exp18_3x3_20k_puzzles"
+    / "exp20_realistic_pieces"
     / "outputs"
     / "checkpoint_best.pt"
 )
@@ -87,8 +87,9 @@ class ImageProcessor:
             print(f"Model checkpoint not found at {CHECKPOINT_PATH}; predictions will use a neutral fallback")
             return None
 
-        # Initialize model with same config as training
+        # Initialize model with same config as exp20 training
         model = FastBackboneModel(
+            backbone_name="shufflenet_v2_x0_5",
             pretrained=False,  # We'll load weights from checkpoint
             correlation_dim=128,
             rotation_hidden_dim=128,
@@ -97,9 +98,11 @@ class ImageProcessor:
             rotation_dropout=0.2,
         )
 
-        # Load checkpoint
+        # Load checkpoint. Some checkpoints wrap the weights in a "model_state_dict"
+        # key (exp18-style); exp20's checkpoint_best.pt is a raw state dict.
         checkpoint = torch.load(CHECKPOINT_PATH, map_location=self.device, weights_only=False)
-        model.load_state_dict(checkpoint["model_state_dict"])
+        state_dict = checkpoint["model_state_dict"] if "model_state_dict" in checkpoint else checkpoint
+        model.load_state_dict(state_dict)
 
         model.to(self.device)
         model.eval()

--- a/backend/app/services/image_processor.py
+++ b/backend/app/services/image_processor.py
@@ -35,6 +35,13 @@ DEFAULT_CHECKPOINT_PATH = str(
 )
 CHECKPOINT_PATH = os.environ.get("MODEL_CHECKPOINT_PATH", DEFAULT_CHECKPOINT_PATH)
 
+# Opt-in escape hatch for legacy checkpoints that pickle non-tensor objects and
+# therefore cannot be loaded with ``weights_only=True``. Off by default because
+# a full pickle load executes arbitrary code, and ``MODEL_CHECKPOINT_PATH`` is
+# operator-configurable. Set ``ALLOW_UNSAFE_CHECKPOINT_LOAD=1`` only for a
+# trusted checkpoint.
+ALLOW_UNSAFE_CHECKPOINT_LOAD = os.environ.get("ALLOW_UNSAFE_CHECKPOINT_LOAD", "").lower() in ("1", "true", "yes")
+
 # Image sizes expected by the model
 PIECE_SIZE = 128
 PUZZLE_SIZE = 256
@@ -58,11 +65,14 @@ def _extract_state_dict(checkpoint: Any) -> Any:
 
 
 def _load_checkpoint(path: str, device: torch.device) -> Any:
-    """Load a checkpoint file, preferring the safe ``weights_only`` path.
+    """Load a checkpoint file using the safe ``weights_only`` path.
 
     Modern checkpoints (including exp20's raw tensor ``state_dict``) load with
     ``weights_only=True``, which avoids arbitrary pickle execution. Legacy
-    checkpoints that pickle non-tensor objects fall back to a full load.
+    checkpoints that pickle non-tensor objects can only be read with a full
+    (unsafe) load; that path is gated behind ``ALLOW_UNSAFE_CHECKPOINT_LOAD`` so
+    it is never taken implicitly. When the safe load fails and the escape hatch
+    is off, the error propagates and the caller degrades to neutral predictions.
 
     Args:
         path: Filesystem path to the checkpoint.
@@ -73,7 +83,10 @@ def _load_checkpoint(path: str, device: torch.device) -> Any:
     """
     try:
         return torch.load(path, map_location=device, weights_only=True)
-    except Exception:  # noqa: BLE001 - fall back for legacy pickled checkpoints
+    except Exception:  # noqa: BLE001 - decide whether the unsafe fallback is permitted
+        if not ALLOW_UNSAFE_CHECKPOINT_LOAD:
+            raise
+        print(f"weights_only load failed for {path}; retrying with full pickle load (ALLOW_UNSAFE_CHECKPOINT_LOAD set)")
         return torch.load(path, map_location=device, weights_only=False)
 
 

--- a/backend/tests/test_image_processor.py
+++ b/backend/tests/test_image_processor.py
@@ -11,7 +11,7 @@ from fastapi import UploadFile
 from PIL import Image
 
 from app.services import image_processor as ip_module
-from app.services.image_processor import ImageProcessor, _extract_state_dict
+from app.services.image_processor import ImageProcessor, _extract_state_dict, _load_checkpoint
 
 
 def make_upload(content: bytes) -> UploadFile:
@@ -61,6 +61,36 @@ def test_extract_state_dict_unwraps_model_state_dict() -> None:
     wrapped = {"model_state_dict": weights, "epoch": 5, "optimizer_state_dict": {}}
 
     assert _extract_state_dict(wrapped) is weights
+
+
+def test_load_checkpoint_reraises_without_unsafe_optin() -> None:
+    """When the safe load fails and the escape hatch is off, the error propagates.
+
+    The unsafe ``weights_only=False`` retry must not run implicitly, so
+    ``torch.load`` is expected to be called exactly once.
+    """
+    safe_error = RuntimeError("weights_only load rejected pickled object")
+
+    with patch.object(ip_module, "ALLOW_UNSAFE_CHECKPOINT_LOAD", False):
+        with patch.object(ip_module.torch, "load", side_effect=safe_error) as mock_load:
+            with pytest.raises(RuntimeError, match="weights_only load rejected"):
+                _load_checkpoint("some.pt", torch.device("cpu"))
+
+    assert mock_load.call_count == 1
+    assert mock_load.call_args.kwargs["weights_only"] is True
+
+
+def test_load_checkpoint_unsafe_optin_retries_full_load() -> None:
+    """With the escape hatch on, a failed safe load retries with a full pickle load."""
+    sentinel = {"layer.weight": torch.zeros(1)}
+
+    with patch.object(ip_module, "ALLOW_UNSAFE_CHECKPOINT_LOAD", True):
+        with patch.object(ip_module.torch, "load", side_effect=[RuntimeError("unsafe"), sentinel]) as mock_load:
+            result = _load_checkpoint("some.pt", torch.device("cpu"))
+
+    assert result is sentinel
+    assert mock_load.call_count == 2
+    assert mock_load.call_args_list[1].kwargs["weights_only"] is False
 
 
 def test_corrupt_checkpoint_falls_back_to_no_model(tmp_path: Path) -> None:

--- a/backend/tests/test_image_processor.py
+++ b/backend/tests/test_image_processor.py
@@ -2,14 +2,16 @@
 
 import asyncio
 import io
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import torch
 from fastapi import UploadFile
 from PIL import Image
 
 from app.services import image_processor as ip_module
-from app.services.image_processor import ImageProcessor
+from app.services.image_processor import ImageProcessor, _extract_state_dict
 
 
 def make_upload(content: bytes) -> UploadFile:
@@ -44,6 +46,32 @@ def test_missing_checkpoint_returns_neutral_fallback() -> None:
     assert result.position_confidence == 0.0
     assert result.rotation == 0
     assert result.rotation_confidence == 0.0
+
+
+def test_extract_state_dict_accepts_raw_state_dict() -> None:
+    """A raw state_dict (exp20 checkpoint_best.pt) is returned unchanged."""
+    raw = {"layer.weight": torch.zeros(2, 2)}
+
+    assert _extract_state_dict(raw) is raw
+
+
+def test_extract_state_dict_unwraps_model_state_dict() -> None:
+    """A wrapped {"model_state_dict": ...} checkpoint (exp18-style) is unwrapped."""
+    weights = {"layer.weight": torch.zeros(2, 2)}
+    wrapped = {"model_state_dict": weights, "epoch": 5, "optimizer_state_dict": {}}
+
+    assert _extract_state_dict(wrapped) is weights
+
+
+def test_corrupt_checkpoint_falls_back_to_no_model(tmp_path: Path) -> None:
+    """A checkpoint that exists but fails to load yields no model, not a crash."""
+    bad_ckpt = tmp_path / "corrupt.pt"
+    bad_ckpt.write_bytes(b"not a real torch checkpoint")
+
+    with patch.object(ip_module, "CHECKPOINT_PATH", str(bad_ckpt)):
+        processor = ImageProcessor()
+
+    assert processor.model is None
 
 
 def test_load_puzzle_tensor_rejects_non_uuid_puzzle_id() -> None:


### PR DESCRIPTION
## Summary

Points the backend piece-inference service at the **exp20 realistic-pieces** checkpoint (`network/experiments/exp20_realistic_pieces/outputs/checkpoint_best.pt`).

exp20 is a different architecture from the previously-served exp18 3×3 model — a timm-capable ShuffleNetV2_x0.5 backbone, 4×4 grid (16 cells), continuous position regression + 4-class rotation — and its checkpoint's state_dict keys are shaped differently. Swapping the path alone wouldn't load, so the model definition had to be vendored in.

## Changes

- **`backend/app/models/model.py`** — Vendored exp20's `FastBackboneModel` (and its `get_backbone`, `SpatialCorrelationModule`, `RotationCorrelationModule`) so the backend can load the exp20 weights.
- **`backend/app/services/image_processor.py`**:
  - `DEFAULT_CHECKPOINT_PATH` → `exp20_realistic_pieces/outputs/checkpoint_best.pt`
  - `FastBackboneModel(...)` now passes `backbone_name="shufflenet_v2_x0_5"`
  - Checkpoint load handles **both** formats: exp20's raw state_dict and exp18's `model_state_dict`-wrapped dict
  - Docstring/comment updated (3×3 → 4×4)

The API contract is unchanged: the backend still returns normalized `(x, y) ∈ [0, 1]`, position confidence, and 4-class rotation.

## Verification

- `make check-backend` — black, isort, flake8, pyright all clean (0 errors)
- `pytest` — 93 passed
- End-to-end: `ImageProcessor` loads the exp20 checkpoint on MPS with a **strict** key match and runs a forward pass (`pos (1,2)`, `rot (1,4)`, `attn (1,1,8,8)`)

## Notes

- `timm` was already a backend dependency — no dependency changes needed.
- The `MODEL_CHECKPOINT_PATH` env override still works and now accepts either checkpoint format.
- Out of scope: any frontend grid overlay still hardcoded to 3×3 would be misaligned with the model's 4×4 space; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)