### PR TITLE
fix: build puzzle path from parsed UUID in image_processor (CodeQL #12)

### DIFF
--- a/backend/app/services/image_processor.py
+++ b/backend/app/services/image_processor.py
@@ -178,12 +178,15 @@ class ImageProcessor:
         """
         if puzzle_id not in self._puzzle_cache:
             try:
-                if str(UUID(puzzle_id)) != puzzle_id:
+                puzzle_uuid = UUID(puzzle_id)
+                if str(puzzle_uuid) != puzzle_id:
                     raise ValueError
             except ValueError as exc:
                 raise FileNotFoundError(f"Puzzle image not found: {puzzle_id}") from exc
 
-            puzzle_path = os.path.join(settings.UPLOAD_DIR, f"{puzzle_id}.jpg")
+            # Build the filename from the parsed UUID rather than the raw request
+            # string, so the path component can only ever be a canonical UUID.
+            puzzle_path = os.path.join(settings.UPLOAD_DIR, f"{puzzle_uuid}.jpg")
             # Normalize and ensure the puzzle path stays within the upload directory
             base_dir = os.path.realpath(settings.UPLOAD_DIR)
             normalized_path = os.path.realpath(puzzle_path)


### PR DESCRIPTION
## Summary

Resolves CodeQL `py/path-injection` alert [#12](https://github.com/claust/pussel/security/code-scanning/12) on `backend/app/services/image_processor.py` (`_load_puzzle_tensor`).

The puzzle image path was assembled with `os.path.join(settings.UPLOAD_DIR, f"{puzzle_id}.jpg")` using the raw request string. Even though `puzzle_id` was validated as a UUID immediately before, CodeQL's taint tracking still saw the raw request string flowing into a filesystem path.

This applies the same fix that PR #79 landed for the identical pattern in `classical_matcher._load_puzzle_features`: parse the request string into a `UUID` object and build the filename from the **parsed** UUID (`f"{puzzle_uuid}.jpg"`), so the path component can only ever be a canonical UUID. The `realpath`/`commonpath` containment check is retained as defense in depth.

## Changes

- `_load_puzzle_tensor` now binds `puzzle_uuid = UUID(puzzle_id)`, validates round-trip equality, and constructs the path from `puzzle_uuid`.

## Testing

- `make check-backend` — black, isort, flake8, pyright all pass
- `cd backend && ENVIRONMENT=test UPLOAD_DIR=test_uploads uv run pytest -q` — 98 passed

The CodeQL alert should close after CI's code-scanning run on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)