### PR TITLE
Wrap piece queue into rows with hover-to-enlarge preview

### DIFF
--- a/.claude/skills/gh-pr-copilot-review/SKILL.md
+++ b/.claude/skills/gh-pr-copilot-review/SKILL.md
@@ -9,7 +9,7 @@ description: Commit local changes, push a branch, create a GitHub pull request, 
 
 Publish local work to GitHub end to end: inspect scope, branch, stage, commit, push, create a PR, request GitHub Copilot code review, verify the request through GitHub issue events, monitor Copilot review output, address substantive feedback, push fixes, re-request Copilot review, and continue until unresolved feedback is only nits or non-actionable.
 
-Claude Code does not receive passive GitHub callbacks in an ordinary session. For follow-up progress, actively poll GitHub, or set up a scheduled task when the user asks to keep watching.
+Claude Code does not receive passive GitHub callbacks in an ordinary session. To wait for a review, use a background watcher that polls internally and wakes you when it finishes (see "Wait For The Review Without Foreground Polling").
 
 ## Publish Workflow
 
@@ -152,6 +152,36 @@ Treat Copilot as done when it submits a review from `copilot-pull-request-review
 - CI status
 - whether the branch is behind the base branch
 
+### Wait For The Review Without Foreground Polling
+
+Copilot reviews take a couple of minutes. Do not sit in a foreground loop
+re-running `gh` by hand — there are no passive GitHub push callbacks, but you
+can make the wait hands-off with a single background watcher that polls
+internally and exits the moment a review lands. When a `run_in_background`
+command finishes, the harness re-invokes you automatically, so this behaves
+like "notify me when the review is ready" while you stay idle in between.
+
+Launch it with `run_in_background: true`:
+
+```bash
+# Waits for a Copilot review NEWER than a known baseline timestamp, then exits.
+# For the first round, use an empty baseline ("") so any Copilot review matches.
+BASELINE="<latest-copilot-review-submitted_at-or-empty>"
+for i in $(seq 1 60); do
+  LATEST=$(gh api repos/<owner>/<repo>/pulls/<pr-number>/reviews \
+    --jq '[.[] | select(.user.login=="copilot-pull-request-reviewer[bot]" or .user.login=="Copilot")] | max_by(.submitted_at) | .submitted_at' 2>/dev/null)
+  if [ -n "$LATEST" ] && [ "$LATEST" \> "$BASELINE" ]; then
+    echo "COPILOT_REVIEW_READY latest=$LATEST"; exit 0
+  fi
+  sleep 20
+done
+echo "WATCHER_TIMEOUT_NO_NEW_REVIEW"; exit 0
+```
+
+For re-review rounds, set `BASELINE` to the previous round's latest Copilot
+`submitted_at` so the watcher waits for the *new* review rather than returning
+the old one immediately. Each round gets its own watcher.
+
 ## Keep The PR Branch Updated
 
 While monitoring or addressing a PR, keep the PR branch current with the base branch. This is the local equivalent of clicking GitHub's "Update branch" button.
@@ -267,11 +297,7 @@ When a review comment has been addressed, resolve the corresponding GitHub revie
 
 ## Periodic Follow-Up
 
-If the user asks to watch, monitor, check back, notify them, or get callbacks, set up a scheduled task rather than claiming passive callbacks exist.
-
-- Use the `/loop` skill for short-term monitoring within the current session.
-- Use a scheduled task (the `schedule` skill) for detached repository monitoring.
-- The follow-up prompt should inspect the PR using the GitHub CLI/API commands above and report only meaningful changes: new Copilot review, new comments, failed checks, or merge readiness.
+If the user asks to watch, monitor, check back, notify them, or get callbacks, use the background watcher in "Wait For The Review Without Foreground Polling" rather than claiming passive callbacks exist. It polls GitHub internally and wakes you on completion, so you never sit in a foreground loop. Report only meaningful changes when it fires: new Copilot review, new comments, failed checks, or merge readiness.
 
 ## Important Details
 

--- a/frontend/src/components/puzzle/piece-queue.tsx
+++ b/frontend/src/components/puzzle/piece-queue.tsx
@@ -33,80 +33,101 @@ export function PieceQueue({ entries, onRetry, onDelete, className }: PieceQueue
   }
 
   return (
-    <div className={cn('overflow-x-auto', className)} data-testid="piece-queue">
-      <div className="flex gap-3 pb-2">
-        {entries.map((entry, index) => (
-          <div
-            key={entry.id}
-            className={cn(
-              'animate-queue-pop relative w-24 shrink-0 overflow-hidden rounded-lg border-2',
-              entry.status === 'done' && 'border-green-500',
-              entry.status === 'error' && 'border-destructive',
-              (entry.status === 'queued' || entry.status === 'predicting') && 'border-border'
-            )}
-            data-testid="queue-entry"
-            data-status={entry.status}
-          >
-            <img
-              src={entry.piece?.imageData ?? entry.imageUrl}
-              alt={`Captured piece ${index + 1}`}
-              className="bg-muted aspect-square w-full object-cover"
-            />
+    <div className={cn(className)} data-testid="piece-queue">
+      <div className="flex flex-wrap gap-3 pb-2">
+        {entries.map((entry, index) => {
+          const imageSrc = entry.piece?.imageData ?? entry.imageUrl;
+          return (
+            <div
+              key={entry.id}
+              className={cn(
+                'animate-queue-pop group relative w-24 shrink-0 rounded-lg border-2',
+                entry.status === 'done' && 'border-green-500',
+                entry.status === 'error' && 'border-destructive',
+                (entry.status === 'queued' || entry.status === 'predicting') && 'border-border'
+              )}
+              data-testid="queue-entry"
+              data-status={entry.status}
+            >
+              {/* Enlarged preview on hover — floats above the tile, ignores pointer so it
+                  never blocks the delete/retry controls. Clipped visuals stay inside the
+                  rounded tile via the inner overflow-hidden wrapper below. */}
+              <div
+                className="pointer-events-none absolute bottom-full left-1/2 z-30 mb-2 hidden -translate-x-1/2 group-hover:block"
+                data-testid="queue-entry-preview"
+              >
+                <div className="bg-background border-border overflow-hidden rounded-lg border-2 shadow-xl">
+                  <img
+                    src={imageSrc}
+                    alt={`Captured piece ${index + 1} enlarged`}
+                    className="bg-muted h-64 w-64 max-w-[75vw] object-contain"
+                  />
+                </div>
+              </div>
 
-            {/* Status overlay */}
-            <div className="bg-background/85 absolute inset-x-0 bottom-0 flex h-6 items-center justify-center gap-1 text-[10px] font-medium">
-              {entry.status === 'queued' && <span className="text-muted-foreground">Queued</span>}
-              {entry.status === 'predicting' && (
-                <>
-                  <Loader2 className="h-3 w-3 animate-spin" />
-                  <span>Predicting…</span>
-                </>
-              )}
-              {entry.status === 'done' && entry.piece && (
-                <>
-                  <Check className="h-3 w-3 text-green-600" />
-                  <span>
-                    ({(entry.piece.position.x * 100).toFixed(0)}%,{' '}
-                    {(entry.piece.position.y * 100).toFixed(0)}%)
-                  </span>
-                </>
-              )}
-              {entry.status === 'error' && (
-                <>
-                  <AlertCircle className="text-destructive h-3 w-3" />
-                  <span className="text-destructive">Failed</span>
-                </>
-              )}
-            </div>
+              <div className="overflow-hidden rounded-md">
+                <img
+                  src={imageSrc}
+                  alt={`Captured piece ${index + 1}`}
+                  className="bg-muted aspect-square w-full object-cover"
+                />
+              </div>
 
-            {/* Retry failed predictions + delete, laid out side by side so they don't overlap */}
-            <div className="absolute top-1 right-1 flex gap-1">
-              {entry.status === 'error' && (
+              {/* Status overlay */}
+              <div className="bg-background/85 absolute inset-x-0 bottom-0 flex h-6 items-center justify-center gap-1 text-[10px] font-medium">
+                {entry.status === 'queued' && <span className="text-muted-foreground">Queued</span>}
+                {entry.status === 'predicting' && (
+                  <>
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    <span>Predicting…</span>
+                  </>
+                )}
+                {entry.status === 'done' && entry.piece && (
+                  <>
+                    <Check className="h-3 w-3 text-green-600" />
+                    <span>
+                      ({(entry.piece.position.x * 100).toFixed(0)}%,{' '}
+                      {(entry.piece.position.y * 100).toFixed(0)}%)
+                    </span>
+                  </>
+                )}
+                {entry.status === 'error' && (
+                  <>
+                    <AlertCircle className="text-destructive h-3 w-3" />
+                    <span className="text-destructive">Failed</span>
+                  </>
+                )}
+              </div>
+
+              {/* Retry failed predictions + delete, laid out side by side so they don't overlap */}
+              <div className="absolute top-1 right-1 flex gap-1">
+                {entry.status === 'error' && (
+                  <Button
+                    size="icon"
+                    variant="secondary"
+                    className="h-6 w-6"
+                    onClick={() => onRetry(entry.id)}
+                    title="Retry prediction"
+                  >
+                    <RotateCcw className="h-3 w-3" />
+                    <span className="sr-only">Retry prediction</span>
+                  </Button>
+                )}
                 <Button
                   size="icon"
                   variant="secondary"
                   className="h-6 w-6"
-                  onClick={() => onRetry(entry.id)}
-                  title="Retry prediction"
+                  onClick={() => onDelete(entry.id)}
+                  title="Remove piece"
+                  data-testid={`queue-entry-delete-${index}`}
                 >
-                  <RotateCcw className="h-3 w-3" />
-                  <span className="sr-only">Retry prediction</span>
+                  <X className="h-3 w-3" />
+                  <span className="sr-only">Remove piece</span>
                 </Button>
-              )}
-              <Button
-                size="icon"
-                variant="secondary"
-                className="h-6 w-6"
-                onClick={() => onDelete(entry.id)}
-                title="Remove piece"
-                data-testid={`queue-entry-delete-${index}`}
-              >
-                <X className="h-3 w-3" />
-                <span className="sr-only">Remove piece</span>
-              </Button>
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend/src/components/puzzle/piece-queue.tsx
+++ b/frontend/src/components/puzzle/piece-queue.tsx
@@ -41,17 +41,22 @@ export function PieceQueue({ entries, onRetry, onDelete, className }: PieceQueue
             <div
               key={entry.id}
               className={cn(
-                'animate-queue-pop group relative w-24 shrink-0 rounded-lg border-2',
+                'animate-queue-pop group focus-visible:ring-ring relative w-24 shrink-0 cursor-pointer rounded-lg border-2 focus:outline-none focus-visible:ring-2',
                 entry.status === 'done' && 'border-green-500',
                 entry.status === 'error' && 'border-destructive',
                 (entry.status === 'queued' || entry.status === 'predicting') && 'border-border'
               )}
+              // Focusable so the enlarged preview is reachable by keyboard (tab to the tile)
+              // and by touch (tap the tile) without activating the retry/delete buttons.
+              tabIndex={0}
+              role="button"
+              aria-label={`Captured piece ${index + 1} — focus to enlarge`}
               data-testid="queue-entry"
               data-status={entry.status}
             >
-              {/* Enlarged preview on hover or keyboard focus — floats above the tile and
-                  ignores pointer events so it never blocks the delete/retry controls.
-                  group-focus-within makes it reachable when tabbing to those controls. */}
+              {/* Enlarged preview on hover, keyboard focus, or touch tap — floats above the
+                  tile and ignores pointer events so it never blocks the delete/retry controls.
+                  group-focus-within covers the focusable tile and the buttons inside it. */}
               <div
                 className="pointer-events-none absolute bottom-full left-1/2 z-30 mb-2 hidden -translate-x-1/2 group-focus-within:block group-hover:block"
                 data-testid="queue-entry-preview"
@@ -65,7 +70,7 @@ export function PieceQueue({ entries, onRetry, onDelete, className }: PieceQueue
                 </div>
               </div>
 
-              <div className="overflow-hidden rounded-md">
+              <div className="overflow-hidden rounded-[inherit]">
                 <img
                   src={imageSrc}
                   alt={`Captured piece ${index + 1}`}
@@ -73,9 +78,9 @@ export function PieceQueue({ entries, onRetry, onDelete, className }: PieceQueue
                 />
               </div>
 
-              {/* Status overlay — rounded bottom matches the tile so its corners don't
-                  protrude past the rounded border (the outer tile has no overflow clip). */}
-              <div className="bg-background/85 absolute inset-x-0 bottom-0 flex h-6 items-center justify-center gap-1 rounded-b-md text-[10px] font-medium">
+              {/* Status overlay — bottom radius matches the tile's rounded-lg so its corners
+                  don't protrude past the rounded border (the outer tile has no overflow clip). */}
+              <div className="bg-background/85 absolute inset-x-0 bottom-0 flex h-6 items-center justify-center gap-1 rounded-b-lg text-[10px] font-medium">
                 {entry.status === 'queued' && <span className="text-muted-foreground">Queued</span>}
                 {entry.status === 'predicting' && (
                   <>

--- a/frontend/src/components/puzzle/piece-queue.tsx
+++ b/frontend/src/components/puzzle/piece-queue.tsx
@@ -49,11 +49,11 @@ export function PieceQueue({ entries, onRetry, onDelete, className }: PieceQueue
               data-testid="queue-entry"
               data-status={entry.status}
             >
-              {/* Enlarged preview on hover — floats above the tile, ignores pointer so it
-                  never blocks the delete/retry controls. Clipped visuals stay inside the
-                  rounded tile via the inner overflow-hidden wrapper below. */}
+              {/* Enlarged preview on hover or keyboard focus — floats above the tile and
+                  ignores pointer events so it never blocks the delete/retry controls.
+                  group-focus-within makes it reachable when tabbing to those controls. */}
               <div
-                className="pointer-events-none absolute bottom-full left-1/2 z-30 mb-2 hidden -translate-x-1/2 group-hover:block"
+                className="pointer-events-none absolute bottom-full left-1/2 z-30 mb-2 hidden -translate-x-1/2 group-focus-within:block group-hover:block"
                 data-testid="queue-entry-preview"
               >
                 <div className="bg-background border-border overflow-hidden rounded-lg border-2 shadow-xl">
@@ -73,8 +73,9 @@ export function PieceQueue({ entries, onRetry, onDelete, className }: PieceQueue
                 />
               </div>
 
-              {/* Status overlay */}
-              <div className="bg-background/85 absolute inset-x-0 bottom-0 flex h-6 items-center justify-center gap-1 text-[10px] font-medium">
+              {/* Status overlay — rounded bottom matches the tile so its corners don't
+                  protrude past the rounded border (the outer tile has no overflow clip). */}
+              <div className="bg-background/85 absolute inset-x-0 bottom-0 flex h-6 items-center justify-center gap-1 rounded-b-md text-[10px] font-medium">
                 {entry.status === 'queued' && <span className="text-muted-foreground">Queued</span>}
                 {entry.status === 'predicting' && (
                   <>

--- a/frontend/src/components/puzzle/piece-queue.tsx
+++ b/frontend/src/components/puzzle/piece-queue.tsx
@@ -41,15 +41,15 @@ export function PieceQueue({ entries, onRetry, onDelete, className }: PieceQueue
             <div
               key={entry.id}
               className={cn(
-                'animate-queue-pop group focus-visible:ring-ring relative w-24 shrink-0 cursor-pointer rounded-lg border-2 focus:outline-none focus-visible:ring-2',
+                'animate-queue-pop group focus-visible:ring-ring relative w-24 shrink-0 rounded-lg border-2 focus:outline-none focus-visible:ring-2',
                 entry.status === 'done' && 'border-green-500',
                 entry.status === 'error' && 'border-destructive',
                 (entry.status === 'queued' || entry.status === 'predicting') && 'border-border'
               )}
-              // Focusable so the enlarged preview is reachable by keyboard (tab to the tile)
-              // and by touch (tap the tile) without activating the retry/delete buttons.
+              // Focusable (but not an activatable control — the preview is revealed purely via
+              // CSS :focus-within) so the enlarged view is reachable by keyboard (tab to the
+              // tile) and by touch (tap the tile) without triggering the retry/delete buttons.
               tabIndex={0}
-              role="button"
               aria-label={`Captured piece ${index + 1} — focus to enlarge`}
               data-testid="queue-entry"
               data-status={entry.status}


### PR DESCRIPTION
## Summary

Fixes two usability issues with the real-mode capture strip (`PieceQueue`) on the `/real` solving screen when many pieces are added:

1. **Horizontal overflow with no scroll** — the queue grew off-screen with no way to reach later pieces.
2. **Tiles too small to see detail** — each `w-24` tile showed the piece image too small to inspect.

## Changes

### `frontend/src/components/puzzle/piece-queue.tsx`
- **Wrap into rows**: replaced the non-scrolling `overflow-x-auto` flex row with `flex flex-wrap`, so tiles reflow onto new rows when horizontal space runs out.
- **Enlarge on hover / focus / touch**: each tile is a `group`; hovering, keyboard-focusing (the tile is `tabIndex`-focusable), or tapping it pops a 256×256 (`object-contain`, capped at `75vw`) preview above the tile via `group-hover`/`group-focus-within`. It is `pointer-events-none` and `z-30` so it never blocks the retry/delete controls.
- Split the tile image into an inner `overflow-hidden rounded-[inherit]` wrapper so rounded clipping stays matched to the tile; status overlay uses `rounded-b-lg`. Status border, prediction overlay, and controls preserved.

### `.claude/skills/gh-pr-copilot-review/SKILL.md`
- Documented a single background-watcher pattern for waiting on Copilot reviews without foreground polling, and removed the `/loop` / scheduled-task alternatives so the agent consistently uses the watcher.

## Verification
- Rendered the component with 18 mock pieces in a temporary route: tiles wrap into multiple rows, and hover/focus/tap shows a large legible preview. (Temp route removed before commit.)
- `prettier --check` and `oxlint` (type-aware) pass with 0 warnings/errors; CI green.

## Copilot review
Three rounds of Copilot review completed; all threads addressed and resolved (keyboard/touch reachability, ARIA semantics, corner-radius matching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)