### PR TITLE
chore(skill): add tested copilot-review.sh helper to gh-pr-copilot-review

### DIFF
--- a/.claude/skills/gh-pr-copilot-review/SKILL.md
+++ b/.claude/skills/gh-pr-copilot-review/SKILL.md
@@ -52,17 +52,41 @@ When the user invokes this skill, execute the workflow automatically when the in
    gh pr create --base <base> --head "$(git branch --show-current)" --title "<title>" --body "<body>"
    ```
 
-8. Request Copilot review using the GraphQL bot-review path below. Use this for both initial review requests and re-review requests after pushing fixes. Do not rely on `gh pr edit --add-reviewer Copilot` or `gh pr edit --add-reviewer @copilot`; those commands can return success without creating a visible pending Copilot request or a new `copilot_work_started` event.
+8. Request Copilot review by running `scripts/copilot-review.sh request` (the GraphQL bot-review path documented below). Use it for both initial review requests and re-review requests after pushing fixes. Do not rely on `gh pr edit --add-reviewer Copilot` or `gh pr edit --add-reviewer @copilot`; those commands can return success without creating a visible pending Copilot request or a new `copilot_work_started` event.
+
+## Helper Script
+
+The shell-fragile steps (request, verify, status, wait) are packaged in
+`scripts/copilot-review.sh`, so they run identically every session instead of
+being retyped and re-broken. It has a `#!/usr/bin/env bash` shebang, so it is
+immune to the caller's interactive shell — importantly it does not hit the
+`[ "$a" \> "$b" ]` string compare that errors under zsh with
+"condition expected: >" and silently defeats a hand-written watcher.
+
+`owner`/`repo`/`pr` auto-detect from the current repo and checked-out PR branch
+when the flags are omitted. Reference paths relative to the skill directory:
+
+```bash
+scripts/copilot-review.sh request   # request / re-request Copilot review
+scripts/copilot-review.sh verify    # events + pending reviewers (confirm it registered)
+scripts/copilot-review.sh status    # submitted reviews (user, state, submitted_at, body)
+scripts/copilot-review.sh wait [--baseline TS] [--interval SECS] [--max-iters N]
+# add --owner O --repo R --pr N to any of the above to be explicit
+```
+
+Prefer this script over the raw `gh` snippets below; the snippets document what
+each subcommand does under the hood and remain the fallback if the script is
+unavailable.
 
 ## Request Or Re-Request Copilot Review
 
-Use GraphQL `requestReviewsByLogin` with `botLogins:["copilot-pull-request-reviewer"]`. This is the reliable programmatic equivalent of the GitHub web UI's Copilot review/re-review request.
+Run `scripts/copilot-review.sh request` (works for both the initial request and
+re-review after pushing fixes). Under the hood it uses GraphQL
+`requestReviewsByLogin` with `botLogins:["copilot-pull-request-reviewer"]` — the
+reliable programmatic equivalent of the web UI's Copilot review/re-review
+request:
 
 ```bash
-PR_NUMBER=<pr-number>
-OWNER=<owner>
-REPO=<repo>
-
 PR_ID=$(
   gh api graphql \
     -f query='query($owner:String!, $repo:String!, $number:Int!) {
@@ -114,7 +138,10 @@ gh api graphql \
 
 ## Verify Copilot Request
 
-Verify Copilot through issue events and requested reviewers. GitHub may leave `reviewRequests` empty in `gh pr view`, and submitted Copilot reviews remove Copilot from the pending requested-reviewer list.
+Run `scripts/copilot-review.sh verify`. It reports issue events and pending
+requested reviewers; GitHub may leave `reviewRequests` empty in `gh pr view`,
+and submitted Copilot reviews remove Copilot from the pending requested-reviewer
+list, so events are the reliable signal. Equivalent raw calls:
 
 ```bash
 gh api repos/<owner>/<repo>/issues/<pr-number>/events --paginate \
@@ -161,26 +188,25 @@ internally and exits the moment a review lands. When a `run_in_background`
 command finishes, the harness re-invokes you automatically, so this behaves
 like "notify me when the review is ready" while you stay idle in between.
 
-Launch it with `run_in_background: true`:
+Launch the `wait` subcommand with `run_in_background: true`:
 
 ```bash
-# Waits for a Copilot review NEWER than a known baseline timestamp, then exits.
-# For the first round, use an empty baseline ("") so any Copilot review matches.
-BASELINE="<latest-copilot-review-submitted_at-or-empty>"
-for i in $(seq 1 60); do
-  LATEST=$(gh api repos/<owner>/<repo>/pulls/<pr-number>/reviews \
-    --jq '[.[] | select(.user.login=="copilot-pull-request-reviewer[bot]" or .user.login=="Copilot")] | max_by(.submitted_at) | .submitted_at' 2>/dev/null)
-  if [ -n "$LATEST" ] && [ "$LATEST" \> "$BASELINE" ]; then
-    echo "COPILOT_REVIEW_READY latest=$LATEST"; exit 0
-  fi
-  sleep 20
-done
-echo "WATCHER_TIMEOUT_NO_NEW_REVIEW"; exit 0
+# First round — empty baseline, so any Copilot review matches:
+scripts/copilot-review.sh wait
+
+# Re-review round — pass the previous round's latest Copilot submitted_at so it
+# waits for the NEW review instead of returning the old one immediately:
+scripts/copilot-review.sh wait --baseline 2026-07-15T15:58:45Z
 ```
 
-For re-review rounds, set `BASELINE` to the previous round's latest Copilot
-`submitted_at` so the watcher waits for the *new* review rather than returning
-the old one immediately. Each round gets its own watcher.
+It prints `COPILOT_REVIEW_READY latest=<ts>` and exits 0 the moment a matching
+review lands, or `WATCHER_TIMEOUT_NO_NEW_REVIEW` after `--max-iters` polls
+(default 60 × 20s = 20 min). Each round gets its own watcher.
+
+Do NOT reimplement this poll loop inline. The earlier inline version used
+`[ "$LATEST" \> "$BASELINE" ]`, which errors under zsh ("condition expected: >")
+and never matches — the watcher then loops uselessly until timeout while the
+review sits ready. The script avoids this with a bash shebang and `[[ > ]]`.
 
 ## Keep The PR Branch Updated
 
@@ -221,7 +247,7 @@ When `gh pr view` reports that the branch is behind, the merge state is blocked 
 
 6. Wait for CI to run again on the updated branch. Monitor the new check run until it finishes. If CI fails, inspect logs, fix the failure, push again, and keep monitoring.
 
-7. If the update or conflict resolution changes code that Copilot previously reviewed, re-request Copilot review with the GraphQL bot-review path.
+7. If the update or conflict resolution changes code that Copilot previously reviewed, re-request Copilot review with `scripts/copilot-review.sh request`.
 
 ## Address Review Feedback
 
@@ -282,7 +308,7 @@ When a review comment has been addressed, resolve the corresponding GitHub revie
      -F thread=<review-thread-id>
    ```
 
-6. Re-request Copilot review with the GraphQL bot-review path above after every push that addresses Copilot feedback.
+6. Re-request Copilot review with `scripts/copilot-review.sh request` after every push that addresses Copilot feedback.
 
 7. Keep the branch updated with the base branch while this loop is running. If the base branch changes, merge it into the PR branch, resolve any conflicts, push, and wait for CI to rerun.
 
@@ -301,6 +327,8 @@ If the user asks to watch, monitor, check back, notify them, or get callbacks, u
 
 ## Important Details
 
+- Prefer `scripts/copilot-review.sh` (subcommands `request`, `verify`, `status`, `wait`) over hand-typed `gh`/loop snippets — it is the tested, shell-portable entrypoint. Reach for raw `gh` only to debug or when the script is unavailable.
+- Never hand-roll the review-wait poll loop in the interactive shell: a `[ "$a" \> "$b" ]` timestamp compare errors under zsh ("condition expected: >") and loops until timeout without ever matching. The script uses a bash shebang + `[[ > ]]` to avoid this.
 - Programmatic Copilot review requests should use GraphQL `requestReviewsByLogin` with `botLogins:["copilot-pull-request-reviewer"]`.
 - `gh pr edit --add-reviewer Copilot` and `gh pr edit --add-reviewer @copilot` can return success without a new visible request. Treat them as insufficient unless verification shows a fresh Copilot event, pending reviewer, or review.
 - The app slug observed in PR events is `copilot-pull-request-reviewer`.

--- a/.claude/skills/gh-pr-copilot-review/SKILL.md
+++ b/.claude/skills/gh-pr-copilot-review/SKILL.md
@@ -52,25 +52,26 @@ When the user invokes this skill, execute the workflow automatically when the in
    gh pr create --base <base> --head "$(git branch --show-current)" --title "<title>" --body "<body>"
    ```
 
-8. Request Copilot review by running `scripts/copilot-review.sh request` (the GraphQL bot-review path documented below). Use it for both initial review requests and re-review requests after pushing fixes. Do not rely on `gh pr edit --add-reviewer Copilot` or `gh pr edit --add-reviewer @copilot`; those commands can return success without creating a visible pending Copilot request or a new `copilot_work_started` event.
+8. Request Copilot review by running `.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh request` (the GraphQL bot-review path documented below). Use it for both initial review requests and re-review requests after pushing fixes. Do not rely on `gh pr edit --add-reviewer Copilot` or `gh pr edit --add-reviewer @copilot`; those commands can return success without creating a visible pending Copilot request or a new `copilot_work_started` event.
 
 ## Helper Script
 
 The shell-fragile steps (request, verify, status, wait) are packaged in
-`scripts/copilot-review.sh`, so they run identically every session instead of
+`.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh`, so they run identically every session instead of
 being retyped and re-broken. It has a `#!/usr/bin/env bash` shebang, so it is
 immune to the caller's interactive shell — importantly it does not hit the
 `[ "$a" \> "$b" ]` string compare that errors under zsh with
 "condition expected: >" and silently defeats a hand-written watcher.
 
 `owner`/`repo`/`pr` auto-detect from the current repo and checked-out PR branch
-when the flags are omitted. Reference paths relative to the skill directory:
+when the flags are omitted. Paths below are relative to the repo root (the usual
+working directory for skill commands), so they run as-is:
 
 ```bash
-scripts/copilot-review.sh request   # request / re-request Copilot review
-scripts/copilot-review.sh verify    # events + pending reviewers (confirm it registered)
-scripts/copilot-review.sh status    # submitted reviews (user, state, submitted_at, body)
-scripts/copilot-review.sh wait [--baseline TS] [--interval SECS] [--max-iters N]
+.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh request   # request / re-request Copilot review
+.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh verify    # events + pending reviewers (confirm it registered)
+.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh status    # submitted reviews (user, state, submitted_at, body)
+.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh wait [--baseline TS] [--interval SECS] [--max-iters N]
 # add --owner O --repo R --pr N to any of the above to be explicit
 ```
 
@@ -80,7 +81,7 @@ unavailable.
 
 ## Request Or Re-Request Copilot Review
 
-Run `scripts/copilot-review.sh request` (works for both the initial request and
+Run `.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh request` (works for both the initial request and
 re-review after pushing fixes). Under the hood it uses GraphQL
 `requestReviewsByLogin` with `botLogins:["copilot-pull-request-reviewer"]` — the
 reliable programmatic equivalent of the web UI's Copilot review/re-review
@@ -138,7 +139,7 @@ gh api graphql \
 
 ## Verify Copilot Request
 
-Run `scripts/copilot-review.sh verify`. It reports issue events and pending
+Run `.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh verify`. It reports issue events and pending
 requested reviewers; GitHub may leave `reviewRequests` empty in `gh pr view`,
 and submitted Copilot reviews remove Copilot from the pending requested-reviewer
 list, so events are the reliable signal. Equivalent raw calls:
@@ -192,11 +193,11 @@ Launch the `wait` subcommand with `run_in_background: true`:
 
 ```bash
 # First round — empty baseline, so any Copilot review matches:
-scripts/copilot-review.sh wait
+.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh wait
 
 # Re-review round — pass the previous round's latest Copilot submitted_at so it
 # waits for the NEW review instead of returning the old one immediately:
-scripts/copilot-review.sh wait --baseline 2026-07-15T15:58:45Z
+.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh wait --baseline 2026-07-15T15:58:45Z
 ```
 
 It prints `COPILOT_REVIEW_READY latest=<ts>` and exits 0 the moment a matching
@@ -247,7 +248,7 @@ When `gh pr view` reports that the branch is behind, the merge state is blocked 
 
 6. Wait for CI to run again on the updated branch. Monitor the new check run until it finishes. If CI fails, inspect logs, fix the failure, push again, and keep monitoring.
 
-7. If the update or conflict resolution changes code that Copilot previously reviewed, re-request Copilot review with `scripts/copilot-review.sh request`.
+7. If the update or conflict resolution changes code that Copilot previously reviewed, re-request Copilot review with `.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh request`.
 
 ## Address Review Feedback
 
@@ -308,7 +309,7 @@ When a review comment has been addressed, resolve the corresponding GitHub revie
      -F thread=<review-thread-id>
    ```
 
-6. Re-request Copilot review with `scripts/copilot-review.sh request` after every push that addresses Copilot feedback.
+6. Re-request Copilot review with `.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh request` after every push that addresses Copilot feedback.
 
 7. Keep the branch updated with the base branch while this loop is running. If the base branch changes, merge it into the PR branch, resolve any conflicts, push, and wait for CI to rerun.
 
@@ -327,7 +328,7 @@ If the user asks to watch, monitor, check back, notify them, or get callbacks, u
 
 ## Important Details
 
-- Prefer `scripts/copilot-review.sh` (subcommands `request`, `verify`, `status`, `wait`) over hand-typed `gh`/loop snippets — it is the tested, shell-portable entrypoint. Reach for raw `gh` only to debug or when the script is unavailable.
+- Prefer `.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh` (subcommands `request`, `verify`, `status`, `wait`) over hand-typed `gh`/loop snippets — it is the tested, shell-portable entrypoint. Reach for raw `gh` only to debug or when the script is unavailable.
 - Never hand-roll the review-wait poll loop in the interactive shell: a `[ "$a" \> "$b" ]` timestamp compare errors under zsh ("condition expected: >") and loops until timeout without ever matching. The script uses a bash shebang + `[[ > ]]` to avoid this.
 - Programmatic Copilot review requests should use GraphQL `requestReviewsByLogin` with `botLogins:["copilot-pull-request-reviewer"]`.
 - `gh pr edit --add-reviewer Copilot` and `gh pr edit --add-reviewer @copilot` can return success without a new visible request. Treat them as insufficient unless verification shows a fresh Copilot event, pending reviewer, or review.

--- a/.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh
+++ b/.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh
@@ -63,6 +63,11 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+# --interval/--max-iters feed `sleep` and a numeric test, so reject non-integers
+# up front instead of failing obscurely mid-loop.
+case "$INTERVAL" in '' | *[!0-9]*) die "--interval must be a non-negative integer, got '$INTERVAL'" ;; esac
+case "$MAX_ITERS" in '' | *[!0-9]*) die "--max-iters must be a non-negative integer, got '$MAX_ITERS'" ;; esac
+
 # Auto-detect owner/repo/pr from context when not supplied.
 [ -n "$OWNER" ] || OWNER=$(gh repo view --json owner --jq '.owner.login' 2>/dev/null) || true
 [ -n "$REPO" ]  || REPO=$(gh repo view --json name --jq '.name' 2>/dev/null) || true

--- a/.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh
+++ b/.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh
@@ -94,8 +94,13 @@ latest_copilot_ts() {
 
 case "$cmd" in
   request)
-    pid=$(pr_node_id)
-    [ -n "$pid" ] || die "could not resolve PR node id for $OWNER/$REPO#$PR"
+    # Guard both failure shapes: a GraphQL error (rc != 0, and gh dumps the raw
+    # JSON to stdout) and a null PR id that jq renders as the literal "null"
+    # (rc 0, non-empty). Either way, fail here instead of sending a bogus
+    # pullRequestId to the mutation.
+    pid=$(pr_node_id) || pid=""
+    { [ -n "$pid" ] && [ "$pid" != "null" ]; } \
+      || die "could not resolve PR node id for $OWNER/$REPO#$PR (does the PR exist?)"
     # shellcheck disable=SC2016  # $pr is a GraphQL var, not shell — must stay unexpanded
     gh api graphql \
       -f query='mutation($pr:ID!){requestReviewsByLogin(input:{pullRequestId:$pr,botLogins:["copilot-pull-request-reviewer"],union:true}){pullRequest{id}}}' \
@@ -140,7 +145,9 @@ case "$cmd" in
         echo "warn: reviews query failed (attempt $fails/$max_fails), retrying…" >&2
       fi
       i=$((i + 1))
-      sleep "$INTERVAL"
+      # Sleep only when another poll will follow, so the final iteration (and
+      # --max-iters 1) doesn't waste one interval before printing the timeout.
+      if [ "$i" -lt "$MAX_ITERS" ]; then sleep "$INTERVAL"; fi
     done
     echo "WATCHER_TIMEOUT_NO_NEW_REVIEW"
     exit 0

--- a/.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh
+++ b/.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Copilot PR review helper for the gh-pr-copilot-review skill.
+#
+# Encapsulates the shell-fragile GraphQL + polling steps so they are written and
+# tested once, instead of being retyped (and re-broken) every session. Because
+# it runs under its own bash shebang it is immune to the caller's interactive
+# shell — notably the `[ "$a" \> "$b" ]` string compare that errors under zsh
+# with "condition expected: >" and silently defeated the inline watcher.
+#
+# owner/repo/pr auto-detect from the current repo + checked-out PR branch when
+# not passed, so the common case is just:  copilot-review.sh wait
+#
+# Usage:
+#   copilot-review.sh request [--owner O --repo R --pr N]
+#   copilot-review.sh verify  [--owner O --repo R --pr N]
+#   copilot-review.sh status  [--owner O --repo R --pr N]
+#   copilot-review.sh wait    [--owner O --repo R --pr N]
+#                             [--baseline TS] [--interval SECS] [--max-iters N]
+#
+# `wait` prints "COPILOT_REVIEW_READY latest=<ts>" and exits 0 when a Copilot
+# review newer than --baseline appears, or "WATCHER_TIMEOUT_NO_NEW_REVIEW" if it
+# gives up. For the first round pass no --baseline (any Copilot review matches);
+# for re-review rounds pass the previous round's latest Copilot submitted_at so
+# it waits for the *new* review. Run it with run_in_background:true to be woken
+# on completion instead of foreground-polling.
+
+set -uo pipefail
+export LC_ALL=C  # deterministic byte ordering for ISO-8601 timestamp compares
+
+# Copilot shows up as this login in submitted reviews / requested reviewers.
+BOT_REVIEW_LOGIN='copilot-pull-request-reviewer[bot]'
+BOT_DISPLAY_LOGIN='Copilot'
+
+die() { echo "error: $*" >&2; exit 1; }
+
+command -v gh >/dev/null 2>&1 || die "gh CLI not found on PATH"
+
+cmd="${1:-}"
+[ -n "$cmd" ] || die "usage: copilot-review.sh <request|verify|status|wait> [flags]"
+shift
+
+OWNER="" REPO="" PR="" BASELINE="" INTERVAL=20 MAX_ITERS=60
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --owner)     OWNER="${2:-}"; shift 2 ;;
+    --repo)      REPO="${2:-}"; shift 2 ;;
+    --pr)        PR="${2:-}"; shift 2 ;;
+    --baseline)  BASELINE="${2:-}"; shift 2 ;;
+    --interval)  INTERVAL="${2:-}"; shift 2 ;;
+    --max-iters) MAX_ITERS="${2:-}"; shift 2 ;;
+    *)           die "unknown argument: $1" ;;
+  esac
+done
+
+# Auto-detect owner/repo/pr from context when not supplied.
+[ -n "$OWNER" ] || OWNER=$(gh repo view --json owner --jq '.owner.login' 2>/dev/null) || true
+[ -n "$REPO" ]  || REPO=$(gh repo view --json name --jq '.name' 2>/dev/null) || true
+[ -n "$OWNER" ] && [ -n "$REPO" ] || die "could not determine owner/repo — pass --owner and --repo"
+[ -n "$PR" ] || PR=$(gh pr view --json number --jq '.number' 2>/dev/null) || true
+[ -n "$PR" ] || die "could not determine PR number — pass --pr or checkout the PR branch"
+
+pr_node_id() {
+  # shellcheck disable=SC2016  # $owner/$repo/$number are GraphQL vars, not shell — must stay unexpanded
+  gh api graphql \
+    -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){id}}}' \
+    -F owner="$OWNER" -F repo="$REPO" -F number="$PR" \
+    --jq '.data.repository.pullRequest.id'
+}
+
+# Latest submitted_at across Copilot reviews, or empty if none yet.
+latest_copilot_ts() {
+  gh api "repos/$OWNER/$REPO/pulls/$PR/reviews" --paginate --jq \
+    "[.[] | select(.user.login==\"$BOT_REVIEW_LOGIN\" or .user.login==\"$BOT_DISPLAY_LOGIN\")] | max_by(.submitted_at) | .submitted_at // empty" \
+    2>/dev/null
+}
+
+case "$cmd" in
+  request)
+    pid=$(pr_node_id)
+    [ -n "$pid" ] || die "could not resolve PR node id for $OWNER/$REPO#$PR"
+    # shellcheck disable=SC2016  # $pr is a GraphQL var, not shell — must stay unexpanded
+    gh api graphql \
+      -f query='mutation($pr:ID!){requestReviewsByLogin(input:{pullRequestId:$pr,botLogins:["copilot-pull-request-reviewer"],union:true}){pullRequest{id}}}' \
+      -F pr="$pid" >/dev/null \
+      && echo "requested Copilot review on $OWNER/$REPO#$PR"
+    ;;
+
+  verify)
+    echo "== review_requested / copilot_work_started events =="
+    gh api "repos/$OWNER/$REPO/issues/$PR/events" --paginate --jq \
+      '.[] | select(.event=="review_requested" or .event=="copilot_work_started") | {event, actor:.actor.login, requested:(.requested_reviewer.login // null), app:(.performed_via_github_app.slug // null), created_at}'
+    echo "== pending requested reviewers =="
+    gh api "repos/$OWNER/$REPO/pulls/$PR/requested_reviewers" --jq '.users[].login' 2>/dev/null || true
+    ;;
+
+  status)
+    gh api "repos/$OWNER/$REPO/pulls/$PR/reviews" --paginate --jq \
+      '.[] | {user:.user.login, state, submitted_at, body:(.body[0:80])}'
+    ;;
+
+  wait)
+    i=0
+    while [ "$i" -lt "$MAX_ITERS" ]; do
+      latest=$(latest_copilot_ts)
+      if [ -n "$latest" ] && { [ -z "$BASELINE" ] || [[ "$latest" > "$BASELINE" ]]; }; then
+        echo "COPILOT_REVIEW_READY latest=$latest"
+        exit 0
+      fi
+      i=$((i + 1))
+      sleep "$INTERVAL"
+    done
+    echo "WATCHER_TIMEOUT_NO_NEW_REVIEW"
+    exit 0
+    ;;
+
+  *)
+    die "unknown command: $cmd (expected request|verify|status|wait)"
+    ;;
+esac

--- a/.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh
+++ b/.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh
@@ -41,14 +41,19 @@ cmd="${1:-}"
 shift
 
 OWNER="" REPO="" PR="" BASELINE="" INTERVAL=20 MAX_ITERS=60
+
+# Require that a flag was given a value ($2 present), so `--owner` with no value
+# fails clearly instead of `shift 2` erroring and continuing with empty values.
+require_value() { [ $# -ge 2 ] || die "flag $1 requires a value"; }
+
 while [ $# -gt 0 ]; do
   case "$1" in
-    --owner)     OWNER="${2:-}"; shift 2 ;;
-    --repo)      REPO="${2:-}"; shift 2 ;;
-    --pr)        PR="${2:-}"; shift 2 ;;
-    --baseline)  BASELINE="${2:-}"; shift 2 ;;
-    --interval)  INTERVAL="${2:-}"; shift 2 ;;
-    --max-iters) MAX_ITERS="${2:-}"; shift 2 ;;
+    --owner)     require_value "$@"; OWNER="$2"; shift 2 ;;
+    --repo)      require_value "$@"; REPO="$2"; shift 2 ;;
+    --pr)        require_value "$@"; PR="$2"; shift 2 ;;
+    --baseline)  require_value "$@"; BASELINE="$2"; shift 2 ;;
+    --interval)  require_value "$@"; INTERVAL="$2"; shift 2 ;;
+    --max-iters) require_value "$@"; MAX_ITERS="$2"; shift 2 ;;
     *)           die "unknown argument: $1" ;;
   esac
 done
@@ -68,11 +73,13 @@ pr_node_id() {
     --jq '.data.repository.pullRequest.id'
 }
 
-# Latest submitted_at across Copilot reviews, or empty if none yet.
+# Prints the latest submitted_at across Copilot reviews (empty if none yet) and
+# returns gh's exit status, so callers can tell "query succeeded, no review yet"
+# (rc 0, empty) apart from "query failed" (rc != 0). stderr is kept for the
+# caller to surface on failure rather than swallowed here.
 latest_copilot_ts() {
   gh api "repos/$OWNER/$REPO/pulls/$PR/reviews" --paginate --jq \
-    "[.[] | select(.user.login==\"$BOT_REVIEW_LOGIN\" or .user.login==\"$BOT_DISPLAY_LOGIN\")] | max_by(.submitted_at) | .submitted_at // empty" \
-    2>/dev/null
+    "[.[] | select(.user.login==\"$BOT_REVIEW_LOGIN\" or .user.login==\"$BOT_DISPLAY_LOGIN\")] | max_by(.submitted_at) | .submitted_at // empty"
 }
 
 case "$cmd" in
@@ -101,11 +108,24 @@ case "$cmd" in
 
   wait)
     i=0
+    fails=0
+    max_fails=3  # tolerate transient blips; abort only on persistent failure
     while [ "$i" -lt "$MAX_ITERS" ]; do
-      latest=$(latest_copilot_ts)
-      if [ -n "$latest" ] && { [ -z "$BASELINE" ] || [[ "$latest" > "$BASELINE" ]]; }; then
-        echo "COPILOT_REVIEW_READY latest=$latest"
-        exit 0
+      # Separate the query's success from its result: rc != 0 is a real failure
+      # (auth, bad PR, network), whereas rc 0 with empty output just means no
+      # Copilot review has landed yet. Masking the former as a timeout hides the
+      # actual problem, so fail fast once it is clearly not transient.
+      if latest=$(latest_copilot_ts 2>/dev/null); then
+        fails=0
+        if [ -n "$latest" ] && { [ -z "$BASELINE" ] || [[ "$latest" > "$BASELINE" ]]; }; then
+          echo "COPILOT_REVIEW_READY latest=$latest"
+          exit 0
+        fi
+      else
+        fails=$((fails + 1))
+        [ "$fails" -lt "$max_fails" ] \
+          || die "reviews query for $OWNER/$REPO#$PR failed $fails times in a row (auth / bad PR / network?) — aborting wait"
+        echo "warn: reviews query failed (attempt $fails/$max_fails), retrying…" >&2
       fi
       i=$((i + 1))
       sleep "$INTERVAL"

--- a/.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh
+++ b/.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh
@@ -42,9 +42,14 @@ shift
 
 OWNER="" REPO="" PR="" BASELINE="" INTERVAL=20 MAX_ITERS=60
 
-# Require that a flag was given a value ($2 present), so `--owner` with no value
-# fails clearly instead of `shift 2` erroring and continuing with empty values.
-require_value() { [ $# -ge 2 ] || die "flag $1 requires a value"; }
+# Require that a flag was given a real value: a next token must exist and not
+# itself look like a flag, so `--owner` (no value) or `--owner --repo x` both
+# fail clearly instead of `shift 2` erroring or capturing `--repo` as the value.
+# None of this script's values legitimately start with `-`.
+require_value() {
+  [ $# -ge 2 ] || die "flag $1 requires a value"
+  case "$2" in -*) die "flag $1 requires a value, got flag-like '$2'" ;; esac
+}
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -115,7 +120,9 @@ case "$cmd" in
       # (auth, bad PR, network), whereas rc 0 with empty output just means no
       # Copilot review has landed yet. Masking the former as a timeout hides the
       # actual problem, so fail fast once it is clearly not transient.
-      if latest=$(latest_copilot_ts 2>/dev/null); then
+      # No 2>/dev/null here: on failure let gh/jq's own error reach the caller,
+      # per latest_copilot_ts's contract, so repeated failures are diagnosable.
+      if latest=$(latest_copilot_ts); then
         fails=0
         if [ -n "$latest" ] && { [ -z "$BASELINE" ] || [[ "$latest" > "$BASELINE" ]]; }; then
           echo "COPILOT_REVIEW_READY latest=$latest"


### PR DESCRIPTION
## Summary

The `gh-pr-copilot-review` skill drove its Copilot request/verify/monitor/wait steps through **inline shell snippets** that got retyped each session and repeatedly broke on shell portability. Most recently the review-wait loop used `[ "$LATEST" \> "$BASELINE" ]`, which errors under **zsh** with `condition expected: >` and never matches — so the background watcher looped uselessly until timeout while Copilot's review had already landed.

This packages those steps into a single tested script and points the skill at it.

## What changed

- **New `scripts/copilot-review.sh`** with subcommands `request`, `verify`, `status`, `wait`:
  - `#!/usr/bin/env bash` shebang → immune to the caller's interactive shell (the root cause of the zsh bug).
  - `wait` compares ISO-8601 timestamps with `[[ > ]]` under `LC_ALL=C`, supports `--baseline` / `--interval` / `--max-iters`, and prints `COPILOT_REVIEW_READY` / `WATCHER_TIMEOUT_NO_NEW_REVIEW`.
  - `owner`/`repo`/`pr` auto-detect from the current repo and checked-out PR branch, so the common call is just `scripts/copilot-review.sh wait`.
- **`SKILL.md`** now calls the script throughout, with the raw `gh`/GraphQL snippets kept as under-the-hood documentation and fallback, plus explicit warnings not to hand-roll the poll loop.

## Testing

- `bash -n` and `shellcheck`: clean.
- Exercised against a live PR: `status` printed the review; `wait` (empty baseline) reported `COPILOT_REVIEW_READY` immediately; `wait --baseline <current-ts>` correctly timed out; `wait --baseline <older-ts>` matched. This is the exact scenario the old zsh snippet failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)