### PR TITLE
build(ios): add Makefile targets + swift-format the codebase

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -72,6 +72,12 @@ jobs:
       - name: SwiftLint
         run: swiftlint lint --quiet
 
+      # swift-format (bundled with the selected Xcode) owns layout; enforce it
+      # in CI so unformatted code can't merge. Mirrors `make check-ios` /
+      # `make format-ios`. --strict fails the job on any formatting drift.
+      - name: swift-format lint
+        run: xcrun swift-format lint --strict --recursive Pussel PusselTests
+
       - name: Build
         run: |
           set -o pipefail

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,10 @@
         start-backend start-frontend stop-backend stop-frontend \
         ios-generate ios-run ios-deploy ios-test
 
-# Run all checks (Python + Next.js)
-check: check-backend check-network check-shared check-frontend
+# Run all checks (Python + Next.js + iOS)
+# Note: check-ios needs macOS + Xcode; CI calls the per-component targets
+# directly (never this aggregate), so Linux runners are unaffected.
+check: check-backend check-network check-shared check-frontend check-ios
 
 # Backend checks (uses uv to run tools from the backend venv)
 check-backend:
@@ -41,8 +43,8 @@ check-frontend:
 check-ios:
 	cd ios && xcrun swift-format lint --strict --recursive Pussel PusselTests
 
-# Auto-format all code (Python + Next.js)
-format: format-backend format-network format-frontend
+# Auto-format all code (Python + Next.js + iOS)
+format: format-backend format-network format-frontend format-ios
 
 # Auto-format backend (uses uv to run tools from the backend venv)
 format-backend:

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ ios-test: ios-generate
 ios-deploy: ios-generate
 	@DEVICE="$(IOS_DEVICE)"; \
 	if [ -z "$$DEVICE" ]; then \
-		DEVICE=$$(xcrun devicectl list devices 2>/dev/null | awk '/connected/ {for (i=1;i<=NF;i++) if ($$i ~ /^[0-9A-Fa-f]{8}-[0-9A-Fa-f]/) {print $$i; exit}}'); \
+		DEVICE=$$(xcrun devicectl list devices 2>/dev/null | awk '{ ok=0; for (i=1;i<=NF;i++) if ($$i=="connected") ok=1; if (ok) for (i=1;i<=NF;i++) if ($$i ~ /^[0-9A-Fa-f]{8}-[0-9A-Fa-f]/) {print $$i; exit} }'); \
 	fi; \
 	if [ -z "$$DEVICE" ]; then \
 		echo "No connected iPhone found. Connect and trust a device, or pass IOS_DEVICE=<name-or-udid>."; \

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,9 @@
         ios-generate ios-run ios-deploy ios-test
 
 # Run all checks (Python + Next.js + iOS)
-# Note: check-ios needs macOS + Xcode; CI calls the per-component targets
-# directly (never this aggregate), so Linux runners are unaffected.
+# check-ios self-skips where swift-format is unavailable (non-macOS), so this
+# aggregate stays cross-platform. CI also calls the per-component targets
+# directly rather than this aggregate.
 check: check-backend check-network check-shared check-frontend check-ios
 
 # Backend checks (uses uv to run tools from the backend venv)
@@ -39,9 +40,15 @@ check-frontend:
 
 # iOS checks — lint Swift formatting without modifying files (macOS + Xcode only).
 # Uses Apple's official swift-format bundled with Xcode; --strict makes lint
-# warnings fail the build so it doubles as a CI-style gate.
+# warnings fail the build so it doubles as a CI-style gate. Skips cleanly where
+# swift-format is unavailable (non-macOS), so the `check` aggregate stays
+# cross-platform.
 check-ios:
-	cd ios && xcrun swift-format lint --strict --recursive Pussel PusselTests
+	@if xcrun --find swift-format >/dev/null 2>&1; then \
+		cd ios && xcrun swift-format lint --strict --recursive Pussel PusselTests; \
+	else \
+		echo "Skipping check-ios (swift-format not found — needs macOS + Xcode)"; \
+	fi
 
 # Auto-format all code (Python + Next.js + iOS)
 format: format-backend format-network format-frontend format-ios
@@ -67,9 +74,14 @@ format-frontend:
 
 # Auto-format iOS Swift code in place (macOS + Xcode only). Uses Apple's
 # official swift-format (bundled with Xcode) with its default style (no
-# project config file).
+# project config file). Skips cleanly where swift-format is unavailable
+# (non-macOS), so the `format` aggregate stays cross-platform.
 format-ios:
-	cd ios && xcrun swift-format format --in-place --recursive Pussel PusselTests
+	@if xcrun --find swift-format >/dev/null 2>&1; then \
+		cd ios && xcrun swift-format format --in-place --recursive Pussel PusselTests; \
+	else \
+		echo "Skipping format-ios (swift-format not found — needs macOS + Xcode)"; \
+	fi
 
 # Run backend tests with coverage (uses uv)
 test-backend:

--- a/Makefile
+++ b/Makefile
@@ -147,17 +147,17 @@ ios-generate:
 ios-run: ios-generate
 	xcrun simctl boot "$(IOS_SIMULATOR)" 2>/dev/null || true
 	open -a Simulator
-	xcodebuild build -project $(IOS_PROJECT) -scheme $(IOS_SCHEME) \
-		-destination 'platform=iOS Simulator,name=$(IOS_SIMULATOR)' -derivedDataPath $(IOS_DERIVED)
-	xcrun simctl install booted $(IOS_DERIVED)/Build/Products/Debug-iphonesimulator/$(IOS_APP_NAME).app
-	xcrun simctl launch booted $(IOS_BUNDLE_ID)
+	xcodebuild build -project "$(IOS_PROJECT)" -scheme "$(IOS_SCHEME)" \
+		-destination 'platform=iOS Simulator,name=$(IOS_SIMULATOR)' -derivedDataPath "$(IOS_DERIVED)"
+	xcrun simctl install booted "$(IOS_DERIVED)/Build/Products/Debug-iphonesimulator/$(IOS_APP_NAME).app"
+	xcrun simctl launch booted "$(IOS_BUNDLE_ID)"
 
 # Run the unit tests on the Simulator.
 ios-test: ios-generate
-	xcodebuild test -project $(IOS_PROJECT) -scheme $(IOS_SCHEME) \
-		-destination 'platform=iOS Simulator,name=$(IOS_SIMULATOR)' -derivedDataPath $(IOS_DERIVED)
+	xcodebuild test -project "$(IOS_PROJECT)" -scheme "$(IOS_SCHEME)" \
+		-destination 'platform=iOS Simulator,name=$(IOS_SIMULATOR)' -derivedDataPath "$(IOS_DERIVED)"
 
-# Build a Debug build, then install + launch on a connected iPhone.
+# Build a Debug build, then install + launch on a connected device (iPhone/iPad).
 # Requires DEVELOPMENT_TEAM in ios/Config/Secrets.xcconfig (device signing).
 # The device is auto-detected; override with IOS_DEVICE=<name-or-udid>.
 ios-deploy: ios-generate
@@ -166,12 +166,12 @@ ios-deploy: ios-generate
 		DEVICE=$$(xcrun devicectl list devices 2>/dev/null | awk '{ ok=0; for (i=1;i<=NF;i++) if ($$i=="connected") ok=1; if (ok) for (i=1;i<=NF;i++) if ($$i ~ /^[0-9A-Fa-f]{8}-[0-9A-Fa-f]/) {print $$i; exit} }'); \
 	fi; \
 	if [ -z "$$DEVICE" ]; then \
-		echo "No connected iPhone found. Connect and trust a device, or pass IOS_DEVICE=<name-or-udid>."; \
+		echo "No connected device found. Connect and trust a device, or pass IOS_DEVICE=<name-or-udid>."; \
 		exit 1; \
 	fi; \
 	echo "Deploying to device: $$DEVICE"; \
-	xcodebuild build -project $(IOS_PROJECT) -scheme $(IOS_SCHEME) \
-		-destination 'generic/platform=iOS' -derivedDataPath $(IOS_DERIVED) -allowProvisioningUpdates && \
+	xcodebuild build -project "$(IOS_PROJECT)" -scheme "$(IOS_SCHEME)" \
+		-destination 'generic/platform=iOS' -derivedDataPath "$(IOS_DERIVED)" -allowProvisioningUpdates && \
 	xcrun devicectl device install app --device "$$DEVICE" \
-		$(IOS_DERIVED)/Build/Products/Debug-iphoneos/$(IOS_APP_NAME).app && \
-	xcrun devicectl device process launch --device "$$DEVICE" $(IOS_BUNDLE_ID)
+		"$(IOS_DERIVED)/Build/Products/Debug-iphoneos/$(IOS_APP_NAME).app" && \
+	xcrun devicectl device process launch --device "$$DEVICE" "$(IOS_BUNDLE_ID)"

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,8 @@ format-frontend:
 	cd frontend && bun run format
 
 # Auto-format iOS Swift code in place (macOS + Xcode only). Uses Apple's
-# official swift-format (bundled with Xcode); style comes from ios/.swift-format.
+# official swift-format (bundled with Xcode) with its default style (no
+# project config file).
 format-ios:
 	cd ios && xcrun swift-format format --in-place --recursive Pussel PusselTests
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,9 @@ check-ios:
 	fi
 
 # Auto-format all code (Python + Next.js + iOS)
-format: format-backend format-network format-frontend format-ios
+# Mirrors the `check` aggregate, including format-shared (the shared library is
+# linted by check-shared, so it must be formatted here too).
+format: format-backend format-network format-shared format-frontend format-ios
 
 # Auto-format backend (uses uv to run tools from the backend venv)
 format-backend:
@@ -123,6 +125,10 @@ IOS_DERIVED    = ios/.build
 # Regenerate the (gitignored) Xcode project from project.yml. Requires
 # `brew install xcodegen`; needs Config/Secrets.xcconfig to exist first.
 ios-generate:
+	@command -v xcodegen >/dev/null 2>&1 || { \
+		echo "xcodegen not found. Install it with: brew install xcodegen"; exit 1; }
+	@test -f ios/Config/Secrets.xcconfig || \
+		echo "Warning: ios/Config/Secrets.xcconfig is missing — copy ios/Config/Secrets.example.xcconfig (device builds need DEVELOPMENT_TEAM)."
 	cd ios && xcodegen generate
 
 # Build, install, and launch on the iOS Simulator. Boots the target simulator

--- a/Makefile
+++ b/Makefile
@@ -127,8 +127,11 @@ IOS_DERIVED    = ios/.build
 ios-generate:
 	@command -v xcodegen >/dev/null 2>&1 || { \
 		echo "xcodegen not found. Install it with: brew install xcodegen"; exit 1; }
-	@test -f ios/Config/Secrets.xcconfig || \
-		echo "Warning: ios/Config/Secrets.xcconfig is missing — copy ios/Config/Secrets.example.xcconfig (device builds need DEVELOPMENT_TEAM)."
+	@test -f ios/Config/Secrets.xcconfig || { \
+		echo "ios/Config/Secrets.xcconfig is missing. Debug.xcconfig and Release.xcconfig"; \
+		echo "#include it, so xcodebuild fails without it. Create it with:"; \
+		echo "  cp ios/Config/Secrets.example.xcconfig ios/Config/Secrets.xcconfig"; \
+		exit 1; }
 	cd ios && xcodegen generate
 
 # Build, install, and launch on the iOS Simulator. Boots the target simulator

--- a/Makefile
+++ b/Makefile
@@ -136,9 +136,9 @@ ios-generate:
 	@command -v xcodegen >/dev/null 2>&1 || { \
 		echo "xcodegen not found. Install it with: brew install xcodegen"; exit 1; }
 	@test -f ios/Config/Secrets.xcconfig || { \
-		echo "ios/Config/Secrets.xcconfig is missing. Debug.xcconfig and Release.xcconfig"; \
-		echo "#include it, so xcodebuild fails without it. Create it with:"; \
-		echo "  cp ios/Config/Secrets.example.xcconfig ios/Config/Secrets.xcconfig"; \
+		echo "ios/Config/Secrets.xcconfig is missing."; \
+		echo "The Debug/Release xcconfigs #include it, so xcodebuild fails without it."; \
+		echo "Create it with: cp ios/Config/Secrets.example.xcconfig ios/Config/Secrets.xcconfig"; \
 		exit 1; }
 	cd ios && xcodegen generate
 

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,9 @@ stop-frontend:
 #   make ios-run IOS_SIMULATOR="iPhone 17 Pro Max"
 #   make ios-deploy IOS_DEVICE=<name-or-udid>
 IOS_SCHEME     = Pussel
+# Built product name (<IOS_APP_NAME>.app). Keep it in sync with IOS_SCHEME's
+# target PRODUCT_NAME if you override the scheme.
+IOS_APP_NAME   = Pussel
 IOS_BUNDLE_ID  = dk.delectosoft.pussel
 IOS_PROJECT    = ios/Pussel.xcodeproj
 IOS_SIMULATOR ?= iPhone 17 Pro
@@ -146,7 +149,7 @@ ios-run: ios-generate
 	open -a Simulator
 	xcodebuild build -project $(IOS_PROJECT) -scheme $(IOS_SCHEME) \
 		-destination 'platform=iOS Simulator,name=$(IOS_SIMULATOR)' -derivedDataPath $(IOS_DERIVED)
-	xcrun simctl install booted $(IOS_DERIVED)/Build/Products/Debug-iphonesimulator/Pussel.app
+	xcrun simctl install booted $(IOS_DERIVED)/Build/Products/Debug-iphonesimulator/$(IOS_APP_NAME).app
 	xcrun simctl launch booted $(IOS_BUNDLE_ID)
 
 # Run the unit tests on the Simulator.
@@ -170,5 +173,5 @@ ios-deploy: ios-generate
 	xcodebuild build -project $(IOS_PROJECT) -scheme $(IOS_SCHEME) \
 		-destination 'generic/platform=iOS' -derivedDataPath $(IOS_DERIVED) -allowProvisioningUpdates && \
 	xcrun devicectl device install app --device "$$DEVICE" \
-		$(IOS_DERIVED)/Build/Products/Debug-iphoneos/Pussel.app && \
+		$(IOS_DERIVED)/Build/Products/Debug-iphoneos/$(IOS_APP_NAME).app && \
 	xcrun devicectl device process launch --device "$$DEVICE" $(IOS_BUNDLE_ID)

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 # Makefile for running CI checks locally
 # Run `make check` to run all checks, or individual targets
 
-.PHONY: check check-backend check-network check-shared check-frontend \
-        format format-backend format-network format-shared format-frontend \
+.PHONY: check check-backend check-network check-shared check-frontend check-ios \
+        format format-backend format-network format-shared format-frontend format-ios \
         test-backend install-dev-backend install-dev-network \
-        start-backend start-frontend stop-backend stop-frontend
+        start-backend start-frontend stop-backend stop-frontend \
+        ios-generate ios-run ios-deploy ios-test
 
 # Run all checks (Python + Next.js)
 check: check-backend check-network check-shared check-frontend
@@ -34,6 +35,12 @@ check-shared:
 check-frontend:
 	cd frontend && bun run check
 
+# iOS checks — lint Swift formatting without modifying files (macOS + Xcode only).
+# Uses Apple's official swift-format bundled with Xcode; --strict makes lint
+# warnings fail the build so it doubles as a CI-style gate.
+check-ios:
+	cd ios && xcrun swift-format lint --strict --recursive Pussel PusselTests
+
 # Auto-format all code (Python + Next.js)
 format: format-backend format-network format-frontend
 
@@ -55,6 +62,11 @@ format-shared:
 # Auto-format frontend
 format-frontend:
 	cd frontend && bun run format
+
+# Auto-format iOS Swift code in place (macOS + Xcode only). Uses Apple's
+# official swift-format (bundled with Xcode); style comes from ios/.swift-format.
+format-ios:
+	cd ios && xcrun swift-format format --in-place --recursive Pussel PusselTests
 
 # Run backend tests with coverage (uses uv)
 test-backend:
@@ -80,3 +92,54 @@ stop-backend:
 
 stop-frontend:
 	@lsof -ti:3000 | xargs kill -9 2>/dev/null || echo "Frontend not running on port 3000"
+
+# ---------------------------------------------------------------------------
+# iOS app (macOS + Xcode 26 only)
+# ---------------------------------------------------------------------------
+# Config knobs — override on the command line, e.g.
+#   make ios-run IOS_SIMULATOR="iPhone 17 Pro Max"
+#   make ios-deploy IOS_DEVICE=<name-or-udid>
+IOS_SCHEME     = Pussel
+IOS_BUNDLE_ID  = dk.delectosoft.pussel
+IOS_PROJECT    = ios/Pussel.xcodeproj
+IOS_SIMULATOR ?= iPhone 17 Pro
+IOS_DERIVED    = ios/.build
+
+# Regenerate the (gitignored) Xcode project from project.yml. Requires
+# `brew install xcodegen`; needs Config/Secrets.xcconfig to exist first.
+ios-generate:
+	cd ios && xcodegen generate
+
+# Build, install, and launch on the iOS Simulator. Boots the target simulator
+# and opens Simulator.app if it isn't already running.
+ios-run: ios-generate
+	xcrun simctl boot "$(IOS_SIMULATOR)" 2>/dev/null || true
+	open -a Simulator
+	xcodebuild build -project $(IOS_PROJECT) -scheme $(IOS_SCHEME) \
+		-destination 'platform=iOS Simulator,name=$(IOS_SIMULATOR)' -derivedDataPath $(IOS_DERIVED)
+	xcrun simctl install booted $(IOS_DERIVED)/Build/Products/Debug-iphonesimulator/Pussel.app
+	xcrun simctl launch booted $(IOS_BUNDLE_ID)
+
+# Run the unit tests on the Simulator.
+ios-test: ios-generate
+	xcodebuild test -project $(IOS_PROJECT) -scheme $(IOS_SCHEME) \
+		-destination 'platform=iOS Simulator,name=$(IOS_SIMULATOR)' -derivedDataPath $(IOS_DERIVED)
+
+# Build a Debug build, then install + launch on a connected iPhone.
+# Requires DEVELOPMENT_TEAM in ios/Config/Secrets.xcconfig (device signing).
+# The device is auto-detected; override with IOS_DEVICE=<name-or-udid>.
+ios-deploy: ios-generate
+	@DEVICE="$(IOS_DEVICE)"; \
+	if [ -z "$$DEVICE" ]; then \
+		DEVICE=$$(xcrun devicectl list devices 2>/dev/null | awk '/connected/ {for (i=1;i<=NF;i++) if ($$i ~ /^[0-9A-Fa-f]{8}-[0-9A-Fa-f]/) {print $$i; exit}}'); \
+	fi; \
+	if [ -z "$$DEVICE" ]; then \
+		echo "No connected iPhone found. Connect and trust a device, or pass IOS_DEVICE=<name-or-udid>."; \
+		exit 1; \
+	fi; \
+	echo "Deploying to device: $$DEVICE"; \
+	xcodebuild build -project $(IOS_PROJECT) -scheme $(IOS_SCHEME) \
+		-destination 'generic/platform=iOS' -derivedDataPath $(IOS_DERIVED) -allowProvisioningUpdates && \
+	xcrun devicectl device install app --device "$$DEVICE" \
+		$(IOS_DERIVED)/Build/Products/Debug-iphoneos/Pussel.app && \
+	xcrun devicectl device process launch --device "$$DEVICE" $(IOS_BUNDLE_ID)

--- a/ios/Pussel/App/AppActions.swift
+++ b/ios/Pussel/App/AppActions.swift
@@ -2,83 +2,84 @@ import UIKit
 
 /// Wizard actions shared by the UI and the debug deep links.
 extension AppModel {
-    /// Default label for a new puzzle — the capture date/time.
-    private static let puzzleNameFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .short
-        return formatter
-    }()
+  /// Default label for a new puzzle — the capture date/time.
+  private static let puzzleNameFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .medium
+    formatter.timeStyle = .short
+    return formatter
+  }()
 
-    /// Detects the puzzle frame and moves to the confirm-trim step.
-    func startTrim(image: UIImage, source: CaptureSource) async {
-        guard let jpeg = ImageUtilities.normalizedJPEG(from: image) else {
-            flow.errorMessage = "Could not process the photo."
-            return
-        }
-        flow.errorMessage = nil
-        flow.isBusy = true
-        defer { flow.isBusy = false }
-        do {
-            let detection = try await api.detectFrame(jpegData: jpeg)
-            flow.phase = .confirmTrim(TrimCandidate(rawJPEG: jpeg, detection: detection, source: source))
-        } catch {
-            flow.errorMessage = error.localizedDescription
-        }
+  /// Detects the puzzle frame and moves to the confirm-trim step.
+  func startTrim(image: UIImage, source: CaptureSource) async {
+    guard let jpeg = ImageUtilities.normalizedJPEG(from: image) else {
+      flow.errorMessage = "Could not process the photo."
+      return
     }
+    flow.errorMessage = nil
+    flow.isBusy = true
+    defer { flow.isBusy = false }
+    do {
+      let detection = try await api.detectFrame(jpegData: jpeg)
+      flow.phase = .confirmTrim(TrimCandidate(rawJPEG: jpeg, detection: detection, source: source))
+    } catch {
+      flow.errorMessage = error.localizedDescription
+    }
+  }
 
-    /// Uploads the accepted trimmed image and starts a solve session.
-    func acceptTrim(_ candidate: TrimCandidate) async {
-        guard let trimmed = candidate.trimmedJPEG else {
-            flow.errorMessage = "Could not decode the trimmed image."
-            return
-        }
-        flow.errorMessage = nil
-        flow.isBusy = true
-        defer { flow.isBusy = false }
-        do {
-            let response = try await api.uploadPuzzle(jpegData: trimmed)
-            let session = SolveSession(
-                name: Self.puzzleNameFormatter.string(from: Date()),
-                puzzleId: response.puzzleId,
-                trimmedJPEG: trimmed,
-                store: store
-            )
-            // Persist immediately so the puzzle survives even before any pieces
-            // are added and shows up on the home screen right away.
-            session.persist()
-            flow.phase = .solving(session)
-        } catch {
-            flow.errorMessage = error.localizedDescription
-        }
+  /// Uploads the accepted trimmed image and starts a solve session.
+  func acceptTrim(_ candidate: TrimCandidate) async {
+    guard let trimmed = candidate.trimmedJPEG else {
+      flow.errorMessage = "Could not decode the trimmed image."
+      return
     }
+    flow.errorMessage = nil
+    flow.isBusy = true
+    defer { flow.isBusy = false }
+    do {
+      let response = try await api.uploadPuzzle(jpegData: trimmed)
+      let session = SolveSession(
+        name: Self.puzzleNameFormatter.string(from: Date()),
+        puzzleId: response.puzzleId,
+        trimmedJPEG: trimmed,
+        store: store
+      )
+      // Persist immediately so the puzzle survives even before any pieces
+      // are added and shows up on the home screen right away.
+      session.persist()
+      flow.phase = .solving(session)
+    } catch {
+      flow.errorMessage = error.localizedDescription
+    }
+  }
 
-    /// Queues a captured piece photo for prediction in the current session.
-    func addPiece(image: UIImage) {
-        guard case .solving(let session) = flow.phase,
-              let jpeg = ImageUtilities.normalizedJPEG(from: image, maxDimension: 1600, quality: 0.9) else { return }
-        session.enqueue(jpeg: jpeg, api: api)
-    }
+  /// Queues a captured piece photo for prediction in the current session.
+  func addPiece(image: UIImage) {
+    guard case .solving(let session) = flow.phase,
+      let jpeg = ImageUtilities.normalizedJPEG(from: image, maxDimension: 1600, quality: 0.9)
+    else { return }
+    session.enqueue(jpeg: jpeg, api: api)
+  }
 
-    /// Reopens a stored puzzle from disk and resumes solving it. Pieces that
-    /// were never predicted are re-queued; if the server forgot this puzzle_id
-    /// (in-memory store restarted) the solve view's expired banner recovers it.
-    func openPuzzle(_ id: UUID) {
-        guard let session = store.loadSession(id: id) else {
-            flow.errorMessage = "Could not open that puzzle."
-            return
-        }
-        flow.errorMessage = nil
-        flow.phase = .solving(session)
-        session.resume(api: api)
+  /// Reopens a stored puzzle from disk and resumes solving it. Pieces that
+  /// were never predicted are re-queued; if the server forgot this puzzle_id
+  /// (in-memory store restarted) the solve view's expired banner recovers it.
+  func openPuzzle(_ id: UUID) {
+    guard let session = store.loadSession(id: id) else {
+      flow.errorMessage = "Could not open that puzzle."
+      return
     }
+    flow.errorMessage = nil
+    flow.phase = .solving(session)
+    session.resume(api: api)
+  }
 
-    /// Permanently deletes a stored puzzle. If it is the one being solved,
-    /// returns to the capture screen.
-    func deletePuzzle(_ id: UUID) {
-        if case .solving(let session) = flow.phase, session.id == id {
-            flow.reset()
-        }
-        store.delete(id)
+  /// Permanently deletes a stored puzzle. If it is the one being solved,
+  /// returns to the capture screen.
+  func deletePuzzle(_ id: UUID) {
+    if case .solving(let session) = flow.phase, session.id == id {
+      flow.reset()
     }
+    store.delete(id)
+  }
 }

--- a/ios/Pussel/App/AppFlow.swift
+++ b/ios/Pussel/App/AppFlow.swift
@@ -4,46 +4,46 @@ import Observation
 /// The linear real-mode wizard, mirroring the web app's RealModePhase
 /// (frontend/src/app/real/page.tsx) minus the corner-adjust step.
 enum AppPhase {
-    case capturePuzzle
-    case confirmTrim(TrimCandidate)
-    case solving(SolveSession)
+  case capturePuzzle
+  case confirmTrim(TrimCandidate)
+  case solving(SolveSession)
 }
 
 /// How the puzzle overview photo was supplied, so "Retake" can reopen the
 /// same picker instead of dropping back to the chooser screen.
 enum CaptureSource {
-    case camera
-    case library
+  case camera
+  case library
 }
 
 /// A detect-frame result awaiting user confirmation.
 struct TrimCandidate {
-    let rawJPEG: Data
-    let detection: DetectFrameResponse
-    let source: CaptureSource
+  let rawJPEG: Data
+  let detection: DetectFrameResponse
+  let source: CaptureSource
 
-    var trimmedJPEG: Data? {
-        ImageUtilities.decodeDataURL(detection.trimmedImage)
-    }
+  var trimmedJPEG: Data? {
+    ImageUtilities.decodeDataURL(detection.trimmedImage)
+  }
 }
 
 @Observable
 @MainActor
 final class AppFlowStore {
-    var phase: AppPhase = .capturePuzzle
-    var isBusy = false
-    var errorMessage: String?
+  var phase: AppPhase = .capturePuzzle
+  var isBusy = false
+  var errorMessage: String?
 
-    /// Set when the user taps "Retake" so CapturePuzzleView reopens the same
-    /// picker on appear; cleared once consumed.
-    var pendingRetake: CaptureSource?
+  /// Set when the user taps "Retake" so CapturePuzzleView reopens the same
+  /// picker on appear; cleared once consumed.
+  var pendingRetake: CaptureSource?
 
-    func reset() {
-        phase = .capturePuzzle
-        isBusy = false
-        errorMessage = nil
-        pendingRetake = nil
-    }
+  func reset() {
+    phase = .capturePuzzle
+    isBusy = false
+    errorMessage = nil
+    pendingRetake = nil
+  }
 }
 
 /// State for one solving session. The trimmed image is kept so the puzzle can
@@ -54,120 +54,122 @@ final class AppFlowStore {
 @Observable
 @MainActor
 final class SolveSession {
-    /// Stable local identity used as the on-disk folder name.
-    let id: UUID
-    /// Human-friendly label shown on the home screen (defaults to a date).
-    var name: String
-    let createdAt: Date
-    var puzzleId: String
-    let trimmedJPEG: Data
-    var entries: [CaptureEntry] = []
-    var isProcessing = false
-    var puzzleExpired = false
-    var errorMessage: String?
+  /// Stable local identity used as the on-disk folder name.
+  let id: UUID
+  /// Human-friendly label shown on the home screen (defaults to a date).
+  var name: String
+  let createdAt: Date
+  var puzzleId: String
+  let trimmedJPEG: Data
+  var entries: [CaptureEntry] = []
+  var isProcessing = false
+  var puzzleExpired = false
+  var errorMessage: String?
 
-    @ObservationIgnored private let store: PuzzleStore?
+  @ObservationIgnored private let store: PuzzleStore?
 
-    init(
-        id: UUID = UUID(),
-        name: String,
-        puzzleId: String,
-        trimmedJPEG: Data,
-        createdAt: Date = Date(),
-        store: PuzzleStore? = nil
-    ) {
-        self.id = id
-        self.name = name
-        self.puzzleId = puzzleId
-        self.trimmedJPEG = trimmedJPEG
-        self.createdAt = createdAt
-        self.store = store
+  init(
+    id: UUID = UUID(),
+    name: String,
+    puzzleId: String,
+    trimmedJPEG: Data,
+    createdAt: Date = Date(),
+    store: PuzzleStore? = nil
+  ) {
+    self.id = id
+    self.name = name
+    self.puzzleId = puzzleId
+    self.trimmedJPEG = trimmedJPEG
+    self.createdAt = createdAt
+    self.store = store
+  }
+
+  /// Writes the current state to disk. Cheap and idempotent.
+  func persist() {
+    store?.save(self)
+  }
+
+  var placedEntries: [CaptureEntry] {
+    entries.filter { $0.result != nil }
+  }
+
+  func enqueue(jpeg: Data, api: APIClient) {
+    entries.append(CaptureEntry(jpeg: jpeg))
+    persist()
+    processNext(api: api)
+  }
+
+  /// Resumes any pieces left `.queued` from a reloaded session.
+  func resume(api: APIClient) {
+    processNext(api: api)
+  }
+
+  func retry(id: UUID, api: APIClient) {
+    guard let index = entries.firstIndex(where: { $0.id == id }) else { return }
+    entries[index].status = .queued
+    processNext(api: api)
+  }
+
+  func remove(id: UUID) {
+    entries.removeAll { $0.id == id }
+    persist()
+  }
+
+  /// Serially drains the queue — one in-flight prediction at a time, like
+  /// the web's usePredictionWorker (rembg segmentation is the slow step).
+  func processNext(api: APIClient) {
+    guard !isProcessing, let index = entries.firstIndex(where: { $0.status == .queued }) else {
+      return
     }
-
-    /// Writes the current state to disk. Cheap and idempotent.
-    func persist() {
-        store?.save(self)
+    isProcessing = true
+    let entry = entries[index]
+    entries[index].status = .predicting
+    Task {
+      await self.process(entry: entry, api: api)
+      self.isProcessing = false
+      self.processNext(api: api)
     }
+  }
 
-    var placedEntries: [CaptureEntry] {
-        entries.filter { $0.result != nil }
+  private func process(entry: CaptureEntry, api: APIClient) async {
+    do {
+      let piece = try await api.processPiece(puzzleId: puzzleId, jpegData: entry.uploadJPEG)
+      update(id: entry.id) { current in
+        current.status = .done
+        current.result = piece
+        if let cleaned = piece.cleanedImage, let data = ImageUtilities.decodeDataURL(cleaned) {
+          current.displayImage = data
+        }
+      }
+      persist()
+    } catch let error as APIError where error.status == 404 {
+      puzzleExpired = true
+      update(id: entry.id) { $0.status = .expired }
+    } catch {
+      update(id: entry.id) { $0.status = .error(error.localizedDescription) }
     }
+  }
 
-    func enqueue(jpeg: Data, api: APIClient) {
-        entries.append(CaptureEntry(jpeg: jpeg))
-        persist()
-        processNext(api: api)
-    }
-
-    /// Resumes any pieces left `.queued` from a reloaded session.
-    func resume(api: APIClient) {
-        processNext(api: api)
-    }
-
-    func retry(id: UUID, api: APIClient) {
-        guard let index = entries.firstIndex(where: { $0.id == id }) else { return }
+  /// Gets a fresh puzzle_id for the kept trimmed image after a backend
+  /// restart, then re-queues entries that failed on the dead id.
+  func reupload(api: APIClient) async {
+    errorMessage = nil
+    do {
+      let response = try await api.uploadPuzzle(jpegData: trimmedJPEG)
+      puzzleId = response.puzzleId
+      puzzleExpired = false
+      for index in entries.indices where entries[index].status == .expired {
         entries[index].status = .queued
-        processNext(api: api)
+      }
+      persist()
+      processNext(api: api)
+    } catch {
+      errorMessage = error.localizedDescription
     }
+  }
 
-    func remove(id: UUID) {
-        entries.removeAll { $0.id == id }
-        persist()
-    }
-
-    /// Serially drains the queue — one in-flight prediction at a time, like
-    /// the web's usePredictionWorker (rembg segmentation is the slow step).
-    func processNext(api: APIClient) {
-        guard !isProcessing, let index = entries.firstIndex(where: { $0.status == .queued }) else { return }
-        isProcessing = true
-        let entry = entries[index]
-        entries[index].status = .predicting
-        Task {
-            await self.process(entry: entry, api: api)
-            self.isProcessing = false
-            self.processNext(api: api)
-        }
-    }
-
-    private func process(entry: CaptureEntry, api: APIClient) async {
-        do {
-            let piece = try await api.processPiece(puzzleId: puzzleId, jpegData: entry.uploadJPEG)
-            update(id: entry.id) { current in
-                current.status = .done
-                current.result = piece
-                if let cleaned = piece.cleanedImage, let data = ImageUtilities.decodeDataURL(cleaned) {
-                    current.displayImage = data
-                }
-            }
-            persist()
-        } catch let error as APIError where error.status == 404 {
-            puzzleExpired = true
-            update(id: entry.id) { $0.status = .expired }
-        } catch {
-            update(id: entry.id) { $0.status = .error(error.localizedDescription) }
-        }
-    }
-
-    /// Gets a fresh puzzle_id for the kept trimmed image after a backend
-    /// restart, then re-queues entries that failed on the dead id.
-    func reupload(api: APIClient) async {
-        errorMessage = nil
-        do {
-            let response = try await api.uploadPuzzle(jpegData: trimmedJPEG)
-            puzzleId = response.puzzleId
-            puzzleExpired = false
-            for index in entries.indices where entries[index].status == .expired {
-                entries[index].status = .queued
-            }
-            persist()
-            processNext(api: api)
-        } catch {
-            errorMessage = error.localizedDescription
-        }
-    }
-
-    private func update(id: UUID, _ mutate: (inout CaptureEntry) -> Void) {
-        guard let index = entries.firstIndex(where: { $0.id == id }) else { return }
-        mutate(&entries[index])
-    }
+  private func update(id: UUID, _ mutate: (inout CaptureEntry) -> Void) {
+    guard let index = entries.firstIndex(where: { $0.id == id }) else { return }
+    mutate(&entries[index])
+  }
 }

--- a/ios/Pussel/App/PusselApp.swift
+++ b/ios/Pussel/App/PusselApp.swift
@@ -3,36 +3,36 @@ import SwiftUI
 @Observable
 @MainActor
 final class AppModel {
-    let auth: AuthStore
-    let flow: AppFlowStore
-    let store: PuzzleStore
-    @ObservationIgnored let api: APIClient
-    @ObservationIgnored let authService: AuthService
+  let auth: AuthStore
+  let flow: AppFlowStore
+  let store: PuzzleStore
+  @ObservationIgnored let api: APIClient
+  @ObservationIgnored let authService: AuthService
 
-    init() {
-        let auth = AuthStore()
-        let api = APIClient(authStore: auth)
-        self.auth = auth
-        self.flow = AppFlowStore()
-        self.store = PuzzleStore()
-        self.api = api
-        self.authService = AuthService(authStore: auth, apiClient: api)
-        authService.configure()
-    }
+  init() {
+    let auth = AuthStore()
+    let api = APIClient(authStore: auth)
+    self.auth = auth
+    self.flow = AppFlowStore()
+    self.store = PuzzleStore()
+    self.api = api
+    self.authService = AuthService(authStore: auth, apiClient: api)
+    authService.configure()
+  }
 }
 
 @main
 struct PusselApp: App {
-    @State private var model = AppModel()
+  @State private var model = AppModel()
 
-    var body: some Scene {
-        WindowGroup {
-            RootView()
-                .environment(model)
-                .onOpenURL { model.authService.handle(url: $0) }
-                #if DEBUG
-                    .task { DebugDriver.start(model) }
-                #endif
-        }
+  var body: some Scene {
+    WindowGroup {
+      RootView()
+        .environment(model)
+        .onOpenURL { model.authService.handle(url: $0) }
+        #if DEBUG
+          .task { DebugDriver.start(model) }
+        #endif
     }
+  }
 }

--- a/ios/Pussel/App/RootView.swift
+++ b/ios/Pussel/App/RootView.swift
@@ -1,56 +1,56 @@
 import SwiftUI
 
 struct RootView: View {
-    @Environment(AppModel.self) private var model
+  @Environment(AppModel.self) private var model
 
-    var body: some View {
-        Group {
-            if model.auth.isAuthenticated {
-                AppFlowView()
-            } else {
-                SignInView()
-            }
-        }
-        .task {
-            await model.authService.restoreSession()
-        }
+  var body: some View {
+    Group {
+      if model.auth.isAuthenticated {
+        AppFlowView()
+      } else {
+        SignInView()
+      }
     }
+    .task {
+      await model.authService.restoreSession()
+    }
+  }
 }
 
 /// Switches between the wizard phases once signed in.
 struct AppFlowView: View {
-    @Environment(AppModel.self) private var model
+  @Environment(AppModel.self) private var model
 
-    var body: some View {
-        NavigationStack {
-            Group {
-                switch model.flow.phase {
-                case .capturePuzzle:
-                    CapturePuzzleView()
-                case .confirmTrim(let candidate):
-                    ConfirmTrimView(candidate: candidate)
-                case .solving(let session):
-                    SolvingView(session: session)
-                }
-            }
-            .navigationTitle("Pussel")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Menu {
-                        if let user = model.auth.user {
-                            Text(user.email)
-                        }
-                        Button("Sign Out", role: .destructive) {
-                            model.authService.signOut()
-                            model.flow.reset()
-                        }
-                    } label: {
-                        Image(systemName: "person.crop.circle")
-                    }
-                    .accessibilityLabel("Account")
-                }
-            }
+  var body: some View {
+    NavigationStack {
+      Group {
+        switch model.flow.phase {
+        case .capturePuzzle:
+          CapturePuzzleView()
+        case .confirmTrim(let candidate):
+          ConfirmTrimView(candidate: candidate)
+        case .solving(let session):
+          SolvingView(session: session)
         }
+      }
+      .navigationTitle("Pussel")
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .topBarTrailing) {
+          Menu {
+            if let user = model.auth.user {
+              Text(user.email)
+            }
+            Button("Sign Out", role: .destructive) {
+              model.authService.signOut()
+              model.flow.reset()
+            }
+          } label: {
+            Image(systemName: "person.crop.circle")
+          }
+          .accessibilityLabel("Account")
+        }
+      }
     }
+  }
 }

--- a/ios/Pussel/Features/Auth/AuthService.swift
+++ b/ios/Pussel/Features/Auth/AuthService.swift
@@ -7,136 +7,144 @@ import UIKit
 /// persisted; GoogleSignIn's Keychain session is the durable credential.
 @MainActor
 final class AuthService {
-    private let authStore: AuthStore
-    private let apiClient: APIClient
+  private let authStore: AuthStore
+  private let apiClient: APIClient
 
-    init(authStore: AuthStore, apiClient: APIClient) {
-        self.authStore = authStore
-        self.apiClient = apiClient
-        apiClient.reauthenticator = { [weak self] in
-            await self?.refreshBackendToken() ?? false
-        }
+  init(authStore: AuthStore, apiClient: APIClient) {
+    self.authStore = authStore
+    self.apiClient = apiClient
+    apiClient.reauthenticator = { [weak self] in
+      await self?.refreshBackendToken() ?? false
     }
+  }
 
-    func configure() {
-        guard Config.isGoogleSignInConfigured else { return }
-        GIDSignIn.sharedInstance.configuration = GIDConfiguration(
-            clientID: Config.googleIOSClientID,
-            serverClientID: Config.googleServerClientID
-        )
-    }
+  func configure() {
+    guard Config.isGoogleSignInConfigured else { return }
+    GIDSignIn.sharedInstance.configuration = GIDConfiguration(
+      clientID: Config.googleIOSClientID,
+      serverClientID: Config.googleServerClientID
+    )
+  }
 
-    func handle(url: URL) {
-        _ = GIDSignIn.sharedInstance.handle(url)
-    }
+  func handle(url: URL) {
+    _ = GIDSignIn.sharedInstance.handle(url)
+  }
 
-    /// Called at launch: restores a previous Google session silently, if any.
-    func restoreSession() async {
-        #if DEBUG
-            if applyDebugToken() { return }
-        #endif
-        guard Config.isGoogleSignInConfigured, GIDSignIn.sharedInstance.hasPreviousSignIn() else { return }
-        _ = await refreshBackendToken()
-    }
-
-    func signIn() async {
-        guard Config.isGoogleSignInConfigured else {
-            authStore.errorMessage = "Google Sign-In is not configured. Fill in ios/Config/Secrets.xcconfig."
-            return
-        }
-        guard let presenter = Self.topViewController() else {
-            authStore.errorMessage = "Could not find a screen to present Google Sign-In from. Please try again."
-            return
-        }
-        authStore.isSigningIn = true
-        authStore.errorMessage = nil
-        defer { authStore.isSigningIn = false }
-        do {
-            let result = try await GIDSignIn.sharedInstance.signIn(withPresenting: presenter)
-            guard let idToken = result.user.idToken?.tokenString else {
-                throw APIError(message: "Google did not return an ID token.", status: nil)
-            }
-            try await exchange(idToken: idToken)
-        } catch let error as GIDSignInError where error.code == .canceled {
-            // User dismissed the sheet.
-        } catch {
-            authStore.errorMessage = error.localizedDescription
-        }
-    }
-
-    func signOut() {
-        GIDSignIn.sharedInstance.signOut()
-        authStore.user = nil
-        authStore.backendToken = nil
-    }
-
-    private func exchange(idToken: String) async throws {
-        let response = try await apiClient.signInWithGoogle(idToken: idToken)
-        authStore.backendToken = response.accessToken
-        authStore.user = response.user
-    }
-
-    /// Silent re-auth used on launch and after 401s.
-    private func refreshBackendToken() async -> Bool {
-        guard Config.isGoogleSignInConfigured else { return false }
-        do {
-            let user = try await restorePreviousSignIn()
-            let refreshed = try await refreshTokens(for: user)
-            guard let idToken = refreshed.idToken?.tokenString else { return false }
-            try await exchange(idToken: idToken)
-            return true
-        } catch {
-            return false
-        }
-    }
-
-    private func restorePreviousSignIn() async throws -> GIDGoogleUser {
-        try await withCheckedThrowingContinuation { continuation in
-            GIDSignIn.sharedInstance.restorePreviousSignIn { user, error in
-                if let user {
-                    continuation.resume(returning: user)
-                } else {
-                    continuation.resume(throwing: error ?? APIError(message: "No previous Google sign-in.", status: nil))
-                }
-            }
-        }
-    }
-
-    private func refreshTokens(for user: GIDGoogleUser) async throws -> GIDGoogleUser {
-        try await withCheckedThrowingContinuation { continuation in
-            user.refreshTokensIfNeeded { user, error in
-                if let user {
-                    continuation.resume(returning: user)
-                } else {
-                    continuation.resume(throwing: error ?? APIError(message: "Could not refresh Google tokens.", status: nil))
-                }
-            }
-        }
-    }
-
-    private static func topViewController() -> UIViewController? {
-        let window = UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .flatMap(\.windows)
-            .first { $0.isKeyWindow }
-        var top = window?.rootViewController
-        while let presented = top?.presentedViewController {
-            top = presented
-        }
-        return top
-    }
-
+  /// Called at launch: restores a previous Google session silently, if any.
+  func restoreSession() async {
     #if DEBUG
-        /// Agent/CI escape hatch: launch with SIMCTL_CHILD_PUSSEL_DEBUG_TOKEN
-        /// set to a JWT from backend/scripts/generate_test_token.py to skip
-        /// Google Sign-In entirely (Simulator testing without OAuth setup).
-        private func applyDebugToken() -> Bool {
-            guard let token = ProcessInfo.processInfo.environment["PUSSEL_DEBUG_TOKEN"], !token.isEmpty else {
-                return false
-            }
-            authStore.backendToken = token
-            authStore.user = UserDTO(id: "debug", email: "debug@example.com", name: "Debug User", picture: nil, createdAt: nil)
-            return true
-        }
+      if applyDebugToken() { return }
     #endif
+    guard Config.isGoogleSignInConfigured, GIDSignIn.sharedInstance.hasPreviousSignIn() else {
+      return
+    }
+    _ = await refreshBackendToken()
+  }
+
+  func signIn() async {
+    guard Config.isGoogleSignInConfigured else {
+      authStore.errorMessage =
+        "Google Sign-In is not configured. Fill in ios/Config/Secrets.xcconfig."
+      return
+    }
+    guard let presenter = Self.topViewController() else {
+      authStore.errorMessage =
+        "Could not find a screen to present Google Sign-In from. Please try again."
+      return
+    }
+    authStore.isSigningIn = true
+    authStore.errorMessage = nil
+    defer { authStore.isSigningIn = false }
+    do {
+      let result = try await GIDSignIn.sharedInstance.signIn(withPresenting: presenter)
+      guard let idToken = result.user.idToken?.tokenString else {
+        throw APIError(message: "Google did not return an ID token.", status: nil)
+      }
+      try await exchange(idToken: idToken)
+    } catch let error as GIDSignInError where error.code == .canceled {
+      // User dismissed the sheet.
+    } catch {
+      authStore.errorMessage = error.localizedDescription
+    }
+  }
+
+  func signOut() {
+    GIDSignIn.sharedInstance.signOut()
+    authStore.user = nil
+    authStore.backendToken = nil
+  }
+
+  private func exchange(idToken: String) async throws {
+    let response = try await apiClient.signInWithGoogle(idToken: idToken)
+    authStore.backendToken = response.accessToken
+    authStore.user = response.user
+  }
+
+  /// Silent re-auth used on launch and after 401s.
+  private func refreshBackendToken() async -> Bool {
+    guard Config.isGoogleSignInConfigured else { return false }
+    do {
+      let user = try await restorePreviousSignIn()
+      let refreshed = try await refreshTokens(for: user)
+      guard let idToken = refreshed.idToken?.tokenString else { return false }
+      try await exchange(idToken: idToken)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  private func restorePreviousSignIn() async throws -> GIDGoogleUser {
+    try await withCheckedThrowingContinuation { continuation in
+      GIDSignIn.sharedInstance.restorePreviousSignIn { user, error in
+        if let user {
+          continuation.resume(returning: user)
+        } else {
+          continuation.resume(
+            throwing: error ?? APIError(message: "No previous Google sign-in.", status: nil))
+        }
+      }
+    }
+  }
+
+  private func refreshTokens(for user: GIDGoogleUser) async throws -> GIDGoogleUser {
+    try await withCheckedThrowingContinuation { continuation in
+      user.refreshTokensIfNeeded { user, error in
+        if let user {
+          continuation.resume(returning: user)
+        } else {
+          continuation.resume(
+            throwing: error ?? APIError(message: "Could not refresh Google tokens.", status: nil))
+        }
+      }
+    }
+  }
+
+  private static func topViewController() -> UIViewController? {
+    let window = UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .flatMap(\.windows)
+      .first { $0.isKeyWindow }
+    var top = window?.rootViewController
+    while let presented = top?.presentedViewController {
+      top = presented
+    }
+    return top
+  }
+
+  #if DEBUG
+    /// Agent/CI escape hatch: launch with SIMCTL_CHILD_PUSSEL_DEBUG_TOKEN
+    /// set to a JWT from backend/scripts/generate_test_token.py to skip
+    /// Google Sign-In entirely (Simulator testing without OAuth setup).
+    private func applyDebugToken() -> Bool {
+      guard let token = ProcessInfo.processInfo.environment["PUSSEL_DEBUG_TOKEN"], !token.isEmpty
+      else {
+        return false
+      }
+      authStore.backendToken = token
+      authStore.user = UserDTO(
+        id: "debug", email: "debug@example.com", name: "Debug User", picture: nil, createdAt: nil)
+      return true
+    }
+  #endif
 }

--- a/ios/Pussel/Features/Auth/AuthStore.swift
+++ b/ios/Pussel/Features/Auth/AuthStore.swift
@@ -4,12 +4,12 @@ import Observation
 @Observable
 @MainActor
 final class AuthStore {
-    var user: UserDTO?
-    /// Backend JWT, in memory only — reminted from the persisted Google
-    /// session on launch and after 401s (60 min expiry, no refresh endpoint).
-    var backendToken: String?
-    var isSigningIn = false
-    var errorMessage: String?
+  var user: UserDTO?
+  /// Backend JWT, in memory only — reminted from the persisted Google
+  /// session on launch and after 401s (60 min expiry, no refresh endpoint).
+  var backendToken: String?
+  var isSigningIn = false
+  var errorMessage: String?
 
-    var isAuthenticated: Bool { backendToken != nil }
+  var isAuthenticated: Bool { backendToken != nil }
 }

--- a/ios/Pussel/Features/Auth/SignInView.swift
+++ b/ios/Pussel/Features/Auth/SignInView.swift
@@ -1,61 +1,63 @@
 import SwiftUI
 
 struct SignInView: View {
-    @Environment(AppModel.self) private var model
-    @State private var backendHealthy: Bool?
+  @Environment(AppModel.self) private var model
+  @State private var backendHealthy: Bool?
 
-    var body: some View {
-        VStack(spacing: 16) {
-            Spacer()
-            Image(systemName: "puzzlepiece.extension.fill")
-                .font(.system(size: 64))
-                .foregroundStyle(.tint)
-            Text("Pussel")
-                .font(.largeTitle.bold())
-            Text("Photograph your puzzle, then each piece,\nand see where it belongs.")
-                .multilineTextAlignment(.center)
-                .foregroundStyle(.secondary)
-            Spacer()
-            if model.auth.isSigningIn {
-                ProgressView()
-            } else {
-                Button {
-                    Task { await model.authService.signIn() }
-                } label: {
-                    Label("Sign in with Google", systemImage: "person.crop.circle")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-                .disabled(!Config.isGoogleSignInConfigured)
-                if !Config.isGoogleSignInConfigured {
-                    Text("Google Sign-In isn't configured yet.\nFill in ios/Config/Secrets.xcconfig and rebuild.")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                }
-            }
-            if let error = model.auth.errorMessage {
-                Text(error)
-                    .font(.footnote)
-                    .foregroundStyle(.red)
-                    .multilineTextAlignment(.center)
-            }
-            statusFooter
-        }
-        .padding(24)
-        .task {
-            backendHealthy = await model.api.checkHealth()
-        }
-    }
-
-    private var statusFooter: some View {
-        VStack(spacing: 2) {
-            Text(Config.apiBaseURL.absoluteString)
-            Text("Backend: \(backendHealthy.map { $0 ? "healthy" : "unreachable" } ?? "checking…")")
-        }
-        .font(.caption.monospaced())
+  var body: some View {
+    VStack(spacing: 16) {
+      Spacer()
+      Image(systemName: "puzzlepiece.extension.fill")
+        .font(.system(size: 64))
+        .foregroundStyle(.tint)
+      Text("Pussel")
+        .font(.largeTitle.bold())
+      Text("Photograph your puzzle, then each piece,\nand see where it belongs.")
+        .multilineTextAlignment(.center)
         .foregroundStyle(.secondary)
-        .padding(.top, 8)
+      Spacer()
+      if model.auth.isSigningIn {
+        ProgressView()
+      } else {
+        Button {
+          Task { await model.authService.signIn() }
+        } label: {
+          Label("Sign in with Google", systemImage: "person.crop.circle")
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+        .disabled(!Config.isGoogleSignInConfigured)
+        if !Config.isGoogleSignInConfigured {
+          Text(
+            "Google Sign-In isn't configured yet.\nFill in ios/Config/Secrets.xcconfig and rebuild."
+          )
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+          .multilineTextAlignment(.center)
+        }
+      }
+      if let error = model.auth.errorMessage {
+        Text(error)
+          .font(.footnote)
+          .foregroundStyle(.red)
+          .multilineTextAlignment(.center)
+      }
+      statusFooter
     }
+    .padding(24)
+    .task {
+      backendHealthy = await model.api.checkHealth()
+    }
+  }
+
+  private var statusFooter: some View {
+    VStack(spacing: 2) {
+      Text(Config.apiBaseURL.absoluteString)
+      Text("Backend: \(backendHealthy.map { $0 ? "healthy" : "unreachable" } ?? "checking…")")
+    }
+    .font(.caption.monospaced())
+    .foregroundStyle(.secondary)
+    .padding(.top, 8)
+  }
 }

--- a/ios/Pussel/Features/Capture/CameraPicker.swift
+++ b/ios/Pussel/Features/Capture/CameraPicker.swift
@@ -5,45 +5,46 @@ import UIKit
 /// puzzle overview photo. Unavailable on the Simulator (no camera), in which
 /// case callers hide the camera button and rely on PhotosPicker.
 struct CameraPicker: UIViewControllerRepresentable {
-    static var isAvailable: Bool {
-        UIImagePickerController.isSourceTypeAvailable(.camera)
+  static var isAvailable: Bool {
+    UIImagePickerController.isSourceTypeAvailable(.camera)
+  }
+
+  let onImage: (UIImage) -> Void
+  @Environment(\.dismiss) private var dismiss
+
+  func makeUIViewController(context: Context) -> UIImagePickerController {
+    let picker = UIImagePickerController()
+    picker.sourceType = .camera
+    picker.delegate = context.coordinator
+    return picker
+  }
+
+  func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(self)
+  }
+
+  final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate
+  {
+    private let parent: CameraPicker
+
+    init(_ parent: CameraPicker) {
+      self.parent = parent
     }
 
-    let onImage: (UIImage) -> Void
-    @Environment(\.dismiss) private var dismiss
-
-    func makeUIViewController(context: Context) -> UIImagePickerController {
-        let picker = UIImagePickerController()
-        picker.sourceType = .camera
-        picker.delegate = context.coordinator
-        return picker
+    func imagePickerController(
+      _ picker: UIImagePickerController,
+      didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+    ) {
+      if let image = info[.originalImage] as? UIImage {
+        parent.onImage(image)
+      }
+      parent.dismiss()
     }
 
-    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(self)
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+      parent.dismiss()
     }
-
-    final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
-        private let parent: CameraPicker
-
-        init(_ parent: CameraPicker) {
-            self.parent = parent
-        }
-
-        func imagePickerController(
-            _ picker: UIImagePickerController,
-            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
-        ) {
-            if let image = info[.originalImage] as? UIImage {
-                parent.onImage(image)
-            }
-            parent.dismiss()
-        }
-
-        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
-            parent.dismiss()
-        }
-    }
+  }
 }

--- a/ios/Pussel/Features/Capture/CapturePuzzleView.swift
+++ b/ios/Pussel/Features/Capture/CapturePuzzleView.swift
@@ -2,128 +2,129 @@ import PhotosUI
 import SwiftUI
 
 struct CapturePuzzleView: View {
-    @Environment(AppModel.self) private var model
-    @State private var showCamera = false
-    @State private var showLibrary = false
-    @State private var photoItem: PhotosPickerItem?
+  @Environment(AppModel.self) private var model
+  @State private var showCamera = false
+  @State private var showLibrary = false
+  @State private var photoItem: PhotosPickerItem?
 
-    private var hasSavedPuzzles: Bool {
-        !model.store.puzzles.isEmpty
+  private var hasSavedPuzzles: Bool {
+    !model.store.puzzles.isEmpty
+  }
+
+  var body: some View {
+    ScrollView {
+      if hasSavedPuzzles {
+        content
+      } else {
+        // Fill the viewport so the hero stays vertically centered like
+        // the original single-screen capture prompt.
+        content.containerRelativeFrame(.vertical, alignment: .center) { height, _ in height }
+      }
     }
-
-    var body: some View {
-        ScrollView {
-            if hasSavedPuzzles {
-                content
-            } else {
-                // Fill the viewport so the hero stays vertically centered like
-                // the original single-screen capture prompt.
-                content.containerRelativeFrame(.vertical, alignment: .center) { height, _ in height }
-            }
-        }
-        .scrollBounceBehavior(.basedOnSize)
-        .fullScreenCover(isPresented: $showCamera) {
-            CameraPicker { image in
-                Task { await handle(image: image, source: .camera) }
-            }
-            .ignoresSafeArea()
-        }
-        .photosPicker(isPresented: $showLibrary, selection: $photoItem, matching: .images)
-        .onChange(of: photoItem) { _, item in
-            guard let item else { return }
-            Task {
-                if let data = try? await item.loadTransferable(type: Data.self),
-                   let image = UIImage(data: data) {
-                    await handle(image: image, source: .library)
-                } else {
-                    model.flow.errorMessage = "Could not load the selected photo."
-                }
-                photoItem = nil
-            }
-        }
-        .onAppear(perform: reopenPickerIfRetaking)
+    .scrollBounceBehavior(.basedOnSize)
+    .fullScreenCover(isPresented: $showCamera) {
+      CameraPicker { image in
+        Task { await handle(image: image, source: .camera) }
+      }
+      .ignoresSafeArea()
     }
-
-    private var content: some View {
-        VStack(spacing: 20) {
-            // Compact header once there are saved puzzles to keep below it;
-            // otherwise a taller hero centered in the screen.
-            Spacer(minLength: hasSavedPuzzles ? 8 : 40)
-            Image(systemName: "puzzlepiece.extension.fill")
-                .font(.system(size: hasSavedPuzzles ? 40 : 56))
-                .foregroundStyle(.tint)
-            Text("Photograph the puzzle")
-                .font(.title2.bold())
-            Text("Take a straight-on photo of the finished puzzle picture — the box front works well.")
-                .multilineTextAlignment(.center)
-                .foregroundStyle(.secondary)
-            if model.flow.isBusy {
-                ProgressView("Detecting puzzle…")
-                    .padding(.top, 8)
-            } else {
-                VStack(spacing: 12) {
-                    if CameraPicker.isAvailable {
-                        Button {
-                            showCamera = true
-                        } label: {
-                            Label("Take Puzzle Photo", systemImage: "camera.fill")
-                                .frame(maxWidth: .infinity)
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .controlSize(.large)
-                    }
-                    if CameraPicker.isAvailable {
-                        photoLibraryButton.buttonStyle(.bordered)
-                    } else {
-                        photoLibraryButton.buttonStyle(.borderedProminent)
-                    }
-                }
-                .padding(.top, 8)
-            }
-            if let error = model.flow.errorMessage {
-                Text(error)
-                    .font(.footnote)
-                    .foregroundStyle(.red)
-                    .multilineTextAlignment(.center)
-            }
-            if hasSavedPuzzles {
-                Divider().padding(.vertical, 4)
-                SavedPuzzlesSection()
-            }
-            Spacer(minLength: hasSavedPuzzles ? 8 : 40)
+    .photosPicker(isPresented: $showLibrary, selection: $photoItem, matching: .images)
+    .onChange(of: photoItem) { _, item in
+      guard let item else { return }
+      Task {
+        if let data = try? await item.loadTransferable(type: Data.self),
+          let image = UIImage(data: data)
+        {
+          await handle(image: image, source: .library)
+        } else {
+          model.flow.errorMessage = "Could not load the selected photo."
         }
-        .padding(24)
+        photoItem = nil
+      }
+    }
+    .onAppear(perform: reopenPickerIfRetaking)
+  }
+
+  private var content: some View {
+    VStack(spacing: 20) {
+      // Compact header once there are saved puzzles to keep below it;
+      // otherwise a taller hero centered in the screen.
+      Spacer(minLength: hasSavedPuzzles ? 8 : 40)
+      Image(systemName: "puzzlepiece.extension.fill")
+        .font(.system(size: hasSavedPuzzles ? 40 : 56))
+        .foregroundStyle(.tint)
+      Text("Photograph the puzzle")
+        .font(.title2.bold())
+      Text("Take a straight-on photo of the finished puzzle picture — the box front works well.")
+        .multilineTextAlignment(.center)
+        .foregroundStyle(.secondary)
+      if model.flow.isBusy {
+        ProgressView("Detecting puzzle…")
+          .padding(.top, 8)
+      } else {
+        VStack(spacing: 12) {
+          if CameraPicker.isAvailable {
+            Button {
+              showCamera = true
+            } label: {
+              Label("Take Puzzle Photo", systemImage: "camera.fill")
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+          }
+          if CameraPicker.isAvailable {
+            photoLibraryButton.buttonStyle(.bordered)
+          } else {
+            photoLibraryButton.buttonStyle(.borderedProminent)
+          }
+        }
+        .padding(.top, 8)
+      }
+      if let error = model.flow.errorMessage {
+        Text(error)
+          .font(.footnote)
+          .foregroundStyle(.red)
+          .multilineTextAlignment(.center)
+      }
+      if hasSavedPuzzles {
+        Divider().padding(.vertical, 4)
+        SavedPuzzlesSection()
+      }
+      Spacer(minLength: hasSavedPuzzles ? 8 : 40)
+    }
+    .padding(24)
+    .frame(maxWidth: .infinity)
+  }
+
+  private var photoLibraryButton: some View {
+    Button {
+      showLibrary = true
+    } label: {
+      Label("Choose from Library", systemImage: "photo.on.rectangle")
         .frame(maxWidth: .infinity)
     }
+    .controlSize(.large)
+  }
 
-    private var photoLibraryButton: some View {
-        Button {
-            showLibrary = true
-        } label: {
-            Label("Choose from Library", systemImage: "photo.on.rectangle")
-                .frame(maxWidth: .infinity)
-        }
-        .controlSize(.large)
+  /// After "Retake", jump straight back into whichever picker produced the
+  /// original photo instead of making the user pick a source again.
+  private func reopenPickerIfRetaking() {
+    guard let source = model.flow.pendingRetake else { return }
+    model.flow.pendingRetake = nil
+    switch source {
+    case .camera:
+      if CameraPicker.isAvailable {
+        showCamera = true
+      } else {
+        showLibrary = true
+      }
+    case .library:
+      showLibrary = true
     }
+  }
 
-    /// After "Retake", jump straight back into whichever picker produced the
-    /// original photo instead of making the user pick a source again.
-    private func reopenPickerIfRetaking() {
-        guard let source = model.flow.pendingRetake else { return }
-        model.flow.pendingRetake = nil
-        switch source {
-        case .camera:
-            if CameraPicker.isAvailable {
-                showCamera = true
-            } else {
-                showLibrary = true
-            }
-        case .library:
-            showLibrary = true
-        }
-    }
-
-    private func handle(image: UIImage, source: CaptureSource) async {
-        await model.startTrim(image: image, source: source)
-    }
+  private func handle(image: UIImage, source: CaptureSource) async {
+    await model.startTrim(image: image, source: source)
+  }
 }

--- a/ios/Pussel/Features/Capture/ConfirmTrimView.swift
+++ b/ios/Pussel/Features/Capture/ConfirmTrimView.swift
@@ -1,67 +1,70 @@
 import SwiftUI
 
 struct ConfirmTrimView: View {
-    /// Mirrors LOW_CONFIDENCE_THRESHOLD in frontend/src/app/real/page.tsx.
-    private static let lowConfidence = 0.4
+  /// Mirrors LOW_CONFIDENCE_THRESHOLD in frontend/src/app/real/page.tsx.
+  private static let lowConfidence = 0.4
 
-    @Environment(AppModel.self) private var model
-    let candidate: TrimCandidate
+  @Environment(AppModel.self) private var model
+  let candidate: TrimCandidate
 
-    var body: some View {
-        VStack(spacing: 16) {
-            Text("Does this look right?")
-                .font(.title2.bold())
-            if candidate.detection.confidence < Self.lowConfidence {
-                Label("Detection looks uncertain — consider retaking.", systemImage: "exclamationmark.triangle.fill")
-                    .font(.footnote)
-                    .foregroundStyle(.orange)
-            }
-            if let data = candidate.trimmedJPEG, let image = UIImage(data: data) {
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFit()
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
-                    .frame(maxHeight: 420)
-            } else {
-                ContentUnavailableView("Could not decode the trimmed image", systemImage: "xmark.octagon")
-            }
-            Text("Detection confidence: \(Int(candidate.detection.confidence * 100))%")
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-            Spacer()
-            if model.flow.isBusy {
-                ProgressView("Uploading puzzle…")
-            } else {
-                HStack(spacing: 12) {
-                    Button {
-                        model.flow.errorMessage = nil
-                        model.flow.pendingRetake = candidate.source
-                        model.flow.phase = .capturePuzzle
-                    } label: {
-                        Label("Retake", systemImage: "arrow.counterclockwise")
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.large)
+  var body: some View {
+    VStack(spacing: 16) {
+      Text("Does this look right?")
+        .font(.title2.bold())
+      if candidate.detection.confidence < Self.lowConfidence {
+        Label(
+          "Detection looks uncertain — consider retaking.",
+          systemImage: "exclamationmark.triangle.fill"
+        )
+        .font(.footnote)
+        .foregroundStyle(.orange)
+      }
+      if let data = candidate.trimmedJPEG, let image = UIImage(data: data) {
+        Image(uiImage: image)
+          .resizable()
+          .scaledToFit()
+          .clipShape(RoundedRectangle(cornerRadius: 12))
+          .frame(maxHeight: 420)
+      } else {
+        ContentUnavailableView("Could not decode the trimmed image", systemImage: "xmark.octagon")
+      }
+      Text("Detection confidence: \(Int(candidate.detection.confidence * 100))%")
+        .font(.footnote)
+        .foregroundStyle(.secondary)
+      Spacer()
+      if model.flow.isBusy {
+        ProgressView("Uploading puzzle…")
+      } else {
+        HStack(spacing: 12) {
+          Button {
+            model.flow.errorMessage = nil
+            model.flow.pendingRetake = candidate.source
+            model.flow.phase = .capturePuzzle
+          } label: {
+            Label("Retake", systemImage: "arrow.counterclockwise")
+              .frame(maxWidth: .infinity)
+          }
+          .buttonStyle(.bordered)
+          .controlSize(.large)
 
-                    Button {
-                        Task { await model.acceptTrim(candidate) }
-                    } label: {
-                        Label("Use This", systemImage: "checkmark")
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.large)
-                    .disabled(candidate.trimmedJPEG == nil)
-                }
-            }
-            if let error = model.flow.errorMessage {
-                Text(error)
-                    .font(.footnote)
-                    .foregroundStyle(.red)
-                    .multilineTextAlignment(.center)
-            }
+          Button {
+            Task { await model.acceptTrim(candidate) }
+          } label: {
+            Label("Use This", systemImage: "checkmark")
+              .frame(maxWidth: .infinity)
+          }
+          .buttonStyle(.borderedProminent)
+          .controlSize(.large)
+          .disabled(candidate.trimmedJPEG == nil)
         }
-        .padding(24)
+      }
+      if let error = model.flow.errorMessage {
+        Text(error)
+          .font(.footnote)
+          .foregroundStyle(.red)
+          .multilineTextAlignment(.center)
+      }
     }
+    .padding(24)
+  }
 }

--- a/ios/Pussel/Features/Library/SavedPuzzlesSection.swift
+++ b/ios/Pussel/Features/Library/SavedPuzzlesSection.swift
@@ -3,95 +3,95 @@ import SwiftUI
 /// The list of locally stored puzzles shown beneath the capture buttons on the
 /// home screen. Tap a card to reopen it; long-press to delete.
 struct SavedPuzzlesSection: View {
-    @Environment(AppModel.self) private var model
-    @State private var pendingDelete: PuzzleSummary?
+  @Environment(AppModel.self) private var model
+  @State private var pendingDelete: PuzzleSummary?
 
-    var body: some View {
-        // Lazy so rows (and their thumbnail decoding) are built only as they
-        // scroll into view as the library grows.
-        LazyVStack(alignment: .leading, spacing: 12) {
-            Text("Your puzzles")
-                .font(.headline)
-                .frame(maxWidth: .infinity, alignment: .leading)
+  var body: some View {
+    // Lazy so rows (and their thumbnail decoding) are built only as they
+    // scroll into view as the library grows.
+    LazyVStack(alignment: .leading, spacing: 12) {
+      Text("Your puzzles")
+        .font(.headline)
+        .frame(maxWidth: .infinity, alignment: .leading)
 
-            ForEach(model.store.puzzles) { puzzle in
-                Button {
-                    model.openPuzzle(puzzle.id)
-                } label: {
-                    SavedPuzzleRow(puzzle: puzzle)
-                }
-                .buttonStyle(.plain)
-                .contextMenu {
-                    Button(role: .destructive) {
-                        pendingDelete = puzzle
-                    } label: {
-                        Label("Delete", systemImage: "trash")
-                    }
-                }
-            }
+      ForEach(model.store.puzzles) { puzzle in
+        Button {
+          model.openPuzzle(puzzle.id)
+        } label: {
+          SavedPuzzleRow(puzzle: puzzle)
         }
-        .confirmationDialog(
-            "Delete this puzzle?",
-            isPresented: Binding(
-                get: { pendingDelete != nil },
-                set: { if !$0 { pendingDelete = nil } }
-            ),
-            titleVisibility: .visible,
-            presenting: pendingDelete
-        ) { puzzle in
-            Button("Delete", role: .destructive) {
-                model.deletePuzzle(puzzle.id)
-                pendingDelete = nil
-            }
-            Button("Cancel", role: .cancel) { pendingDelete = nil }
-        } message: { puzzle in
-            Text("“\(puzzle.name)” and its pieces will be removed from this device.")
+        .buttonStyle(.plain)
+        .contextMenu {
+          Button(role: .destructive) {
+            pendingDelete = puzzle
+          } label: {
+            Label("Delete", systemImage: "trash")
+          }
         }
+      }
     }
+    .confirmationDialog(
+      "Delete this puzzle?",
+      isPresented: Binding(
+        get: { pendingDelete != nil },
+        set: { if !$0 { pendingDelete = nil } }
+      ),
+      titleVisibility: .visible,
+      presenting: pendingDelete
+    ) { puzzle in
+      Button("Delete", role: .destructive) {
+        model.deletePuzzle(puzzle.id)
+        pendingDelete = nil
+      }
+      Button("Cancel", role: .cancel) { pendingDelete = nil }
+    } message: { puzzle in
+      Text("“\(puzzle.name)” and its pieces will be removed from this device.")
+    }
+  }
 }
 
 private struct SavedPuzzleRow: View {
-    let puzzle: PuzzleSummary
+  let puzzle: PuzzleSummary
 
-    var body: some View {
-        HStack(spacing: 12) {
-            thumbnail
-            VStack(alignment: .leading, spacing: 4) {
-                Text(puzzle.name)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-                Text(subtitle)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            Spacer(minLength: 0)
-            Image(systemName: "chevron.right")
-                .font(.footnote.weight(.semibold))
-                .foregroundStyle(.tertiary)
-        }
-        .padding(10)
-        .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 12))
+  var body: some View {
+    HStack(spacing: 12) {
+      thumbnail
+      VStack(alignment: .leading, spacing: 4) {
+        Text(puzzle.name)
+          .font(.subheadline.weight(.semibold))
+          .foregroundStyle(.primary)
+          .lineLimit(1)
+        Text(subtitle)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+      Spacer(minLength: 0)
+      Image(systemName: "chevron.right")
+        .font(.footnote.weight(.semibold))
+        .foregroundStyle(.tertiary)
     }
+    .padding(10)
+    .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 12))
+  }
 
-    @ViewBuilder
-    private var thumbnail: some View {
-        Group {
-            if let data = puzzle.thumbnail, let image = UIImage(data: data) {
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFill()
-            } else {
-                Image(systemName: "photo")
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .frame(width: 56, height: 56)
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+  @ViewBuilder
+  private var thumbnail: some View {
+    Group {
+      if let data = puzzle.thumbnail, let image = UIImage(data: data) {
+        Image(uiImage: image)
+          .resizable()
+          .scaledToFill()
+      } else {
+        Image(systemName: "photo")
+          .foregroundStyle(.secondary)
+      }
     }
+    .frame(width: 56, height: 56)
+    .clipShape(RoundedRectangle(cornerRadius: 8))
+  }
 
-    private var subtitle: String {
-        let pieces = puzzle.pieceCount == 1 ? "1 piece" : "\(puzzle.pieceCount) pieces"
-        return "\(pieces) · \(puzzle.createdAt.formatted(date: .abbreviated, time: .shortened))"
-    }
+  private var subtitle: String {
+    let pieces = puzzle.pieceCount == 1 ? "1 piece" : "\(puzzle.pieceCount) pieces"
+    return "\(pieces) · \(puzzle.createdAt.formatted(date: .abbreviated, time: .shortened))"
+  }
 }

--- a/ios/Pussel/Features/Solve/PieceCameraSession.swift
+++ b/ios/Pussel/Features/Solve/PieceCameraSession.swift
@@ -5,64 +5,67 @@ import UIKit
 /// manual shutter. Device-only — on the Simulator `isCameraAvailable` is false
 /// and the UI falls back to PhotosPicker.
 final class PieceCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
-    static var isCameraAvailable: Bool {
-        AVCaptureDevice.default(for: .video) != nil
-    }
+  static var isCameraAvailable: Bool {
+    AVCaptureDevice.default(for: .video) != nil
+  }
 
-    let session = AVCaptureSession()
-    private let photoOutput = AVCapturePhotoOutput()
-    private var isConfigured = false
-    private var captureContinuation: CheckedContinuation<UIImage?, Never>?
+  let session = AVCaptureSession()
+  private let photoOutput = AVCapturePhotoOutput()
+  private var isConfigured = false
+  private var captureContinuation: CheckedContinuation<UIImage?, Never>?
 
-    func start() async {
-        guard await AVCaptureDevice.requestAccess(for: .video) else { return }
-        configureIfNeeded()
-        guard isConfigured, !session.isRunning else { return }
-        let session = self.session
-        Task.detached {
-            // startRunning blocks, so keep it off the main thread.
-            session.startRunning()
-        }
+  func start() async {
+    guard await AVCaptureDevice.requestAccess(for: .video) else { return }
+    configureIfNeeded()
+    guard isConfigured, !session.isRunning else { return }
+    let session = self.session
+    Task.detached {
+      // startRunning blocks, so keep it off the main thread.
+      session.startRunning()
     }
+  }
 
-    func stop() {
-        guard session.isRunning else { return }
-        let session = self.session
-        Task.detached {
-            session.stopRunning()
-        }
+  func stop() {
+    guard session.isRunning else { return }
+    let session = self.session
+    Task.detached {
+      session.stopRunning()
     }
+  }
 
-    func capturePhoto() async -> UIImage? {
-        // Ignore shutter taps while a capture is in flight — overwriting the
-        // stored continuation would leak it and hang the first caller.
-        guard isConfigured, captureContinuation == nil else { return nil }
-        return await withCheckedContinuation { continuation in
-            captureContinuation = continuation
-            photoOutput.capturePhoto(with: AVCapturePhotoSettings(), delegate: self)
-        }
+  func capturePhoto() async -> UIImage? {
+    // Ignore shutter taps while a capture is in flight — overwriting the
+    // stored continuation would leak it and hang the first caller.
+    guard isConfigured, captureContinuation == nil else { return nil }
+    return await withCheckedContinuation { continuation in
+      captureContinuation = continuation
+      photoOutput.capturePhoto(with: AVCapturePhotoSettings(), delegate: self)
     }
+  }
 
-    func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
-        let image = photo.fileDataRepresentation().flatMap(UIImage.init(data:))
-        captureContinuation?.resume(returning: image)
-        captureContinuation = nil
-    }
+  func photoOutput(
+    _ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?
+  ) {
+    let image = photo.fileDataRepresentation().flatMap(UIImage.init(data:))
+    captureContinuation?.resume(returning: image)
+    captureContinuation = nil
+  }
 
-    private func configureIfNeeded() {
-        guard !isConfigured,
-              let device = AVCaptureDevice.default(for: .video),
-              let input = try? AVCaptureDeviceInput(device: device),
-              session.canAddInput(input) else { return }
-        session.beginConfiguration()
-        session.sessionPreset = .photo
-        session.addInput(input)
-        guard session.canAddOutput(photoOutput) else {
-            session.commitConfiguration()
-            return
-        }
-        session.addOutput(photoOutput)
-        session.commitConfiguration()
-        isConfigured = true
+  private func configureIfNeeded() {
+    guard !isConfigured,
+      let device = AVCaptureDevice.default(for: .video),
+      let input = try? AVCaptureDeviceInput(device: device),
+      session.canAddInput(input)
+    else { return }
+    session.beginConfiguration()
+    session.sessionPreset = .photo
+    session.addInput(input)
+    guard session.canAddOutput(photoOutput) else {
+      session.commitConfiguration()
+      return
     }
+    session.addOutput(photoOutput)
+    session.commitConfiguration()
+    isConfigured = true
+  }
 }

--- a/ios/Pussel/Features/Solve/PieceCaptureView.swift
+++ b/ios/Pussel/Features/Solve/PieceCaptureView.swift
@@ -6,78 +6,79 @@ import SwiftUI
 /// on device, and a PhotosPicker path that also serves as the only option on
 /// the Simulator.
 struct PieceCaptureView: View {
-    @Environment(AppModel.self) private var model
-    @State private var camera = PieceCameraSession()
-    @State private var photoItem: PhotosPickerItem?
+  @Environment(AppModel.self) private var model
+  @State private var camera = PieceCameraSession()
+  @State private var photoItem: PhotosPickerItem?
 
-    var body: some View {
-        VStack(spacing: 12) {
-            if PieceCameraSession.isCameraAvailable {
-                CameraPreview(session: camera.session)
-                    .frame(height: 280)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
-                    .overlay(alignment: .bottom) {
-                        shutterButton.padding(.bottom, 14)
-                    }
-                    .task {
-                        await camera.start()
-                    }
-                    .onDisappear {
-                        camera.stop()
-                    }
-            }
-            PhotosPicker(selection: $photoItem, matching: .images) {
-                Label(
-                    PieceCameraSession.isCameraAvailable ? "Add Piece from Library" : "Pick Piece Photo",
-                    systemImage: "photo.on.rectangle"
-                )
-                .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.bordered)
-        }
-        .onChange(of: photoItem) { _, item in
-            guard let item else { return }
-            Task {
-                if let data = try? await item.loadTransferable(type: Data.self),
-                   let image = UIImage(data: data) {
-                    model.addPiece(image: image)
-                }
-                photoItem = nil
-            }
-        }
+  var body: some View {
+    VStack(spacing: 12) {
+      if PieceCameraSession.isCameraAvailable {
+        CameraPreview(session: camera.session)
+          .frame(height: 280)
+          .clipShape(RoundedRectangle(cornerRadius: 12))
+          .overlay(alignment: .bottom) {
+            shutterButton.padding(.bottom, 14)
+          }
+          .task {
+            await camera.start()
+          }
+          .onDisappear {
+            camera.stop()
+          }
+      }
+      PhotosPicker(selection: $photoItem, matching: .images) {
+        Label(
+          PieceCameraSession.isCameraAvailable ? "Add Piece from Library" : "Pick Piece Photo",
+          systemImage: "photo.on.rectangle"
+        )
+        .frame(maxWidth: .infinity)
+      }
+      .buttonStyle(.bordered)
     }
+    .onChange(of: photoItem) { _, item in
+      guard let item else { return }
+      Task {
+        if let data = try? await item.loadTransferable(type: Data.self),
+          let image = UIImage(data: data)
+        {
+          model.addPiece(image: image)
+        }
+        photoItem = nil
+      }
+    }
+  }
 
-    private var shutterButton: some View {
-        Button {
-            Task {
-                if let image = await camera.capturePhoto() {
-                    model.addPiece(image: image)
-                }
-            }
-        } label: {
-            ZStack {
-                Circle().fill(.white).frame(width: 58, height: 58)
-                Circle().strokeBorder(.white, lineWidth: 3).frame(width: 70, height: 70)
-            }
+  private var shutterButton: some View {
+    Button {
+      Task {
+        if let image = await camera.capturePhoto() {
+          model.addPiece(image: image)
         }
-        .accessibilityLabel("Capture piece")
+      }
+    } label: {
+      ZStack {
+        Circle().fill(.white).frame(width: 58, height: 58)
+        Circle().strokeBorder(.white, lineWidth: 3).frame(width: 70, height: 70)
+      }
     }
+    .accessibilityLabel("Capture piece")
+  }
 }
 
 struct CameraPreview: UIViewRepresentable {
-    let session: AVCaptureSession
+  let session: AVCaptureSession
 
-    final class PreviewView: UIView {
-        override class var layerClass: AnyClass { AVCaptureVideoPreviewLayer.self }
-        var previewLayer: AVCaptureVideoPreviewLayer { layer as! AVCaptureVideoPreviewLayer }
-    }
+  final class PreviewView: UIView {
+    override class var layerClass: AnyClass { AVCaptureVideoPreviewLayer.self }
+    var previewLayer: AVCaptureVideoPreviewLayer { layer as! AVCaptureVideoPreviewLayer }
+  }
 
-    func makeUIView(context: Context) -> PreviewView {
-        let view = PreviewView()
-        view.previewLayer.session = session
-        view.previewLayer.videoGravity = .resizeAspectFill
-        return view
-    }
+  func makeUIView(context: Context) -> PreviewView {
+    let view = PreviewView()
+    view.previewLayer.session = session
+    view.previewLayer.videoGravity = .resizeAspectFill
+    return view
+  }
 
-    func updateUIView(_ uiView: PreviewView, context: Context) {}
+  func updateUIView(_ uiView: PreviewView, context: Context) {}
 }

--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -3,95 +3,95 @@ import SwiftUI
 /// Horizontal strip of captured pieces with their prediction status,
 /// mirroring frontend/src/components/puzzle/piece-queue.tsx.
 struct PieceQueueView: View {
-    @Environment(AppModel.self) private var model
-    let session: SolveSession
+  @Environment(AppModel.self) private var model
+  let session: SolveSession
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Pieces (\(session.entries.count))")
-                .font(.headline)
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 12) {
-                    ForEach(session.entries) { entry in
-                        QueueTile(
-                            entry: entry,
-                            onRetry: { session.retry(id: entry.id, api: model.api) },
-                            onDelete: { session.remove(id: entry.id) }
-                        )
-                    }
-                }
-                .padding(.vertical, 2)
-            }
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("Pieces (\(session.entries.count))")
+        .font(.headline)
+      ScrollView(.horizontal, showsIndicators: false) {
+        HStack(spacing: 12) {
+          ForEach(session.entries) { entry in
+            QueueTile(
+              entry: entry,
+              onRetry: { session.retry(id: entry.id, api: model.api) },
+              onDelete: { session.remove(id: entry.id) }
+            )
+          }
         }
+        .padding(.vertical, 2)
+      }
     }
+  }
 }
 
 private struct QueueTile: View {
-    let entry: CaptureEntry
-    let onRetry: () -> Void
-    let onDelete: () -> Void
+  let entry: CaptureEntry
+  let onRetry: () -> Void
+  let onDelete: () -> Void
 
-    var body: some View {
-        VStack(spacing: 6) {
-            ZStack {
-                if let image = UIImage(data: entry.displayImage) {
-                    Image(uiImage: image)
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: 84, height: 84)
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
-                }
-                if entry.status == .predicting {
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(.black.opacity(0.4))
-                        .frame(width: 84, height: 84)
-                    ProgressView()
-                        .tint(.white)
-                }
-            }
-            statusLabel
-            HStack(spacing: 10) {
-                if entry.status.isRetryable {
-                    Button(action: onRetry) {
-                        Image(systemName: "arrow.clockwise")
-                    }
-                    .accessibilityLabel("Retry piece")
-                }
-                Button(role: .destructive, action: onDelete) {
-                    Image(systemName: "trash")
-                }
-                .accessibilityLabel("Delete piece")
-            }
-            .font(.footnote)
-            .buttonStyle(.borderless)
+  var body: some View {
+    VStack(spacing: 6) {
+      ZStack {
+        if let image = UIImage(data: entry.displayImage) {
+          Image(uiImage: image)
+            .resizable()
+            .scaledToFill()
+            .frame(width: 84, height: 84)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
         }
+        if entry.status == .predicting {
+          RoundedRectangle(cornerRadius: 10)
+            .fill(.black.opacity(0.4))
+            .frame(width: 84, height: 84)
+          ProgressView()
+            .tint(.white)
+        }
+      }
+      statusLabel
+      HStack(spacing: 10) {
+        if entry.status.isRetryable {
+          Button(action: onRetry) {
+            Image(systemName: "arrow.clockwise")
+          }
+          .accessibilityLabel("Retry piece")
+        }
+        Button(role: .destructive, action: onDelete) {
+          Image(systemName: "trash")
+        }
+        .accessibilityLabel("Delete piece")
+      }
+      .font(.footnote)
+      .buttonStyle(.borderless)
     }
+  }
 
-    @ViewBuilder
-    private var statusLabel: some View {
-        switch entry.status {
-        case .queued:
-            Text("Queued").font(.caption2).foregroundStyle(.secondary)
-        case .predicting:
-            Text("Predicting…").font(.caption2).foregroundStyle(.secondary)
-        case .done:
-            if let piece = entry.result {
-                Text("(\(Int(piece.position.x * 100))%, \(Int(piece.position.y * 100))%)")
-                    .font(.caption2.monospacedDigit())
-                    .foregroundStyle(.green)
-            }
-        case .expired:
-            Text("Puzzle session expired")
-                .font(.caption2)
-                .foregroundStyle(.red)
-                .lineLimit(1)
-                .frame(maxWidth: 96)
-        case .error(let message):
-            Text(message)
-                .font(.caption2)
-                .foregroundStyle(.red)
-                .lineLimit(1)
-                .frame(maxWidth: 96)
-        }
+  @ViewBuilder
+  private var statusLabel: some View {
+    switch entry.status {
+    case .queued:
+      Text("Queued").font(.caption2).foregroundStyle(.secondary)
+    case .predicting:
+      Text("Predicting…").font(.caption2).foregroundStyle(.secondary)
+    case .done:
+      if let piece = entry.result {
+        Text("(\(Int(piece.position.x * 100))%, \(Int(piece.position.y * 100))%)")
+          .font(.caption2.monospacedDigit())
+          .foregroundStyle(.green)
+      }
+    case .expired:
+      Text("Puzzle session expired")
+        .font(.caption2)
+        .foregroundStyle(.red)
+        .lineLimit(1)
+        .frame(maxWidth: 96)
+    case .error(let message):
+      Text(message)
+        .font(.caption2)
+        .foregroundStyle(.red)
+        .lineLimit(1)
+        .frame(maxWidth: 96)
     }
+  }
 }

--- a/ios/Pussel/Features/Solve/PuzzleOverlayView.swift
+++ b/ios/Pussel/Features/Solve/PuzzleOverlayView.swift
@@ -8,66 +8,66 @@ private let pieceSizeRatio: CGFloat = 0.12
 /// fixed piece size (12% of image dimensions), counter-clockwise rotation,
 /// confidence bar along the bottom edge.
 struct PuzzleOverlayView: View {
-    let session: SolveSession
+  let session: SolveSession
 
-    var body: some View {
-        if let image = UIImage(data: session.trimmedJPEG) {
-            Image(uiImage: image)
-                .resizable()
-                .scaledToFit()
-                .overlay(Color.black.opacity(0.3))
-                .overlay {
-                    GeometryReader { geo in
-                        ForEach(session.placedEntries) { entry in
-                            if let piece = entry.result {
-                                PieceMarker(entry: entry, piece: piece, canvas: geo.size)
-                            }
-                        }
-                    }
-                }
-                .clipShape(RoundedRectangle(cornerRadius: 12))
+  var body: some View {
+    if let image = UIImage(data: session.trimmedJPEG) {
+      Image(uiImage: image)
+        .resizable()
+        .scaledToFit()
+        .overlay(Color.black.opacity(0.3))
+        .overlay {
+          GeometryReader { geo in
+            ForEach(session.placedEntries) { entry in
+              if let piece = entry.result {
+                PieceMarker(entry: entry, piece: piece, canvas: geo.size)
+              }
+            }
+          }
         }
+        .clipShape(RoundedRectangle(cornerRadius: 12))
     }
+  }
 }
 
 private struct PieceMarker: View {
-    let entry: CaptureEntry
-    let piece: PieceResponse
-    let canvas: CGSize
+  let entry: CaptureEntry
+  let piece: PieceResponse
+  let canvas: CGSize
 
-    var body: some View {
-        let width = canvas.width * pieceSizeRatio
-        let height = canvas.height * pieceSizeRatio
-        VStack(spacing: 0) {
-            if let image = UIImage(data: entry.displayImage) {
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
-            ConfidenceBar(value: piece.positionConfidence)
-                .frame(height: 4)
-        }
-        .frame(width: width, height: height)
-        .background(.black.opacity(0.25))
-        .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(.white, lineWidth: 1.5))
-        .rotationEffect(.degrees(-Double(piece.rotation)))
-        .position(x: canvas.width * piece.position.x, y: canvas.height * piece.position.y)
+  var body: some View {
+    let width = canvas.width * pieceSizeRatio
+    let height = canvas.height * pieceSizeRatio
+    VStack(spacing: 0) {
+      if let image = UIImage(data: entry.displayImage) {
+        Image(uiImage: image)
+          .resizable()
+          .scaledToFit()
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+      ConfidenceBar(value: piece.positionConfidence)
+        .frame(height: 4)
     }
+    .frame(width: width, height: height)
+    .background(.black.opacity(0.25))
+    .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(.white, lineWidth: 1.5))
+    .rotationEffect(.degrees(-Double(piece.rotation)))
+    .position(x: canvas.width * piece.position.x, y: canvas.height * piece.position.y)
+  }
 }
 
 struct ConfidenceBar: View {
-    /// 0...1
-    let value: Double
+  /// 0...1
+  let value: Double
 
-    var body: some View {
-        GeometryReader { geo in
-            ZStack(alignment: .leading) {
-                Rectangle().fill(.red.opacity(0.8))
-                Rectangle()
-                    .fill(.green)
-                    .frame(width: geo.size.width * min(max(value, 0), 1))
-            }
-        }
+  var body: some View {
+    GeometryReader { geo in
+      ZStack(alignment: .leading) {
+        Rectangle().fill(.red.opacity(0.8))
+        Rectangle()
+          .fill(.green)
+          .frame(width: geo.size.width * min(max(value, 0), 1))
+      }
     }
+  }
 }

--- a/ios/Pussel/Features/Solve/SolvingView.swift
+++ b/ios/Pussel/Features/Solve/SolvingView.swift
@@ -1,65 +1,67 @@
 import SwiftUI
 
 struct SolvingView: View {
-    @Environment(AppModel.self) private var model
-    let session: SolveSession
-    @State private var isReuploading = false
+  @Environment(AppModel.self) private var model
+  let session: SolveSession
+  @State private var isReuploading = false
 
-    var body: some View {
-        ScrollView {
-            VStack(spacing: 16) {
-                if session.puzzleExpired {
-                    expiredBanner
-                }
-                PuzzleOverlayView(session: session)
-                PieceCaptureView()
-                if !session.entries.isEmpty {
-                    PieceQueueView(session: session)
-                }
-                if let error = session.errorMessage {
-                    Text(error)
-                        .font(.footnote)
-                        .foregroundStyle(.red)
-                }
-            }
-            .padding()
+  var body: some View {
+    ScrollView {
+      VStack(spacing: 16) {
+        if session.puzzleExpired {
+          expiredBanner
         }
-        .toolbar {
-            // Work is saved locally, so leaving the session keeps it around on
-            // the home screen — this is a plain "back", not a discard.
-            ToolbarItem(placement: .topBarLeading) {
-                Button {
-                    model.flow.reset()
-                } label: {
-                    Image(systemName: "chevron.left")
-                }
-                .accessibilityLabel("Back to puzzles")
-            }
+        PuzzleOverlayView(session: session)
+        PieceCaptureView()
+        if !session.entries.isEmpty {
+          PieceQueueView(session: session)
         }
+        if let error = session.errorMessage {
+          Text(error)
+            .font(.footnote)
+            .foregroundStyle(.red)
+        }
+      }
+      .padding()
     }
+    .toolbar {
+      // Work is saved locally, so leaving the session keeps it around on
+      // the home screen — this is a plain "back", not a discard.
+      ToolbarItem(placement: .topBarLeading) {
+        Button {
+          model.flow.reset()
+        } label: {
+          Image(systemName: "chevron.left")
+        }
+        .accessibilityLabel("Back to puzzles")
+      }
+    }
+  }
 
-    /// Shown when the backend restarted and forgot the puzzle_id — the kept
-    /// trimmed image can be re-uploaded for a fresh id without re-shooting.
-    private var expiredBanner: some View {
-        VStack(spacing: 8) {
-            Label("This puzzle session expired on the server.", systemImage: "exclamationmark.triangle.fill")
-                .font(.footnote)
-            if isReuploading {
-                ProgressView()
-            } else {
-                Button("Re-upload and continue") {
-                    Task {
-                        isReuploading = true
-                        await session.reupload(api: model.api)
-                        isReuploading = false
-                    }
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
+  /// Shown when the backend restarted and forgot the puzzle_id — the kept
+  /// trimmed image can be re-uploaded for a fresh id without re-shooting.
+  private var expiredBanner: some View {
+    VStack(spacing: 8) {
+      Label(
+        "This puzzle session expired on the server.", systemImage: "exclamationmark.triangle.fill"
+      )
+      .font(.footnote)
+      if isReuploading {
+        ProgressView()
+      } else {
+        Button("Re-upload and continue") {
+          Task {
+            isReuploading = true
+            await session.reupload(api: model.api)
+            isReuploading = false
+          }
         }
-        .frame(maxWidth: .infinity)
-        .padding(12)
-        .background(.orange.opacity(0.15), in: RoundedRectangle(cornerRadius: 10))
+        .buttonStyle(.borderedProminent)
+        .controlSize(.small)
+      }
     }
+    .frame(maxWidth: .infinity)
+    .padding(12)
+    .background(.orange.opacity(0.15), in: RoundedRectangle(cornerRadius: 10))
+  }
 }

--- a/ios/Pussel/Models/AuthModels.swift
+++ b/ios/Pussel/Models/AuthModels.swift
@@ -1,17 +1,17 @@
 import Foundation
 
 struct UserDTO: Codable, Equatable {
-    let id: String
-    let email: String
-    let name: String
-    let picture: String?
-    let createdAt: String?
+  let id: String
+  let email: String
+  let name: String
+  let picture: String?
+  let createdAt: String?
 }
 
 /// Response of POST /api/v1/auth/google.
 struct AuthResponse: Codable, Equatable {
-    let accessToken: String
-    let tokenType: String
-    let expiresIn: Int
-    let user: UserDTO
+  let accessToken: String
+  let tokenType: String
+  let expiresIn: Int
+  let user: UserDTO
 }

--- a/ios/Pussel/Models/PieceModels.swift
+++ b/ios/Pussel/Models/PieceModels.swift
@@ -2,54 +2,54 @@ import Foundation
 
 /// Response of POST /api/v1/puzzle/{id}/piece.
 struct PieceResponse: Codable, Equatable {
-    /// Predicted piece center, normalized to the trimmed puzzle image.
-    let position: NormalizedPoint
-    let positionConfidence: Double
-    /// One of 0, 90, 180, 270 (degrees).
-    let rotation: Int
-    let rotationConfidence: Double
-    /// data:image/png;base64,... with background removed, when available.
-    let cleanedImage: String?
+  /// Predicted piece center, normalized to the trimmed puzzle image.
+  let position: NormalizedPoint
+  let positionConfidence: Double
+  /// One of 0, 90, 180, 270 (degrees).
+  let rotation: Int
+  let rotationConfidence: Double
+  /// data:image/png;base64,... with background removed, when available.
+  let cleanedImage: String?
 }
 
 /// A captured piece moving through the prediction queue.
 struct CaptureEntry: Identifiable, Equatable {
-    enum Status: Equatable {
-        case queued
-        case predicting
-        case done
-        /// The backend forgot the puzzle_id (restart) — recoverable via re-upload.
-        case expired
-        case error(String)
+  enum Status: Equatable {
+    case queued
+    case predicting
+    case done
+    /// The backend forgot the puzzle_id (restart) — recoverable via re-upload.
+    case expired
+    case error(String)
 
-        var isRetryable: Bool {
-            switch self {
-            case .expired, .error: return true
-            case .queued, .predicting, .done: return false
-            }
-        }
+    var isRetryable: Bool {
+      switch self {
+      case .expired, .error: return true
+      case .queued, .predicting, .done: return false
+      }
     }
+  }
 
-    let id: UUID
-    /// JPEG sent to the backend; kept for retry.
-    let uploadJPEG: Data
-    /// Image shown in the UI — the raw capture until a cleaned PNG replaces it.
-    var displayImage: Data
-    var status: Status = .queued
-    var result: PieceResponse?
+  let id: UUID
+  /// JPEG sent to the backend; kept for retry.
+  let uploadJPEG: Data
+  /// Image shown in the UI — the raw capture until a cleaned PNG replaces it.
+  var displayImage: Data
+  var status: Status = .queued
+  var result: PieceResponse?
 
-    init(jpeg: Data) {
-        self.id = UUID()
-        self.uploadJPEG = jpeg
-        self.displayImage = jpeg
-    }
+  init(jpeg: Data) {
+    self.id = UUID()
+    self.uploadJPEG = jpeg
+    self.displayImage = jpeg
+  }
 
-    /// Rehydrates an entry loaded from disk (see PuzzleStore.loadSession).
-    init(id: UUID, uploadJPEG: Data, displayImage: Data, status: Status, result: PieceResponse?) {
-        self.id = id
-        self.uploadJPEG = uploadJPEG
-        self.displayImage = displayImage
-        self.status = status
-        self.result = result
-    }
+  /// Rehydrates an entry loaded from disk (see PuzzleStore.loadSession).
+  init(id: UUID, uploadJPEG: Data, displayImage: Data, status: Status, result: PieceResponse?) {
+    self.id = id
+    self.uploadJPEG = uploadJPEG
+    self.displayImage = displayImage
+    self.status = status
+    self.result = result
+  }
 }

--- a/ios/Pussel/Models/PuzzleModels.swift
+++ b/ios/Pussel/Models/PuzzleModels.swift
@@ -2,27 +2,27 @@ import Foundation
 
 /// A point in [0, 1] coordinates relative to the image it belongs to.
 struct NormalizedPoint: Codable, Equatable {
-    let x: Double
-    let y: Double
+  let x: Double
+  let y: Double
 }
 
 struct QuadCorners: Codable, Equatable {
-    let topLeft: NormalizedPoint
-    let topRight: NormalizedPoint
-    let bottomRight: NormalizedPoint
-    let bottomLeft: NormalizedPoint
+  let topLeft: NormalizedPoint
+  let topRight: NormalizedPoint
+  let bottomRight: NormalizedPoint
+  let bottomLeft: NormalizedPoint
 }
 
 /// Response of POST /api/v1/puzzle/detect-frame.
 struct DetectFrameResponse: Codable, Equatable {
-    /// data:image/jpeg;base64,... of the trimmed, perspective-corrected puzzle.
-    let trimmedImage: String
-    let corners: QuadCorners
-    let confidence: Double
+  /// data:image/jpeg;base64,... of the trimmed, perspective-corrected puzzle.
+  let trimmedImage: String
+  let corners: QuadCorners
+  let confidence: Double
 }
 
 /// Response of POST /api/v1/puzzle/upload.
 struct PuzzleUploadResponse: Codable, Equatable {
-    let puzzleId: String
-    let imageUrl: String?
+  let puzzleId: String
+  let imageUrl: String?
 }

--- a/ios/Pussel/Networking/APIClient.swift
+++ b/ios/Pussel/Networking/APIClient.swift
@@ -3,105 +3,116 @@ import Foundation
 /// Async client for the Pussel FastAPI backend, mirroring frontend/src/lib/api.ts.
 @MainActor
 final class APIClient {
-    private let baseURL: URL
-    private let session: URLSession
-    private let authStore: AuthStore
-    private let decoder: JSONDecoder
+  private let baseURL: URL
+  private let session: URLSession
+  private let authStore: AuthStore
+  private let decoder: JSONDecoder
 
-    /// Set by AuthService: silently refresh the backend JWT after a 401.
-    /// Returns true when a fresh token was stored and the request can retry.
-    var reauthenticator: (() async -> Bool)?
+  /// Set by AuthService: silently refresh the backend JWT after a 401.
+  /// Returns true when a fresh token was stored and the request can retry.
+  var reauthenticator: (() async -> Bool)?
 
-    init(baseURL: URL = Config.apiBaseURL, session: URLSession = .shared, authStore: AuthStore) {
-        self.baseURL = baseURL
-        self.session = session
-        self.authStore = authStore
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
-        self.decoder = decoder
+  init(baseURL: URL = Config.apiBaseURL, session: URLSession = .shared, authStore: AuthStore) {
+    self.baseURL = baseURL
+    self.session = session
+    self.authStore = authStore
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    self.decoder = decoder
+  }
+
+  // MARK: - Endpoints
+
+  func checkHealth() async -> Bool {
+    let request = URLRequest(url: baseURL.appending(path: "health"))
+    guard let (_, response) = try? await session.data(for: request),
+      let http = response as? HTTPURLResponse
+    else { return false }
+    return http.statusCode == 200
+  }
+
+  func signInWithGoogle(idToken: String) async throws -> AuthResponse {
+    var request = URLRequest(url: baseURL.appending(path: "api/v1/auth/google"))
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try JSONEncoder().encode(["id_token": idToken])
+    let data = try await send(request, authenticated: false)
+    return try decoder.decode(AuthResponse.self, from: data)
+  }
+
+  func detectFrame(jpegData: Data) async throws -> DetectFrameResponse {
+    let request = makeMultipartRequest(
+      path: "api/v1/puzzle/detect-frame", jpegData: jpegData, filename: "puzzle.jpg")
+    return try await sendDecoding(request)
+  }
+
+  func uploadPuzzle(jpegData: Data) async throws -> PuzzleUploadResponse {
+    let request = makeMultipartRequest(
+      path: "api/v1/puzzle/upload", jpegData: jpegData, filename: "puzzle.jpg")
+    return try await sendDecoding(request)
+  }
+
+  func processPiece(puzzleId: String, jpegData: Data, removeBg: Bool = true) async throws
+    -> PieceResponse
+  {
+    let request = makeMultipartRequest(
+      path: "api/v1/puzzle/\(puzzleId)/piece",
+      queryItems: [URLQueryItem(name: "remove_bg", value: removeBg ? "true" : "false")],
+      jpegData: jpegData,
+      filename: "piece.jpg"
+    )
+    return try await sendDecoding(request)
+  }
+
+  // MARK: - Request building & sending
+
+  func makeMultipartRequest(
+    path: String, queryItems: [URLQueryItem] = [], jpegData: Data, filename: String
+  )
+    -> URLRequest
+  {
+    var url = baseURL.appending(path: path)
+    if !queryItems.isEmpty {
+      url.append(queryItems: queryItems)
     }
+    var form = MultipartFormData()
+    form.appendFile(name: "file", filename: filename, mimeType: "image/jpeg", data: jpegData)
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue(form.contentType, forHTTPHeaderField: "Content-Type")
+    request.httpBody = form.encoded()
+    return request
+  }
 
-    // MARK: - Endpoints
+  private func sendDecoding<T: Decodable>(_ request: URLRequest) async throws -> T {
+    let data = try await send(request, authenticated: true)
+    return try decoder.decode(T.self, from: data)
+  }
 
-    func checkHealth() async -> Bool {
-        let request = URLRequest(url: baseURL.appending(path: "health"))
-        guard let (_, response) = try? await session.data(for: request),
-              let http = response as? HTTPURLResponse else { return false }
-        return http.statusCode == 200
+  private func send(_ request: URLRequest, authenticated: Bool, allowRetry: Bool = true)
+    async throws -> Data
+  {
+    var request = request
+    if authenticated, let token = authStore.backendToken {
+      request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
     }
-
-    func signInWithGoogle(idToken: String) async throws -> AuthResponse {
-        var request = URLRequest(url: baseURL.appending(path: "api/v1/auth/google"))
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try JSONEncoder().encode(["id_token": idToken])
-        let data = try await send(request, authenticated: false)
-        return try decoder.decode(AuthResponse.self, from: data)
+    let (data, response) = try await session.data(for: request)
+    guard let http = response as? HTTPURLResponse else {
+      throw APIError(message: "Invalid response from server.", status: nil)
     }
-
-    func detectFrame(jpegData: Data) async throws -> DetectFrameResponse {
-        let request = makeMultipartRequest(path: "api/v1/puzzle/detect-frame", jpegData: jpegData, filename: "puzzle.jpg")
-        return try await sendDecoding(request)
+    if http.statusCode == 401, authenticated, allowRetry, await reauthenticator?() == true {
+      return try await send(request, authenticated: true, allowRetry: false)
     }
-
-    func uploadPuzzle(jpegData: Data) async throws -> PuzzleUploadResponse {
-        let request = makeMultipartRequest(path: "api/v1/puzzle/upload", jpegData: jpegData, filename: "puzzle.jpg")
-        return try await sendDecoding(request)
+    guard (200..<300).contains(http.statusCode) else {
+      if http.statusCode == 401, authenticated {
+        // Silent re-auth failed or the retry 401ed again — drop the
+        // session so RootView falls back to SignInView instead of
+        // leaving an "authenticated" UI whose every call fails.
+        authStore.backendToken = nil
+        authStore.user = nil
+      }
+      throw APIError.from(data: data, status: http.statusCode)
     }
-
-    func processPiece(puzzleId: String, jpegData: Data, removeBg: Bool = true) async throws -> PieceResponse {
-        let request = makeMultipartRequest(
-            path: "api/v1/puzzle/\(puzzleId)/piece",
-            queryItems: [URLQueryItem(name: "remove_bg", value: removeBg ? "true" : "false")],
-            jpegData: jpegData,
-            filename: "piece.jpg"
-        )
-        return try await sendDecoding(request)
-    }
-
-    // MARK: - Request building & sending
-
-    func makeMultipartRequest(path: String, queryItems: [URLQueryItem] = [], jpegData: Data, filename: String) -> URLRequest {
-        var url = baseURL.appending(path: path)
-        if !queryItems.isEmpty {
-            url.append(queryItems: queryItems)
-        }
-        var form = MultipartFormData()
-        form.appendFile(name: "file", filename: filename, mimeType: "image/jpeg", data: jpegData)
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue(form.contentType, forHTTPHeaderField: "Content-Type")
-        request.httpBody = form.encoded()
-        return request
-    }
-
-    private func sendDecoding<T: Decodable>(_ request: URLRequest) async throws -> T {
-        let data = try await send(request, authenticated: true)
-        return try decoder.decode(T.self, from: data)
-    }
-
-    private func send(_ request: URLRequest, authenticated: Bool, allowRetry: Bool = true) async throws -> Data {
-        var request = request
-        if authenticated, let token = authStore.backendToken {
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        }
-        let (data, response) = try await session.data(for: request)
-        guard let http = response as? HTTPURLResponse else {
-            throw APIError(message: "Invalid response from server.", status: nil)
-        }
-        if http.statusCode == 401, authenticated, allowRetry, await reauthenticator?() == true {
-            return try await send(request, authenticated: true, allowRetry: false)
-        }
-        guard (200..<300).contains(http.statusCode) else {
-            if http.statusCode == 401, authenticated {
-                // Silent re-auth failed or the retry 401ed again — drop the
-                // session so RootView falls back to SignInView instead of
-                // leaving an "authenticated" UI whose every call fails.
-                authStore.backendToken = nil
-                authStore.user = nil
-            }
-            throw APIError.from(data: data, status: http.statusCode)
-        }
-        return data
-    }
+    return data
+  }
 }

--- a/ios/Pussel/Networking/APIError.swift
+++ b/ios/Pussel/Networking/APIError.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 struct APIError: Error, LocalizedError, Equatable {
-    let message: String
-    let status: Int?
+  let message: String
+  let status: Int?
 
-    var errorDescription: String? { message }
+  var errorDescription: String? { message }
 
-    /// Maps a non-2xx backend response to an error, mirroring frontend/src/lib/api.ts.
-    static func from(data: Data, status: Int) -> APIError {
-        if status == 401 {
-            return APIError(message: "Authentication required. Please sign in.", status: status)
-        }
-        struct Body: Decodable {
-            let detail: String?
-        }
-        let detail = (try? JSONDecoder().decode(Body.self, from: data))?.detail
-        return APIError(message: detail ?? "Request failed with status \(status)", status: status)
+  /// Maps a non-2xx backend response to an error, mirroring frontend/src/lib/api.ts.
+  static func from(data: Data, status: Int) -> APIError {
+    if status == 401 {
+      return APIError(message: "Authentication required. Please sign in.", status: status)
     }
+    struct Body: Decodable {
+      let detail: String?
+    }
+    let detail = (try? JSONDecoder().decode(Body.self, from: data))?.detail
+    return APIError(message: detail ?? "Request failed with status \(status)", status: status)
+  }
 }

--- a/ios/Pussel/Networking/MultipartFormData.swift
+++ b/ios/Pussel/Networking/MultipartFormData.swift
@@ -3,36 +3,36 @@ import Foundation
 /// Minimal multipart/form-data body builder — the backend only ever needs a
 /// single `file` part (and occasionally simple string fields).
 struct MultipartFormData {
-    let boundary: String
-    private var body = Data()
+  let boundary: String
+  private var body = Data()
 
-    init(boundary: String = "Boundary-\(UUID().uuidString)") {
-        self.boundary = boundary
-    }
+  init(boundary: String = "Boundary-\(UUID().uuidString)") {
+    self.boundary = boundary
+  }
 
-    var contentType: String { "multipart/form-data; boundary=\(boundary)" }
+  var contentType: String { "multipart/form-data; boundary=\(boundary)" }
 
-    mutating func appendField(name: String, value: String) {
-        append("--\(boundary)\r\n")
-        append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
-        append("\(value)\r\n")
-    }
+  mutating func appendField(name: String, value: String) {
+    append("--\(boundary)\r\n")
+    append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+    append("\(value)\r\n")
+  }
 
-    mutating func appendFile(name: String, filename: String, mimeType: String, data: Data) {
-        append("--\(boundary)\r\n")
-        append("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n")
-        append("Content-Type: \(mimeType)\r\n\r\n")
-        body.append(data)
-        append("\r\n")
-    }
+  mutating func appendFile(name: String, filename: String, mimeType: String, data: Data) {
+    append("--\(boundary)\r\n")
+    append("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n")
+    append("Content-Type: \(mimeType)\r\n\r\n")
+    body.append(data)
+    append("\r\n")
+  }
 
-    func encoded() -> Data {
-        var data = body
-        data.append(Data("--\(boundary)--\r\n".utf8))
-        return data
-    }
+  func encoded() -> Data {
+    var data = body
+    data.append(Data("--\(boundary)--\r\n".utf8))
+    return data
+  }
 
-    private mutating func append(_ string: String) {
-        body.append(Data(string.utf8))
-    }
+  private mutating func append(_ string: String) {
+    body.append(Data(string.utf8))
+  }
 }

--- a/ios/Pussel/Persistence/PuzzleStore.swift
+++ b/ios/Pussel/Persistence/PuzzleStore.swift
@@ -4,40 +4,40 @@ import Observation
 /// A lightweight row for the home-screen list — enough to render a card
 /// without loading every piece image of every stored puzzle.
 struct PuzzleSummary: Identifiable, Equatable {
-    let id: UUID
-    let name: String
-    let createdAt: Date
-    let updatedAt: Date
-    let pieceCount: Int
-    let placedCount: Int
-    /// Bytes of the small downsampled thumbnail (thumb.jpg), used as the card
-    /// image — not the full-size trimmed puzzle JPEG.
-    let thumbnail: Data?
+  let id: UUID
+  let name: String
+  let createdAt: Date
+  let updatedAt: Date
+  let pieceCount: Int
+  let placedCount: Int
+  /// Bytes of the small downsampled thumbnail (thumb.jpg), used as the card
+  /// image — not the full-size trimmed puzzle JPEG.
+  let thumbnail: Data?
 }
 
 /// On-disk manifest for one puzzle. Image bytes live in sibling files, so the
 /// JSON stays small; the piece's `cleanedImage` base64 is never persisted here
 /// (the display image is stored as a `<id>-display.jpg` file instead).
 private struct PuzzleManifest: Codable {
-    let id: UUID
-    var serverPuzzleId: String
-    var name: String
-    let createdAt: Date
-    var updatedAt: Date
-    var pieces: [StoredPiece]
+  let id: UUID
+  var serverPuzzleId: String
+  var name: String
+  let createdAt: Date
+  var updatedAt: Date
+  var pieces: [StoredPiece]
 }
 
 private struct StoredPiece: Codable {
-    let id: UUID
-    /// nil while the piece is captured but not yet predicted.
-    var result: StoredResult?
+  let id: UUID
+  /// nil while the piece is captured but not yet predicted.
+  var result: StoredResult?
 }
 
 private struct StoredResult: Codable {
-    let position: NormalizedPoint
-    let positionConfidence: Double
-    let rotation: Int
-    let rotationConfidence: Double
+  let position: NormalizedPoint
+  let positionConfidence: Double
+  let rotation: Int
+  let rotationConfidence: Double
 }
 
 /// Local, on-device persistence for solved/in-progress puzzles. Everything is
@@ -48,272 +48,277 @@ private struct StoredResult: Codable {
 @Observable
 @MainActor
 final class PuzzleStore {
-    /// Home-screen rows, newest activity first. Refreshed after every mutation.
-    private(set) var puzzles: [PuzzleSummary] = []
+  /// Home-screen rows, newest activity first. Refreshed after every mutation.
+  private(set) var puzzles: [PuzzleSummary] = []
 
-    @ObservationIgnored private let fileManager = FileManager.default
-    @ObservationIgnored private let encoder: JSONEncoder
-    @ObservationIgnored private let decoder: JSONDecoder
+  @ObservationIgnored private let fileManager = FileManager.default
+  @ObservationIgnored private let encoder: JSONEncoder
+  @ObservationIgnored private let decoder: JSONDecoder
 
-    init() {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        self.encoder = encoder
-        self.decoder = decoder
-        try? fileManager.createDirectory(at: rootURL, withIntermediateDirectories: true)
-        refresh()
+  init() {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    self.encoder = encoder
+    self.decoder = decoder
+    try? fileManager.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    refresh()
+  }
+
+  // MARK: Public API
+
+  /// Persists the current state of a session: writes any missing image files,
+  /// prunes files for removed pieces, and rewrites the manifest. Idempotent —
+  /// safe to call on every change (enqueue, prediction done, remove, reupload).
+  func save(_ session: SolveSession) {
+    let pieces = piecesDir(session.id)
+    // Creating the pieces dir with intermediates also creates its parent
+    // puzzle dir, so no separate puzzle-dir creation is needed.
+    try? fileManager.createDirectory(at: pieces, withIntermediateDirectories: true)
+
+    let trimmed = trimmedURL(session.id)
+    if !fileManager.fileExists(atPath: trimmed.path) {
+      try? session.trimmedJPEG.write(to: trimmed, options: .atomic)
     }
+    // The trimmed image is immutable, so its downsampled thumbnail is
+    // generated once and reused for the home-screen list.
+    let thumbnailData = loadOrCreateThumbnail(for: session.id, from: session.trimmedJPEG)
 
-    // MARK: Public API
+    // Only entries whose upload image is actually on disk go into the
+    // manifest, so a failed best-effort write can't leave the manifest
+    // referencing a missing file (which loadSession would then drop,
+    // diverging from the summary counts). A dropped entry is retried on the
+    // next persist(). keep set drives orphan pruning.
+    var keep = Set<String>()
+    var persistedEntries: [CaptureEntry] = []
+    for entry in session.entries {
+      let upload = uploadURL(session.id, entry.id)
+      if !fileManager.fileExists(atPath: upload.path) {
+        try? entry.uploadJPEG.write(to: upload, options: .atomic)
+      }
+      // Skip entries whose upload image didn't make it to disk; they'll be
+      // retried on the next persist() rather than left dangling.
+      guard fileManager.fileExists(atPath: upload.path) else { continue }
+      keep.insert(entry.id.uuidString)
 
-    /// Persists the current state of a session: writes any missing image files,
-    /// prunes files for removed pieces, and rewrites the manifest. Idempotent —
-    /// safe to call on every change (enqueue, prediction done, remove, reupload).
-    func save(_ session: SolveSession) {
-        let pieces = piecesDir(session.id)
-        // Creating the pieces dir with intermediates also creates its parent
-        // puzzle dir, so no separate puzzle-dir creation is needed.
-        try? fileManager.createDirectory(at: pieces, withIntermediateDirectories: true)
+      let display = displayURL(session.id, entry.id)
+      // Only store a separate display file when the cleaned image actually
+      // differs from the raw capture, otherwise the bytes are duplicated.
+      // The cleaned image is immutable once predicted, so skip the rewrite
+      // if it already exists (avoids rewriting every piece on each persist).
+      if entry.displayImage != entry.uploadJPEG, !fileManager.fileExists(atPath: display.path) {
+        try? entry.displayImage.write(to: display, options: .atomic)
+      }
+      persistedEntries.append(entry)
+    }
+    pruneOrphanPieceFiles(in: pieces, keeping: keep)
 
-        let trimmed = trimmedURL(session.id)
-        if !fileManager.fileExists(atPath: trimmed.path) {
-            try? session.trimmedJPEG.write(to: trimmed, options: .atomic)
-        }
-        // The trimmed image is immutable, so its downsampled thumbnail is
-        // generated once and reused for the home-screen list.
-        let thumbnailData = loadOrCreateThumbnail(for: session.id, from: session.trimmedJPEG)
-
-        // Only entries whose upload image is actually on disk go into the
-        // manifest, so a failed best-effort write can't leave the manifest
-        // referencing a missing file (which loadSession would then drop,
-        // diverging from the summary counts). A dropped entry is retried on the
-        // next persist(). keep set drives orphan pruning.
-        var keep = Set<String>()
-        var persistedEntries: [CaptureEntry] = []
-        for entry in session.entries {
-            let upload = uploadURL(session.id, entry.id)
-            if !fileManager.fileExists(atPath: upload.path) {
-                try? entry.uploadJPEG.write(to: upload, options: .atomic)
-            }
-            // Skip entries whose upload image didn't make it to disk; they'll be
-            // retried on the next persist() rather than left dangling.
-            guard fileManager.fileExists(atPath: upload.path) else { continue }
-            keep.insert(entry.id.uuidString)
-
-            let display = displayURL(session.id, entry.id)
-            // Only store a separate display file when the cleaned image actually
-            // differs from the raw capture, otherwise the bytes are duplicated.
-            // The cleaned image is immutable once predicted, so skip the rewrite
-            // if it already exists (avoids rewriting every piece on each persist).
-            if entry.displayImage != entry.uploadJPEG, !fileManager.fileExists(atPath: display.path) {
-                try? entry.displayImage.write(to: display, options: .atomic)
-            }
-            persistedEntries.append(entry)
-        }
-        pruneOrphanPieceFiles(in: pieces, keeping: keep)
-
-        let now = Date()
-        let manifest = PuzzleManifest(
-            id: session.id,
-            serverPuzzleId: session.puzzleId,
-            name: session.name,
-            createdAt: session.createdAt,
-            updatedAt: now,
-            pieces: persistedEntries.map { entry in
-                StoredPiece(
-                    id: entry.id,
-                    result: entry.result.map {
-                        StoredResult(
-                            position: $0.position,
-                            positionConfidence: $0.positionConfidence,
-                            rotation: $0.rotation,
-                            rotationConfidence: $0.rotationConfidence
-                        )
-                    }
-                )
-            }
-        )
-        do {
-            let data = try encoder.encode(manifest)
-            try data.write(to: manifestURL(session.id), options: .atomic)
-        } catch {
-            // Persistence is the whole point — don't advertise a puzzle in the
-            // list that won't survive a relaunch. Surface loudly in Debug and
-            // leave the in-memory list untouched.
-            assertionFailure("Failed to persist puzzle \(session.id): \(error)")
-            return
-        }
-
-        // Update just this puzzle's summary from in-memory state rather than
-        // rescanning and re-decoding the whole directory on every persist()
-        // (which runs on enqueue/prediction/remove/reupload).
-        upsert(
-            PuzzleSummary(
-                id: session.id,
-                name: session.name,
-                createdAt: session.createdAt,
-                updatedAt: now,
-                // Counts reflect what was persisted, matching the manifest.
-                pieceCount: persistedEntries.count,
-                placedCount: persistedEntries.filter { $0.result != nil }.count,
-                thumbnail: thumbnailData
+    let now = Date()
+    let manifest = PuzzleManifest(
+      id: session.id,
+      serverPuzzleId: session.puzzleId,
+      name: session.name,
+      createdAt: session.createdAt,
+      updatedAt: now,
+      pieces: persistedEntries.map { entry in
+        StoredPiece(
+          id: entry.id,
+          result: entry.result.map {
+            StoredResult(
+              position: $0.position,
+              positionConfidence: $0.positionConfidence,
+              rotation: $0.rotation,
+              rotationConfidence: $0.rotationConfidence
             )
+          }
         )
+      }
+    )
+    do {
+      let data = try encoder.encode(manifest)
+      try data.write(to: manifestURL(session.id), options: .atomic)
+    } catch {
+      // Persistence is the whole point — don't advertise a puzzle in the
+      // list that won't survive a relaunch. Surface loudly in Debug and
+      // leave the in-memory list untouched.
+      assertionFailure("Failed to persist puzzle \(session.id): \(error)")
+      return
     }
 
-    /// Inserts or replaces a summary in the in-memory list, keeping it sorted
-    /// by most-recent activity.
-    private func upsert(_ summary: PuzzleSummary) {
-        puzzles.removeAll { $0.id == summary.id }
-        puzzles.append(summary)
-        puzzles.sort { $0.updatedAt > $1.updatedAt }
-    }
+    // Update just this puzzle's summary from in-memory state rather than
+    // rescanning and re-decoding the whole directory on every persist()
+    // (which runs on enqueue/prediction/remove/reupload).
+    upsert(
+      PuzzleSummary(
+        id: session.id,
+        name: session.name,
+        createdAt: session.createdAt,
+        updatedAt: now,
+        // Counts reflect what was persisted, matching the manifest.
+        pieceCount: persistedEntries.count,
+        placedCount: persistedEntries.filter { $0.result != nil }.count,
+        thumbnail: thumbnailData
+      )
+    )
+  }
 
-    /// Returns the cached thumbnail bytes for a puzzle, generating and caching
-    /// them from the trimmed image on first use. Falls back to nil (the row
-    /// then shows a placeholder) rather than the full-size image.
-    private func loadOrCreateThumbnail(for id: UUID, from trimmedJPEG: Data) -> Data? {
-        let url = thumbnailURL(id)
-        if let existing = try? Data(contentsOf: url) {
-            return existing
-        }
-        guard let generated = ImageUtilities.thumbnailJPEG(from: trimmedJPEG) else { return nil }
-        try? generated.write(to: url, options: .atomic)
-        return generated
-    }
+  /// Inserts or replaces a summary in the in-memory list, keeping it sorted
+  /// by most-recent activity.
+  private func upsert(_ summary: PuzzleSummary) {
+    puzzles.removeAll { $0.id == summary.id }
+    puzzles.append(summary)
+    puzzles.sort { $0.updatedAt > $1.updatedAt }
+  }
 
-    /// Rehydrates a full working session from disk, or nil if the folder is
-    /// missing/corrupt. Pieces with a stored result come back `.done`; pieces
-    /// captured but never predicted come back `.queued` so the solve view can
-    /// resume them.
-    func loadSession(id: UUID) -> SolveSession? {
-        guard let data = try? Data(contentsOf: manifestURL(id)),
-              let manifest = try? decoder.decode(PuzzleManifest.self, from: data),
-              let trimmed = try? Data(contentsOf: trimmedURL(id)) else {
-            return nil
-        }
-        // The folder name is the canonical identity — use it (not manifest.id)
-        // so persist() always writes back to the directory we loaded from,
-        // even if the manifest was copied or moved.
-        let session = SolveSession(
-            id: id,
-            name: manifest.name,
-            puzzleId: manifest.serverPuzzleId,
-            trimmedJPEG: trimmed,
-            createdAt: manifest.createdAt,
-            store: self
+  /// Returns the cached thumbnail bytes for a puzzle, generating and caching
+  /// them from the trimmed image on first use. Falls back to nil (the row
+  /// then shows a placeholder) rather than the full-size image.
+  private func loadOrCreateThumbnail(for id: UUID, from trimmedJPEG: Data) -> Data? {
+    let url = thumbnailURL(id)
+    if let existing = try? Data(contentsOf: url) {
+      return existing
+    }
+    guard let generated = ImageUtilities.thumbnailJPEG(from: trimmedJPEG) else { return nil }
+    try? generated.write(to: url, options: .atomic)
+    return generated
+  }
+
+  /// Rehydrates a full working session from disk, or nil if the folder is
+  /// missing/corrupt. Pieces with a stored result come back `.done`; pieces
+  /// captured but never predicted come back `.queued` so the solve view can
+  /// resume them.
+  func loadSession(id: UUID) -> SolveSession? {
+    guard let data = try? Data(contentsOf: manifestURL(id)),
+      let manifest = try? decoder.decode(PuzzleManifest.self, from: data),
+      let trimmed = try? Data(contentsOf: trimmedURL(id))
+    else {
+      return nil
+    }
+    // The folder name is the canonical identity — use it (not manifest.id)
+    // so persist() always writes back to the directory we loaded from,
+    // even if the manifest was copied or moved.
+    let session = SolveSession(
+      id: id,
+      name: manifest.name,
+      puzzleId: manifest.serverPuzzleId,
+      trimmedJPEG: trimmed,
+      createdAt: manifest.createdAt,
+      store: self
+    )
+    session.entries = manifest.pieces.compactMap { piece in
+      guard let upload = try? Data(contentsOf: uploadURL(id, piece.id)) else { return nil }
+      let display = (try? Data(contentsOf: displayURL(id, piece.id))) ?? upload
+      let result = piece.result.map {
+        PieceResponse(
+          position: $0.position,
+          positionConfidence: $0.positionConfidence,
+          rotation: $0.rotation,
+          rotationConfidence: $0.rotationConfidence,
+          cleanedImage: nil
         )
-        session.entries = manifest.pieces.compactMap { piece in
-            guard let upload = try? Data(contentsOf: uploadURL(id, piece.id)) else { return nil }
-            let display = (try? Data(contentsOf: displayURL(id, piece.id))) ?? upload
-            let result = piece.result.map {
-                PieceResponse(
-                    position: $0.position,
-                    positionConfidence: $0.positionConfidence,
-                    rotation: $0.rotation,
-                    rotationConfidence: $0.rotationConfidence,
-                    cleanedImage: nil
-                )
-            }
-            return CaptureEntry(
-                id: piece.id,
-                uploadJPEG: upload,
-                displayImage: display,
-                status: result == nil ? .queued : .done,
-                result: result
-            )
+      }
+      return CaptureEntry(
+        id: piece.id,
+        uploadJPEG: upload,
+        displayImage: display,
+        status: result == nil ? .queued : .done,
+        result: result
+      )
+    }
+    return session
+  }
+
+  /// Permanently removes a puzzle and all of its images from disk.
+  func delete(_ id: UUID) {
+    try? fileManager.removeItem(at: puzzleDir(id))
+    refresh()
+  }
+
+  /// Rebuilds `puzzles` by scanning the store directory.
+  func refresh() {
+    let dirs =
+      (try? fileManager.contentsOfDirectory(
+        at: rootURL,
+        includingPropertiesForKeys: [.isDirectoryKey]
+      )) ?? []
+    puzzles = dirs.compactMap { dir -> PuzzleSummary? in
+      // The folder name is the canonical id (matching loadSession); use it
+      // for the summary and all file lookups rather than manifest.id, which
+      // could drift if a manifest was copied or moved.
+      guard (try? dir.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true,
+        let id = UUID(uuidString: dir.lastPathComponent),
+        let data = try? Data(contentsOf: dir.appendingPathComponent("manifest.json")),
+        let manifest = try? decoder.decode(PuzzleManifest.self, from: data)
+      else {
+        return nil
+      }
+      // Prefer the small cached thumbnail; generate it lazily from the
+      // trimmed image if this puzzle predates thumbnail caching.
+      let thumbnail =
+        (try? Data(contentsOf: thumbnailURL(id)))
+        ?? (try? Data(contentsOf: trimmedURL(id))).flatMap { trimmed in
+          loadOrCreateThumbnail(for: id, from: trimmed)
         }
-        return session
+      return PuzzleSummary(
+        id: id,
+        name: manifest.name,
+        createdAt: manifest.createdAt,
+        updatedAt: manifest.updatedAt,
+        pieceCount: manifest.pieces.count,
+        placedCount: manifest.pieces.filter { $0.result != nil }.count,
+        thumbnail: thumbnail
+      )
     }
+    .sorted { $0.updatedAt > $1.updatedAt }
+  }
 
-    /// Permanently removes a puzzle and all of its images from disk.
-    func delete(_ id: UUID) {
-        try? fileManager.removeItem(at: puzzleDir(id))
-        refresh()
+  // MARK: File layout
+
+  private var rootURL: URL {
+    let docs = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    return docs.appendingPathComponent("Puzzles", isDirectory: true)
+  }
+
+  private func puzzleDir(_ id: UUID) -> URL {
+    rootURL.appendingPathComponent(id.uuidString, isDirectory: true)
+  }
+
+  private func piecesDir(_ id: UUID) -> URL {
+    puzzleDir(id).appendingPathComponent("pieces", isDirectory: true)
+  }
+
+  private func trimmedURL(_ id: UUID) -> URL {
+    puzzleDir(id).appendingPathComponent("trimmed.jpg")
+  }
+
+  private func thumbnailURL(_ id: UUID) -> URL {
+    puzzleDir(id).appendingPathComponent("thumb.jpg")
+  }
+
+  private func manifestURL(_ id: UUID) -> URL {
+    puzzleDir(id).appendingPathComponent("manifest.json")
+  }
+
+  private func uploadURL(_ puzzle: UUID, _ piece: UUID) -> URL {
+    piecesDir(puzzle).appendingPathComponent("\(piece.uuidString)-upload.jpg")
+  }
+
+  private func displayURL(_ puzzle: UUID, _ piece: UUID) -> URL {
+    piecesDir(puzzle).appendingPathComponent("\(piece.uuidString)-display.jpg")
+  }
+
+  /// Deletes piece image files whose id is no longer in the session.
+  private func pruneOrphanPieceFiles(in dir: URL, keeping keep: Set<String>) {
+    let files =
+      (try? fileManager.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)) ?? []
+    for file in files {
+      // Filenames are "<uuid>-upload.jpg" / "<uuid>-display.jpg".
+      let id = String(file.lastPathComponent.prefix(36))
+      if !keep.contains(id) {
+        try? fileManager.removeItem(at: file)
+      }
     }
-
-    /// Rebuilds `puzzles` by scanning the store directory.
-    func refresh() {
-        let dirs = (try? fileManager.contentsOfDirectory(
-            at: rootURL,
-            includingPropertiesForKeys: [.isDirectoryKey]
-        )) ?? []
-        puzzles = dirs.compactMap { dir -> PuzzleSummary? in
-            // The folder name is the canonical id (matching loadSession); use it
-            // for the summary and all file lookups rather than manifest.id, which
-            // could drift if a manifest was copied or moved.
-            guard (try? dir.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true,
-                  let id = UUID(uuidString: dir.lastPathComponent),
-                  let data = try? Data(contentsOf: dir.appendingPathComponent("manifest.json")),
-                  let manifest = try? decoder.decode(PuzzleManifest.self, from: data) else {
-                return nil
-            }
-            // Prefer the small cached thumbnail; generate it lazily from the
-            // trimmed image if this puzzle predates thumbnail caching.
-            let thumbnail = (try? Data(contentsOf: thumbnailURL(id)))
-                ?? (try? Data(contentsOf: trimmedURL(id))).flatMap { trimmed in
-                    loadOrCreateThumbnail(for: id, from: trimmed)
-                }
-            return PuzzleSummary(
-                id: id,
-                name: manifest.name,
-                createdAt: manifest.createdAt,
-                updatedAt: manifest.updatedAt,
-                pieceCount: manifest.pieces.count,
-                placedCount: manifest.pieces.filter { $0.result != nil }.count,
-                thumbnail: thumbnail
-            )
-        }
-        .sorted { $0.updatedAt > $1.updatedAt }
-    }
-
-    // MARK: File layout
-
-    private var rootURL: URL {
-        let docs = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
-        return docs.appendingPathComponent("Puzzles", isDirectory: true)
-    }
-
-    private func puzzleDir(_ id: UUID) -> URL {
-        rootURL.appendingPathComponent(id.uuidString, isDirectory: true)
-    }
-
-    private func piecesDir(_ id: UUID) -> URL {
-        puzzleDir(id).appendingPathComponent("pieces", isDirectory: true)
-    }
-
-    private func trimmedURL(_ id: UUID) -> URL {
-        puzzleDir(id).appendingPathComponent("trimmed.jpg")
-    }
-
-    private func thumbnailURL(_ id: UUID) -> URL {
-        puzzleDir(id).appendingPathComponent("thumb.jpg")
-    }
-
-    private func manifestURL(_ id: UUID) -> URL {
-        puzzleDir(id).appendingPathComponent("manifest.json")
-    }
-
-    private func uploadURL(_ puzzle: UUID, _ piece: UUID) -> URL {
-        piecesDir(puzzle).appendingPathComponent("\(piece.uuidString)-upload.jpg")
-    }
-
-    private func displayURL(_ puzzle: UUID, _ piece: UUID) -> URL {
-        piecesDir(puzzle).appendingPathComponent("\(piece.uuidString)-display.jpg")
-    }
-
-    /// Deletes piece image files whose id is no longer in the session.
-    private func pruneOrphanPieceFiles(in dir: URL, keeping keep: Set<String>) {
-        let files = (try? fileManager.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)) ?? []
-        for file in files {
-            // Filenames are "<uuid>-upload.jpg" / "<uuid>-display.jpg".
-            let id = String(file.lastPathComponent.prefix(36))
-            if !keep.contains(id) {
-                try? fileManager.removeItem(at: file)
-            }
-        }
-    }
+  }
 }

--- a/ios/Pussel/Support/Config.swift
+++ b/ios/Pussel/Support/Config.swift
@@ -3,36 +3,36 @@ import Foundation
 /// Typed access to build-time configuration injected into Info.plist from
 /// Config/*.xcconfig (see project.yml `info.properties`).
 enum Config {
-    static var apiBaseURL: URL {
-        let raw = string(for: "APIBaseURL")
-        if let url = URL(string: raw), url.scheme != nil {
-            return url
-        }
-        #if DEBUG
-            return URL(string: "http://localhost:8000")!
-        #else
-            // A silent localhost fallback would mask a broken Release config;
-            // fail fast instead.
-            fatalError("APIBaseURL is missing or invalid in Info.plist: '\(raw)'")
-        #endif
+  static var apiBaseURL: URL {
+    let raw = string(for: "APIBaseURL")
+    if let url = URL(string: raw), url.scheme != nil {
+      return url
     }
+    #if DEBUG
+      return URL(string: "http://localhost:8000")!
+    #else
+      // A silent localhost fallback would mask a broken Release config;
+      // fail fast instead.
+      fatalError("APIBaseURL is missing or invalid in Info.plist: '\(raw)'")
+    #endif
+  }
 
-    static var googleIOSClientID: String { string(for: "GoogleIOSClientID") }
+  static var googleIOSClientID: String { string(for: "GoogleIOSClientID") }
 
-    static var googleServerClientID: String { string(for: "GoogleServerClientID") }
+  static var googleServerClientID: String { string(for: "GoogleServerClientID") }
 
-    /// True once Secrets.xcconfig holds real client ids (not the placeholders).
-    /// Both are needed: the iOS id for the sign-in sheet, the server id for a
-    /// backend-accepted ID-token audience.
-    static var isGoogleSignInConfigured: Bool {
-        isRealClientID(googleIOSClientID) && isRealClientID(googleServerClientID)
-    }
+  /// True once Secrets.xcconfig holds real client ids (not the placeholders).
+  /// Both are needed: the iOS id for the sign-in sheet, the server id for a
+  /// backend-accepted ID-token audience.
+  static var isGoogleSignInConfigured: Bool {
+    isRealClientID(googleIOSClientID) && isRealClientID(googleServerClientID)
+  }
 
-    private static func isRealClientID(_ id: String) -> Bool {
-        id.hasSuffix(".apps.googleusercontent.com") && !id.hasPrefix("YOUR_")
-    }
+  private static func isRealClientID(_ id: String) -> Bool {
+    id.hasSuffix(".apps.googleusercontent.com") && !id.hasPrefix("YOUR_")
+  }
 
-    private static func string(for key: String) -> String {
-        (Bundle.main.object(forInfoDictionaryKey: key) as? String) ?? ""
-    }
+  private static func string(for key: String) -> String {
+    (Bundle.main.object(forInfoDictionaryKey: key) as? String) ?? ""
+  }
 }

--- a/ios/Pussel/Support/DebugNavigation.swift
+++ b/ios/Pussel/Support/DebugNavigation.swift
@@ -1,100 +1,102 @@
 #if DEBUG
-    import UIKit
+  import UIKit
 
-    /// Debug-only command channel so the wizard can be driven from the CLI
-    /// while testing in the Simulator (which has no camera and no way to tap).
-    /// `simctl openurl` shows a confirmation dialog for custom schemes, so the
-    /// promptless path is a Darwin notification plus a command file:
-    ///   echo "pusseldebug://trim?puzzle=/host/path.jpg" > /tmp/pussel-debug-command
-    ///   xcrun simctl spawn booted notifyutil -p dk.delectosoft.pussel.debug
-    /// Commands: trim?puzzle=, accept, piece?path=, reupload, reset,
-    ///   open?index=, delete?index= (index into the saved-puzzles list).
-    /// Simulator apps can read host file paths directly. Compiled out of
-    /// Release builds; the handler runs the same actions as the real UI.
-    @MainActor
-    enum DebugDriver {
-        static weak var model: AppModel?
-        private static let notificationName = "dk.delectosoft.pussel.debug" as CFString
-        /// Override with SIMCTL_CHILD_PUSSEL_DEBUG_COMMAND_FILE at launch when
-        /// the host shell cannot write to /tmp.
-        private static var commandFile: String {
-            ProcessInfo.processInfo.environment["PUSSEL_DEBUG_COMMAND_FILE"] ?? "/tmp/pussel-debug-command"
-        }
-
-        private static var isObserving = false
-
-        static func start(_ model: AppModel) {
-            Self.model = model
-            // .task can re-run when the view hierarchy is recreated; register
-            // the Darwin observer only once or commands would run repeatedly.
-            guard !isObserving else { return }
-            isObserving = true
-            CFNotificationCenterAddObserver(
-                CFNotificationCenterGetDarwinNotifyCenter(),
-                nil,
-                { _, _, _, _, _ in
-                    Task { @MainActor in
-                        DebugDriver.runPendingCommand()
-                    }
-                },
-                notificationName,
-                nil,
-                .deliverImmediately
-            )
-        }
-
-        private static func runPendingCommand() {
-            guard let command = try? String(contentsOfFile: commandFile, encoding: .utf8),
-                  let url = URL(string: command.trimmingCharacters(in: .whitespacesAndNewlines)) else { return }
-            _ = model?.handleDebugURL(url)
-        }
+  /// Debug-only command channel so the wizard can be driven from the CLI
+  /// while testing in the Simulator (which has no camera and no way to tap).
+  /// `simctl openurl` shows a confirmation dialog for custom schemes, so the
+  /// promptless path is a Darwin notification plus a command file:
+  ///   echo "pusseldebug://trim?puzzle=/host/path.jpg" > /tmp/pussel-debug-command
+  ///   xcrun simctl spawn booted notifyutil -p dk.delectosoft.pussel.debug
+  /// Commands: trim?puzzle=, accept, piece?path=, reupload, reset,
+  ///   open?index=, delete?index= (index into the saved-puzzles list).
+  /// Simulator apps can read host file paths directly. Compiled out of
+  /// Release builds; the handler runs the same actions as the real UI.
+  @MainActor
+  enum DebugDriver {
+    static weak var model: AppModel?
+    private static let notificationName = "dk.delectosoft.pussel.debug" as CFString
+    /// Override with SIMCTL_CHILD_PUSSEL_DEBUG_COMMAND_FILE at launch when
+    /// the host shell cannot write to /tmp.
+    private static var commandFile: String {
+      ProcessInfo.processInfo.environment["PUSSEL_DEBUG_COMMAND_FILE"]
+        ?? "/tmp/pussel-debug-command"
     }
 
-    extension AppModel {
-        func handleDebugURL(_ url: URL) -> Bool {
-            guard url.scheme == "pusseldebug" else { return false }
-            let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
-            func value(_ name: String) -> String? {
-                items.first { $0.name == name }?.value
-            }
-            Task { @MainActor in
-                switch url.host() {
-                case "reset":
-                    flow.reset()
-                case "trim":
-                    if let image = Self.hostImage(value("puzzle")) {
-                        await startTrim(image: image, source: .library)
-                    }
-                case "accept":
-                    if case .confirmTrim(let candidate) = flow.phase {
-                        await acceptTrim(candidate)
-                    }
-                case "piece":
-                    if let image = Self.hostImage(value("path")) {
-                        addPiece(image: image)
-                    }
-                case "reupload":
-                    if case .solving(let session) = flow.phase {
-                        await session.reupload(api: api)
-                    }
-                case "open":
-                    if let index = value("index").flatMap(Int.init), store.puzzles.indices.contains(index) {
-                        openPuzzle(store.puzzles[index].id)
-                    }
-                case "delete":
-                    if let index = value("index").flatMap(Int.init), store.puzzles.indices.contains(index) {
-                        deletePuzzle(store.puzzles[index].id)
-                    }
-                default:
-                    break
-                }
-            }
-            return true
-        }
+    private static var isObserving = false
 
-        private static func hostImage(_ path: String?) -> UIImage? {
-            guard let path else { return nil }
-            return UIImage(contentsOfFile: path)
-        }
+    static func start(_ model: AppModel) {
+      Self.model = model
+      // .task can re-run when the view hierarchy is recreated; register
+      // the Darwin observer only once or commands would run repeatedly.
+      guard !isObserving else { return }
+      isObserving = true
+      CFNotificationCenterAddObserver(
+        CFNotificationCenterGetDarwinNotifyCenter(),
+        nil,
+        { _, _, _, _, _ in
+          Task { @MainActor in
+            DebugDriver.runPendingCommand()
+          }
+        },
+        notificationName,
+        nil,
+        .deliverImmediately
+      )
     }
+
+    private static func runPendingCommand() {
+      guard let command = try? String(contentsOfFile: commandFile, encoding: .utf8),
+        let url = URL(string: command.trimmingCharacters(in: .whitespacesAndNewlines))
+      else { return }
+      _ = model?.handleDebugURL(url)
+    }
+  }
+
+  extension AppModel {
+    func handleDebugURL(_ url: URL) -> Bool {
+      guard url.scheme == "pusseldebug" else { return false }
+      let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+      func value(_ name: String) -> String? {
+        items.first { $0.name == name }?.value
+      }
+      Task { @MainActor in
+        switch url.host() {
+        case "reset":
+          flow.reset()
+        case "trim":
+          if let image = Self.hostImage(value("puzzle")) {
+            await startTrim(image: image, source: .library)
+          }
+        case "accept":
+          if case .confirmTrim(let candidate) = flow.phase {
+            await acceptTrim(candidate)
+          }
+        case "piece":
+          if let image = Self.hostImage(value("path")) {
+            addPiece(image: image)
+          }
+        case "reupload":
+          if case .solving(let session) = flow.phase {
+            await session.reupload(api: api)
+          }
+        case "open":
+          if let index = value("index").flatMap(Int.init), store.puzzles.indices.contains(index) {
+            openPuzzle(store.puzzles[index].id)
+          }
+        case "delete":
+          if let index = value("index").flatMap(Int.init), store.puzzles.indices.contains(index) {
+            deletePuzzle(store.puzzles[index].id)
+          }
+        default:
+          break
+        }
+      }
+      return true
+    }
+
+    private static func hostImage(_ path: String?) -> UIImage? {
+      guard let path else { return nil }
+      return UIImage(contentsOfFile: path)
+    }
+  }
 #endif

--- a/ios/Pussel/Support/ImageUtilities.swift
+++ b/ios/Pussel/Support/ImageUtilities.swift
@@ -2,65 +2,74 @@ import ImageIO
 import UIKit
 
 enum ImageUtilities {
-    /// Backend rejects uploads above 10 MB (413).
-    static let maxUploadBytes = 10 * 1024 * 1024
+  /// Backend rejects uploads above 10 MB (413).
+  static let maxUploadBytes = 10 * 1024 * 1024
 
-    /// Downsamples JPEG data to a small thumbnail (long side ~`maxPixel`) using
-    /// ImageIO, which decodes only what the thumbnail needs. Used for the
-    /// home-screen puzzle list so a full-size image isn't held in memory or
-    /// decoded just to draw a small card.
-    static func thumbnailJPEG(from data: Data, maxPixel: Int = 240) -> Data? {
-        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
-        let options: [CFString: Any] = [
-            kCGImageSourceCreateThumbnailFromImageAlways: true,
-            kCGImageSourceCreateThumbnailWithTransform: true,
-            kCGImageSourceThumbnailMaxPixelSize: maxPixel,
-        ]
-        guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
-            return nil
-        }
-        let output = NSMutableData()
-        guard let destination = CGImageDestinationCreateWithData(output, "public.jpeg" as CFString, 1, nil) else {
-            return nil
-        }
-        CGImageDestinationAddImage(destination, thumbnail, [kCGImageDestinationLossyCompressionQuality: 0.8] as CFDictionary)
-        guard CGImageDestinationFinalize(destination) else { return nil }
-        return output as Data
+  /// Downsamples JPEG data to a small thumbnail (long side ~`maxPixel`) using
+  /// ImageIO, which decodes only what the thumbnail needs. Used for the
+  /// home-screen puzzle list so a full-size image isn't held in memory or
+  /// decoded just to draw a small card.
+  static func thumbnailJPEG(from data: Data, maxPixel: Int = 240) -> Data? {
+    guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+    let options: [CFString: Any] = [
+      kCGImageSourceCreateThumbnailFromImageAlways: true,
+      kCGImageSourceCreateThumbnailWithTransform: true,
+      kCGImageSourceThumbnailMaxPixelSize: maxPixel,
+    ]
+    guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
+    else {
+      return nil
+    }
+    let output = NSMutableData()
+    guard
+      let destination = CGImageDestinationCreateWithData(output, "public.jpeg" as CFString, 1, nil)
+    else {
+      return nil
+    }
+    CGImageDestinationAddImage(
+      destination, thumbnail, [kCGImageDestinationLossyCompressionQuality: 0.8] as CFDictionary)
+    guard CGImageDestinationFinalize(destination) else { return nil }
+    return output as Data
+  }
+
+  /// Redraws the image upright (baking in EXIF orientation) and downscales it
+  /// so the long side is at most `maxDimension`, then encodes JPEG. Reduces
+  /// quality stepwise if the result would exceed the backend's upload limit.
+  static func normalizedJPEG(
+    from image: UIImage, maxDimension: CGFloat = 1920, quality: CGFloat = 0.9
+  ) -> Data? {
+    let pixelSize = CGSize(
+      width: image.size.width * image.scale, height: image.size.height * image.scale)
+    let longSide = max(pixelSize.width, pixelSize.height)
+    guard longSide > 0 else { return nil }
+    let ratio = min(1, maxDimension / longSide)
+    let targetSize = CGSize(
+      width: (pixelSize.width * ratio).rounded(.down),
+      height: (pixelSize.height * ratio).rounded(.down))
+
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    let upright = UIGraphicsImageRenderer(size: targetSize, format: format).image { _ in
+      image.draw(in: CGRect(origin: .zero, size: targetSize))
     }
 
-    /// Redraws the image upright (baking in EXIF orientation) and downscales it
-    /// so the long side is at most `maxDimension`, then encodes JPEG. Reduces
-    /// quality stepwise if the result would exceed the backend's upload limit.
-    static func normalizedJPEG(from image: UIImage, maxDimension: CGFloat = 1920, quality: CGFloat = 0.9) -> Data? {
-        let pixelSize = CGSize(width: image.size.width * image.scale, height: image.size.height * image.scale)
-        let longSide = max(pixelSize.width, pixelSize.height)
-        guard longSide > 0 else { return nil }
-        let ratio = min(1, maxDimension / longSide)
-        let targetSize = CGSize(width: (pixelSize.width * ratio).rounded(.down), height: (pixelSize.height * ratio).rounded(.down))
-
-        let format = UIGraphicsImageRendererFormat()
-        format.scale = 1
-        let upright = UIGraphicsImageRenderer(size: targetSize, format: format).image { _ in
-            image.draw(in: CGRect(origin: .zero, size: targetSize))
-        }
-
-        let minQuality: CGFloat = 0.4
-        var quality = quality
-        var data = upright.jpegData(compressionQuality: quality)
-        while let encoded = data, encoded.count > maxUploadBytes, quality > minQuality {
-            quality = max(quality - 0.15, minQuality)
-            data = upright.jpegData(compressionQuality: quality)
-        }
-        // Fail fast rather than letting the backend reject the upload with 413.
-        guard let encoded = data, encoded.count <= maxUploadBytes else { return nil }
-        return encoded
+    let minQuality: CGFloat = 0.4
+    var quality = quality
+    var data = upright.jpegData(compressionQuality: quality)
+    while let encoded = data, encoded.count > maxUploadBytes, quality > minQuality {
+      quality = max(quality - 0.15, minQuality)
+      data = upright.jpegData(compressionQuality: quality)
     }
+    // Fail fast rather than letting the backend reject the upload with 413.
+    guard let encoded = data, encoded.count <= maxUploadBytes else { return nil }
+    return encoded
+  }
 
-    /// Decodes a "data:image/...;base64,..." string (or bare base64) to bytes.
-    static func decodeDataURL(_ string: String) -> Data? {
-        guard let comma = string.firstIndex(of: ",") else {
-            return Data(base64Encoded: string)
-        }
-        return Data(base64Encoded: String(string[string.index(after: comma)...]))
+  /// Decodes a "data:image/...;base64,..." string (or bare base64) to bytes.
+  static func decodeDataURL(_ string: String) -> Data? {
+    guard let comma = string.firstIndex(of: ",") else {
+      return Data(base64Encoded: string)
     }
+    return Data(base64Encoded: String(string[string.index(after: comma)...]))
+  }
 }

--- a/ios/PusselTests/APIClientTests.swift
+++ b/ios/PusselTests/APIClientTests.swift
@@ -6,137 +6,139 @@ import XCTest
 /// callbacks run on URLSession's internal threads, so the shared state is
 /// guarded by a lock.
 final class StubURLProtocol: URLProtocol {
-    private static let lock = NSLock()
-    nonisolated(unsafe) private static var _handler: ((URLRequest) -> (Int, Data))?
-    nonisolated(unsafe) private static var _receivedRequests: [URLRequest] = []
+  private static let lock = NSLock()
+  nonisolated(unsafe) private static var _handler: ((URLRequest) -> (Int, Data))?
+  nonisolated(unsafe) private static var _receivedRequests: [URLRequest] = []
 
-    static var handler: ((URLRequest) -> (Int, Data))? {
-        get { lock.withLock { _handler } }
-        set { lock.withLock { _handler = newValue } }
+  static var handler: ((URLRequest) -> (Int, Data))? {
+    get { lock.withLock { _handler } }
+    set { lock.withLock { _handler = newValue } }
+  }
+
+  static var receivedRequests: [URLRequest] {
+    get { lock.withLock { _receivedRequests } }
+    set { lock.withLock { _receivedRequests = newValue } }
+  }
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    let handler = Self.lock.withLock {
+      Self._receivedRequests.append(request)
+      return Self._handler
     }
-
-    static var receivedRequests: [URLRequest] {
-        get { lock.withLock { _receivedRequests } }
-        set { lock.withLock { _receivedRequests = newValue } }
+    guard let handler else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+      return
     }
+    let (status, data) = handler(request)
+    let response = HTTPURLResponse(
+      url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: data)
+    client?.urlProtocolDidFinishLoading(self)
+  }
 
-    override class func canInit(with request: URLRequest) -> Bool { true }
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
-
-    override func startLoading() {
-        let handler = Self.lock.withLock {
-            Self._receivedRequests.append(request)
-            return Self._handler
-        }
-        guard let handler else {
-            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-            return
-        }
-        let (status, data) = handler(request)
-        let response = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
-        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        client?.urlProtocol(self, didLoad: data)
-        client?.urlProtocolDidFinishLoading(self)
-    }
-
-    override func stopLoading() {}
+  override func stopLoading() {}
 }
 
 @MainActor
 final class APIClientTests: XCTestCase {
-    private var authStore: AuthStore!
-    private var client: APIClient!
+  private var authStore: AuthStore!
+  private var client: APIClient!
 
-    override func setUp() {
-        super.setUp()
-        StubURLProtocol.handler = nil
-        StubURLProtocol.receivedRequests = []
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [StubURLProtocol.self]
-        authStore = AuthStore()
-        client = APIClient(
-            baseURL: URL(string: "http://stub.local")!,
-            session: URLSession(configuration: configuration),
-            authStore: authStore
-        )
-    }
+  override func setUp() {
+    super.setUp()
+    StubURLProtocol.handler = nil
+    StubURLProtocol.receivedRequests = []
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [StubURLProtocol.self]
+    authStore = AuthStore()
+    client = APIClient(
+      baseURL: URL(string: "http://stub.local")!,
+      session: URLSession(configuration: configuration),
+      authStore: authStore
+    )
+  }
 
-    func testMultipartRequestBuilding() {
-        let request = client.makeMultipartRequest(
-            path: "api/v1/puzzle/abc/piece",
-            queryItems: [URLQueryItem(name: "remove_bg", value: "true")],
-            jpegData: Data("JPEG".utf8),
-            filename: "piece.jpg"
-        )
-        XCTAssertEqual(request.httpMethod, "POST")
-        XCTAssertEqual(request.url?.absoluteString, "http://stub.local/api/v1/puzzle/abc/piece?remove_bg=true")
-        let contentType = request.value(forHTTPHeaderField: "Content-Type") ?? ""
-        XCTAssertTrue(contentType.hasPrefix("multipart/form-data; boundary="))
-        let body = String(decoding: request.httpBody ?? Data(), as: UTF8.self)
-        XCTAssertTrue(body.contains("name=\"file\"; filename=\"piece.jpg\""))
-        XCTAssertTrue(body.contains("Content-Type: image/jpeg"))
-    }
+  func testMultipartRequestBuilding() {
+    let request = client.makeMultipartRequest(
+      path: "api/v1/puzzle/abc/piece",
+      queryItems: [URLQueryItem(name: "remove_bg", value: "true")],
+      jpegData: Data("JPEG".utf8),
+      filename: "piece.jpg"
+    )
+    XCTAssertEqual(request.httpMethod, "POST")
+    XCTAssertEqual(
+      request.url?.absoluteString, "http://stub.local/api/v1/puzzle/abc/piece?remove_bg=true")
+    let contentType = request.value(forHTTPHeaderField: "Content-Type") ?? ""
+    XCTAssertTrue(contentType.hasPrefix("multipart/form-data; boundary="))
+    let body = String(decoding: request.httpBody ?? Data(), as: UTF8.self)
+    XCTAssertTrue(body.contains("name=\"file\"; filename=\"piece.jpg\""))
+    XCTAssertTrue(body.contains("Content-Type: image/jpeg"))
+  }
 
-    func testAuthorizationHeaderAttached() async throws {
-        authStore.backendToken = "token123"
-        StubURLProtocol.handler = { _ in
-            (200, Data(#"{"puzzle_id": "p1", "image_url": null}"#.utf8))
-        }
-        _ = try await client.uploadPuzzle(jpegData: Data("JPEG".utf8))
-        let auth = StubURLProtocol.receivedRequests.first?.value(forHTTPHeaderField: "Authorization")
-        XCTAssertEqual(auth, "Bearer token123")
+  func testAuthorizationHeaderAttached() async throws {
+    authStore.backendToken = "token123"
+    StubURLProtocol.handler = { _ in
+      (200, Data(#"{"puzzle_id": "p1", "image_url": null}"#.utf8))
     }
+    _ = try await client.uploadPuzzle(jpegData: Data("JPEG".utf8))
+    let auth = StubURLProtocol.receivedRequests.first?.value(forHTTPHeaderField: "Authorization")
+    XCTAssertEqual(auth, "Bearer token123")
+  }
 
-    func testErrorMappingUsesDetail() async {
-        StubURLProtocol.handler = { _ in
-            (404, Data(#"{"detail": "Puzzle not found"}"#.utf8))
-        }
-        do {
-            _ = try await client.processPiece(puzzleId: "dead", jpegData: Data("J".utf8))
-            XCTFail("Expected APIError")
-        } catch let error as APIError {
-            XCTAssertEqual(error.status, 404)
-            XCTAssertEqual(error.message, "Puzzle not found")
-        } catch {
-            XCTFail("Unexpected error type: \(error)")
-        }
+  func testErrorMappingUsesDetail() async {
+    StubURLProtocol.handler = { _ in
+      (404, Data(#"{"detail": "Puzzle not found"}"#.utf8))
     }
+    do {
+      _ = try await client.processPiece(puzzleId: "dead", jpegData: Data("J".utf8))
+      XCTFail("Expected APIError")
+    } catch let error as APIError {
+      XCTAssertEqual(error.status, 404)
+      XCTAssertEqual(error.message, "Puzzle not found")
+    } catch {
+      XCTFail("Unexpected error type: \(error)")
+    }
+  }
 
-    func test401TriggersReauthAndRetriesOnce() async throws {
-        authStore.backendToken = "stale"
-        StubURLProtocol.handler = { request in
-            if request.value(forHTTPHeaderField: "Authorization") == "Bearer fresh" {
-                return (200, Data(#"{"puzzle_id": "p2", "image_url": null}"#.utf8))
-            }
-            return (401, Data(#"{"detail": "Invalid or expired token"}"#.utf8))
-        }
-        client.reauthenticator = { [authStore] in
-            authStore?.backendToken = "fresh"
-            return true
-        }
-        let response = try await client.uploadPuzzle(jpegData: Data("J".utf8))
-        XCTAssertEqual(response.puzzleId, "p2")
-        // The lock-guarded request log stands in for a hand-rolled counter,
-        // which would race with URLSession's internal threads.
-        XCTAssertEqual(StubURLProtocol.receivedRequests.count, 2)
+  func test401TriggersReauthAndRetriesOnce() async throws {
+    authStore.backendToken = "stale"
+    StubURLProtocol.handler = { request in
+      if request.value(forHTTPHeaderField: "Authorization") == "Bearer fresh" {
+        return (200, Data(#"{"puzzle_id": "p2", "image_url": null}"#.utf8))
+      }
+      return (401, Data(#"{"detail": "Invalid or expired token"}"#.utf8))
     }
+    client.reauthenticator = { [authStore] in
+      authStore?.backendToken = "fresh"
+      return true
+    }
+    let response = try await client.uploadPuzzle(jpegData: Data("J".utf8))
+    XCTAssertEqual(response.puzzleId, "p2")
+    // The lock-guarded request log stands in for a hand-rolled counter,
+    // which would race with URLSession's internal threads.
+    XCTAssertEqual(StubURLProtocol.receivedRequests.count, 2)
+  }
 
-    func test401WithoutReauthSurfacesError() async {
-        authStore.backendToken = "stale"
-        StubURLProtocol.handler = { _ in
-            (401, Data(#"{"detail": "Invalid or expired token"}"#.utf8))
-        }
-        do {
-            _ = try await client.uploadPuzzle(jpegData: Data("J".utf8))
-            XCTFail("Expected APIError")
-        } catch let error as APIError {
-            XCTAssertEqual(error.status, 401)
-            XCTAssertEqual(error.message, "Authentication required. Please sign in.")
-            // The dead session must be dropped so the UI returns to sign-in.
-            XCTAssertNil(authStore.backendToken)
-            XCTAssertNil(authStore.user)
-        } catch {
-            XCTFail("Unexpected error type: \(error)")
-        }
+  func test401WithoutReauthSurfacesError() async {
+    authStore.backendToken = "stale"
+    StubURLProtocol.handler = { _ in
+      (401, Data(#"{"detail": "Invalid or expired token"}"#.utf8))
     }
+    do {
+      _ = try await client.uploadPuzzle(jpegData: Data("J".utf8))
+      XCTFail("Expected APIError")
+    } catch let error as APIError {
+      XCTAssertEqual(error.status, 401)
+      XCTAssertEqual(error.message, "Authentication required. Please sign in.")
+      // The dead session must be dropped so the UI returns to sign-in.
+      XCTAssertNil(authStore.backendToken)
+      XCTAssertNil(authStore.user)
+    } catch {
+      XCTFail("Unexpected error type: \(error)")
+    }
+  }
 }

--- a/ios/PusselTests/ModelDecodingTests.swift
+++ b/ios/PusselTests/ModelDecodingTests.swift
@@ -5,96 +5,96 @@ import XCTest
 /// Decoding tests against the backend's snake_case JSON shapes
 /// (backend/app/models/puzzle_model.py and app/auth models).
 final class ModelDecodingTests: XCTestCase {
-    private let decoder: JSONDecoder = {
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
-        return decoder
-    }()
+  private let decoder: JSONDecoder = {
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    return decoder
+  }()
 
-    func testDecodeAuthResponse() throws {
-        let json = """
-        {
-          "access_token": "jwt-token-value",
-          "token_type": "bearer",
-          "expires_in": 3600,
-          "user": {
-            "id": "12345",
-            "email": "claus@example.com",
-            "name": "Claus",
-            "picture": null,
-            "created_at": "2026-07-15T10:00:00.000000"
-          }
+  func testDecodeAuthResponse() throws {
+    let json = """
+      {
+        "access_token": "jwt-token-value",
+        "token_type": "bearer",
+        "expires_in": 3600,
+        "user": {
+          "id": "12345",
+          "email": "claus@example.com",
+          "name": "Claus",
+          "picture": null,
+          "created_at": "2026-07-15T10:00:00.000000"
         }
-        """
-        let response = try decoder.decode(AuthResponse.self, from: Data(json.utf8))
-        XCTAssertEqual(response.accessToken, "jwt-token-value")
-        XCTAssertEqual(response.expiresIn, 3600)
-        XCTAssertEqual(response.user.email, "claus@example.com")
-        XCTAssertNil(response.user.picture)
-    }
+      }
+      """
+    let response = try decoder.decode(AuthResponse.self, from: Data(json.utf8))
+    XCTAssertEqual(response.accessToken, "jwt-token-value")
+    XCTAssertEqual(response.expiresIn, 3600)
+    XCTAssertEqual(response.user.email, "claus@example.com")
+    XCTAssertNil(response.user.picture)
+  }
 
-    func testDecodeDetectFrameResponse() throws {
-        let json = """
-        {
-          "trimmed_image": "data:image/jpeg;base64,aGVsbG8=",
-          "corners": {
-            "top_left": {"x": 0.1, "y": 0.1},
-            "top_right": {"x": 0.9, "y": 0.1},
-            "bottom_right": {"x": 0.9, "y": 0.9},
-            "bottom_left": {"x": 0.1, "y": 0.9}
-          },
-          "confidence": 0.87
-        }
-        """
-        let response = try decoder.decode(DetectFrameResponse.self, from: Data(json.utf8))
-        XCTAssertEqual(response.confidence, 0.87)
-        XCTAssertEqual(response.corners.topLeft, NormalizedPoint(x: 0.1, y: 0.1))
-        XCTAssertEqual(response.corners.bottomRight, NormalizedPoint(x: 0.9, y: 0.9))
-        XCTAssertEqual(ImageUtilities.decodeDataURL(response.trimmedImage), Data("hello".utf8))
-    }
+  func testDecodeDetectFrameResponse() throws {
+    let json = """
+      {
+        "trimmed_image": "data:image/jpeg;base64,aGVsbG8=",
+        "corners": {
+          "top_left": {"x": 0.1, "y": 0.1},
+          "top_right": {"x": 0.9, "y": 0.1},
+          "bottom_right": {"x": 0.9, "y": 0.9},
+          "bottom_left": {"x": 0.1, "y": 0.9}
+        },
+        "confidence": 0.87
+      }
+      """
+    let response = try decoder.decode(DetectFrameResponse.self, from: Data(json.utf8))
+    XCTAssertEqual(response.confidence, 0.87)
+    XCTAssertEqual(response.corners.topLeft, NormalizedPoint(x: 0.1, y: 0.1))
+    XCTAssertEqual(response.corners.bottomRight, NormalizedPoint(x: 0.9, y: 0.9))
+    XCTAssertEqual(ImageUtilities.decodeDataURL(response.trimmedImage), Data("hello".utf8))
+  }
 
-    func testDecodePuzzleUploadResponse() throws {
-        let json = """
-        {"puzzle_id": "3f2b9c", "image_url": null}
-        """
-        let response = try decoder.decode(PuzzleUploadResponse.self, from: Data(json.utf8))
-        XCTAssertEqual(response.puzzleId, "3f2b9c")
-        XCTAssertNil(response.imageUrl)
-    }
+  func testDecodePuzzleUploadResponse() throws {
+    let json = """
+      {"puzzle_id": "3f2b9c", "image_url": null}
+      """
+    let response = try decoder.decode(PuzzleUploadResponse.self, from: Data(json.utf8))
+    XCTAssertEqual(response.puzzleId, "3f2b9c")
+    XCTAssertNil(response.imageUrl)
+  }
 
-    func testDecodePieceResponse() throws {
-        let json = """
-        {
-          "position": {"x": 0.25, "y": 0.75},
-          "position_confidence": 0.91,
-          "rotation": 270,
-          "rotation_confidence": 0.66,
-          "cleaned_image": "data:image/png;base64,cGll"
-        }
-        """
-        let response = try decoder.decode(PieceResponse.self, from: Data(json.utf8))
-        XCTAssertEqual(response.position, NormalizedPoint(x: 0.25, y: 0.75))
-        XCTAssertEqual(response.rotation, 270)
-        XCTAssertEqual(response.positionConfidence, 0.91)
-        XCTAssertEqual(ImageUtilities.decodeDataURL(response.cleanedImage!), Data("pie".utf8))
-    }
+  func testDecodePieceResponse() throws {
+    let json = """
+      {
+        "position": {"x": 0.25, "y": 0.75},
+        "position_confidence": 0.91,
+        "rotation": 270,
+        "rotation_confidence": 0.66,
+        "cleaned_image": "data:image/png;base64,cGll"
+      }
+      """
+    let response = try decoder.decode(PieceResponse.self, from: Data(json.utf8))
+    XCTAssertEqual(response.position, NormalizedPoint(x: 0.25, y: 0.75))
+    XCTAssertEqual(response.rotation, 270)
+    XCTAssertEqual(response.positionConfidence, 0.91)
+    XCTAssertEqual(ImageUtilities.decodeDataURL(response.cleanedImage!), Data("pie".utf8))
+  }
 
-    func testDecodePieceResponseWithoutCleanedImage() throws {
-        let json = """
-        {
-          "position": {"x": 0.5, "y": 0.5},
-          "position_confidence": 0.0,
-          "rotation": 0,
-          "rotation_confidence": 0.0,
-          "cleaned_image": null
-        }
-        """
-        let response = try decoder.decode(PieceResponse.self, from: Data(json.utf8))
-        XCTAssertNil(response.cleanedImage)
-    }
+  func testDecodePieceResponseWithoutCleanedImage() throws {
+    let json = """
+      {
+        "position": {"x": 0.5, "y": 0.5},
+        "position_confidence": 0.0,
+        "rotation": 0,
+        "rotation_confidence": 0.0,
+        "cleaned_image": null
+      }
+      """
+    let response = try decoder.decode(PieceResponse.self, from: Data(json.utf8))
+    XCTAssertNil(response.cleanedImage)
+  }
 
-    func testDecodeBareBase64DataURL() {
-        XCTAssertEqual(ImageUtilities.decodeDataURL("aGVsbG8="), Data("hello".utf8))
-        XCTAssertNil(ImageUtilities.decodeDataURL("data:image/png;base64,%%%invalid%%%"))
-    }
+  func testDecodeBareBase64DataURL() {
+    XCTAssertEqual(ImageUtilities.decodeDataURL("aGVsbG8="), Data("hello".utf8))
+    XCTAssertNil(ImageUtilities.decodeDataURL("data:image/png;base64,%%%invalid%%%"))
+  }
 }

--- a/ios/PusselTests/MultipartFormDataTests.swift
+++ b/ios/PusselTests/MultipartFormDataTests.swift
@@ -3,33 +3,36 @@ import XCTest
 @testable import Pussel
 
 final class MultipartFormDataTests: XCTestCase {
-    func testFilePartStructure() {
-        var form = MultipartFormData(boundary: "TESTBOUNDARY")
-        form.appendFile(name: "file", filename: "puzzle.jpg", mimeType: "image/jpeg", data: Data("JPEGBYTES".utf8))
-        let body = String(decoding: form.encoded(), as: UTF8.self)
+  func testFilePartStructure() {
+    var form = MultipartFormData(boundary: "TESTBOUNDARY")
+    form.appendFile(
+      name: "file", filename: "puzzle.jpg", mimeType: "image/jpeg", data: Data("JPEGBYTES".utf8))
+    let body = String(decoding: form.encoded(), as: UTF8.self)
 
-        let expected = "--TESTBOUNDARY\r\n"
-            + "Content-Disposition: form-data; name=\"file\"; filename=\"puzzle.jpg\"\r\n"
-            + "Content-Type: image/jpeg\r\n\r\n"
-            + "JPEGBYTES\r\n"
-            + "--TESTBOUNDARY--\r\n"
-        XCTAssertEqual(body, expected)
-        XCTAssertEqual(form.contentType, "multipart/form-data; boundary=TESTBOUNDARY")
-    }
+    let expected =
+      "--TESTBOUNDARY\r\n"
+      + "Content-Disposition: form-data; name=\"file\"; filename=\"puzzle.jpg\"\r\n"
+      + "Content-Type: image/jpeg\r\n\r\n"
+      + "JPEGBYTES\r\n"
+      + "--TESTBOUNDARY--\r\n"
+    XCTAssertEqual(body, expected)
+    XCTAssertEqual(form.contentType, "multipart/form-data; boundary=TESTBOUNDARY")
+  }
 
-    func testFieldPartStructure() {
-        var form = MultipartFormData(boundary: "TESTBOUNDARY")
-        form.appendField(name: "corners", value: "{\"x\":0.1}")
-        let body = String(decoding: form.encoded(), as: UTF8.self)
+  func testFieldPartStructure() {
+    var form = MultipartFormData(boundary: "TESTBOUNDARY")
+    form.appendField(name: "corners", value: "{\"x\":0.1}")
+    let body = String(decoding: form.encoded(), as: UTF8.self)
 
-        XCTAssertTrue(body.contains("Content-Disposition: form-data; name=\"corners\"\r\n\r\n{\"x\":0.1}\r\n"))
-        XCTAssertTrue(body.hasSuffix("--TESTBOUNDARY--\r\n"))
-    }
+    XCTAssertTrue(
+      body.contains("Content-Disposition: form-data; name=\"corners\"\r\n\r\n{\"x\":0.1}\r\n"))
+    XCTAssertTrue(body.hasSuffix("--TESTBOUNDARY--\r\n"))
+  }
 
-    func testBinaryDataPreserved() {
-        let binary = Data([0xFF, 0xD8, 0x00, 0x1F, 0xFF])
-        var form = MultipartFormData(boundary: "B")
-        form.appendFile(name: "file", filename: "f.jpg", mimeType: "image/jpeg", data: binary)
-        XCTAssertNotNil(form.encoded().range(of: binary))
-    }
+  func testBinaryDataPreserved() {
+    let binary = Data([0xFF, 0xD8, 0x00, 0x1F, 0xFF])
+    var form = MultipartFormData(boundary: "B")
+    form.appendFile(name: "file", filename: "f.jpg", mimeType: "image/jpeg", data: binary)
+    XCTAssertNotNil(form.encoded().range(of: binary))
+  }
 }

--- a/ios/PusselTests/PuzzleStoreTests.swift
+++ b/ios/PusselTests/PuzzleStoreTests.swift
@@ -8,136 +8,140 @@ import XCTest
 /// Documents directory is left clean.
 @MainActor
 final class PuzzleStoreTests: XCTestCase {
-    /// A real (decodable) JPEG so thumbnail generation exercises ImageIO.
-    private func tinyJPEG() -> Data {
-        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 8, height: 8))
-        return renderer.image { context in
-            UIColor.systemBlue.setFill()
-            context.fill(CGRect(x: 0, y: 0, width: 8, height: 8))
-        }.jpegData(compressionQuality: 0.9)!
-    }
+  /// A real (decodable) JPEG so thumbnail generation exercises ImageIO.
+  private func tinyJPEG() -> Data {
+    let renderer = UIGraphicsImageRenderer(size: CGSize(width: 8, height: 8))
+    return renderer.image { context in
+      UIColor.systemBlue.setFill()
+      context.fill(CGRect(x: 0, y: 0, width: 8, height: 8))
+    }.jpegData(compressionQuality: 0.9)!
+  }
 
-    // Mirrors PuzzleStore's on-disk layout so tests can assert against the
-    // actual files (the store's URL helpers are private).
-    private var puzzlesRoot: URL {
-        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("Puzzles", isDirectory: true)
-    }
+  // Mirrors PuzzleStore's on-disk layout so tests can assert against the
+  // actual files (the store's URL helpers are private).
+  private var puzzlesRoot: URL {
+    FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+      .appendingPathComponent("Puzzles", isDirectory: true)
+  }
 
-    private func puzzleDir(_ id: UUID) -> URL {
-        puzzlesRoot.appendingPathComponent(id.uuidString, isDirectory: true)
-    }
+  private func puzzleDir(_ id: UUID) -> URL {
+    puzzlesRoot.appendingPathComponent(id.uuidString, isDirectory: true)
+  }
 
-    private func uploadFile(_ puzzle: UUID, _ piece: UUID) -> URL {
-        puzzleDir(puzzle).appendingPathComponent("pieces/\(piece.uuidString)-upload.jpg")
-    }
+  private func uploadFile(_ puzzle: UUID, _ piece: UUID) -> URL {
+    puzzleDir(puzzle).appendingPathComponent("pieces/\(piece.uuidString)-upload.jpg")
+  }
 
-    private func makeSession(store: PuzzleStore, name: String = "Test") -> SolveSession {
-        SolveSession(
-            id: UUID(),
-            name: name,
-            puzzleId: "server-123",
-            trimmedJPEG: tinyJPEG(),
-            store: store
+  private func makeSession(store: PuzzleStore, name: String = "Test") -> SolveSession {
+    SolveSession(
+      id: UUID(),
+      name: name,
+      puzzleId: "server-123",
+      trimmedJPEG: tinyJPEG(),
+      store: store
+    )
+  }
+
+  func testSavePersistsSummaryAndSurvivesReload() throws {
+    let store = PuzzleStore()
+    let session = makeSession(store: store, name: "Frosty field")
+    addTeardownBlock { @MainActor in store.delete(session.id) }
+
+    session.entries = [
+      CaptureEntry(
+        id: UUID(),
+        uploadJPEG: Data("piece-upload".utf8),
+        displayImage: Data("piece-display".utf8),
+        status: .done,
+        result: PieceResponse(
+          position: NormalizedPoint(x: 0.34, y: 0.4),
+          positionConfidence: 0.77,
+          rotation: 90,
+          rotationConfidence: 0.77,
+          cleanedImage: nil
         )
-    }
+      )
+    ]
+    session.persist()
 
-    func testSavePersistsSummaryAndSurvivesReload() throws {
-        let store = PuzzleStore()
-        let session = makeSession(store: store, name: "Frosty field")
-        addTeardownBlock { @MainActor in store.delete(session.id) }
+    let summary = try XCTUnwrap(store.puzzles.first { $0.id == session.id })
+    XCTAssertEqual(summary.name, "Frosty field")
+    XCTAssertEqual(summary.pieceCount, 1)
+    XCTAssertEqual(summary.placedCount, 1)
+    XCTAssertNotNil(summary.thumbnail)
 
-        session.entries = [
-            CaptureEntry(
-                id: UUID(),
-                uploadJPEG: Data("piece-upload".utf8),
-                displayImage: Data("piece-display".utf8),
-                status: .done,
-                result: PieceResponse(
-                    position: NormalizedPoint(x: 0.34, y: 0.4),
-                    positionConfidence: 0.77,
-                    rotation: 90,
-                    rotationConfidence: 0.77,
-                    cleanedImage: nil
-                )
-            )
-        ]
-        session.persist()
+    // A brand-new store instance reads purely from disk.
+    let reloaded = try XCTUnwrap(PuzzleStore().loadSession(id: session.id))
+    XCTAssertEqual(reloaded.name, "Frosty field")
+    XCTAssertEqual(reloaded.puzzleId, "server-123")
+    XCTAssertEqual(reloaded.trimmedJPEG, session.trimmedJPEG)
+    XCTAssertEqual(reloaded.entries.count, 1)
+    let entry = try XCTUnwrap(reloaded.entries.first)
+    XCTAssertEqual(entry.status, .done)
+    XCTAssertEqual(entry.displayImage, Data("piece-display".utf8))
+    XCTAssertEqual(entry.result?.position, NormalizedPoint(x: 0.34, y: 0.4))
+    XCTAssertEqual(entry.result?.rotation, 90)
+  }
 
-        let summary = try XCTUnwrap(store.puzzles.first { $0.id == session.id })
-        XCTAssertEqual(summary.name, "Frosty field")
-        XCTAssertEqual(summary.pieceCount, 1)
-        XCTAssertEqual(summary.placedCount, 1)
-        XCTAssertNotNil(summary.thumbnail)
+  func testUnpredictedPieceReloadsAsQueued() throws {
+    let store = PuzzleStore()
+    let session = makeSession(store: store)
+    addTeardownBlock { @MainActor in store.delete(session.id) }
 
-        // A brand-new store instance reads purely from disk.
-        let reloaded = try XCTUnwrap(PuzzleStore().loadSession(id: session.id))
-        XCTAssertEqual(reloaded.name, "Frosty field")
-        XCTAssertEqual(reloaded.puzzleId, "server-123")
-        XCTAssertEqual(reloaded.trimmedJPEG, session.trimmedJPEG)
-        XCTAssertEqual(reloaded.entries.count, 1)
-        let entry = try XCTUnwrap(reloaded.entries.first)
-        XCTAssertEqual(entry.status, .done)
-        XCTAssertEqual(entry.displayImage, Data("piece-display".utf8))
-        XCTAssertEqual(entry.result?.position, NormalizedPoint(x: 0.34, y: 0.4))
-        XCTAssertEqual(entry.result?.rotation, 90)
-    }
+    // Captured but never predicted: no separate display file, no result.
+    let raw = Data("raw-capture".utf8)
+    session.entries = [
+      CaptureEntry(id: UUID(), uploadJPEG: raw, displayImage: raw, status: .queued, result: nil)
+    ]
+    session.persist()
 
-    func testUnpredictedPieceReloadsAsQueued() throws {
-        let store = PuzzleStore()
-        let session = makeSession(store: store)
-        addTeardownBlock { @MainActor in store.delete(session.id) }
+    let reloaded = try XCTUnwrap(PuzzleStore().loadSession(id: session.id))
+    let entry = try XCTUnwrap(reloaded.entries.first)
+    XCTAssertEqual(entry.status, .queued)
+    XCTAssertNil(entry.result)
+    // Display falls back to the upload bytes when no cleaned image was stored.
+    XCTAssertEqual(entry.displayImage, raw)
+  }
 
-        // Captured but never predicted: no separate display file, no result.
-        let raw = Data("raw-capture".utf8)
-        session.entries = [
-            CaptureEntry(id: UUID(), uploadJPEG: raw, displayImage: raw, status: .queued, result: nil)
-        ]
-        session.persist()
+  func testRemovedPieceIsPrunedFromDisk() throws {
+    let store = PuzzleStore()
+    let session = makeSession(store: store)
+    addTeardownBlock { @MainActor in store.delete(session.id) }
 
-        let reloaded = try XCTUnwrap(PuzzleStore().loadSession(id: session.id))
-        let entry = try XCTUnwrap(reloaded.entries.first)
-        XCTAssertEqual(entry.status, .queued)
-        XCTAssertNil(entry.result)
-        // Display falls back to the upload bytes when no cleaned image was stored.
-        XCTAssertEqual(entry.displayImage, raw)
-    }
+    let keep = CaptureEntry(
+      id: UUID(), uploadJPEG: Data("keep".utf8), displayImage: Data("keep".utf8), status: .queued,
+      result: nil)
+    let drop = CaptureEntry(
+      id: UUID(), uploadJPEG: Data("drop".utf8), displayImage: Data("drop".utf8), status: .queued,
+      result: nil)
+    session.entries = [keep, drop]
+    session.persist()
 
-    func testRemovedPieceIsPrunedFromDisk() throws {
-        let store = PuzzleStore()
-        let session = makeSession(store: store)
-        addTeardownBlock { @MainActor in store.delete(session.id) }
+    let fileManager = FileManager.default
+    XCTAssertTrue(fileManager.fileExists(atPath: uploadFile(session.id, drop.id).path))
 
-        let keep = CaptureEntry(id: UUID(), uploadJPEG: Data("keep".utf8), displayImage: Data("keep".utf8), status: .queued, result: nil)
-        let drop = CaptureEntry(id: UUID(), uploadJPEG: Data("drop".utf8), displayImage: Data("drop".utf8), status: .queued, result: nil)
-        session.entries = [keep, drop]
-        session.persist()
+    session.remove(id: drop.id)
 
-        let fileManager = FileManager.default
-        XCTAssertTrue(fileManager.fileExists(atPath: uploadFile(session.id, drop.id).path))
+    // The dropped piece's image file is pruned; the kept one remains.
+    XCTAssertFalse(fileManager.fileExists(atPath: uploadFile(session.id, drop.id).path))
+    XCTAssertTrue(fileManager.fileExists(atPath: uploadFile(session.id, keep.id).path))
 
-        session.remove(id: drop.id)
+    let reloaded = try XCTUnwrap(PuzzleStore().loadSession(id: session.id))
+    XCTAssertEqual(reloaded.entries.map(\.id), [keep.id])
+  }
 
-        // The dropped piece's image file is pruned; the kept one remains.
-        XCTAssertFalse(fileManager.fileExists(atPath: uploadFile(session.id, drop.id).path))
-        XCTAssertTrue(fileManager.fileExists(atPath: uploadFile(session.id, keep.id).path))
+  func testDeleteRemovesPuzzle() throws {
+    let store = PuzzleStore()
+    let session = makeSession(store: store)
+    // Clean up even if an assertion fails before the delete below.
+    addTeardownBlock { @MainActor in store.delete(session.id) }
+    session.persist()
+    XCTAssertTrue(store.puzzles.contains { $0.id == session.id })
+    XCTAssertTrue(FileManager.default.fileExists(atPath: puzzleDir(session.id).path))
 
-        let reloaded = try XCTUnwrap(PuzzleStore().loadSession(id: session.id))
-        XCTAssertEqual(reloaded.entries.map(\.id), [keep.id])
-    }
-
-    func testDeleteRemovesPuzzle() throws {
-        let store = PuzzleStore()
-        let session = makeSession(store: store)
-        // Clean up even if an assertion fails before the delete below.
-        addTeardownBlock { @MainActor in store.delete(session.id) }
-        session.persist()
-        XCTAssertTrue(store.puzzles.contains { $0.id == session.id })
-        XCTAssertTrue(FileManager.default.fileExists(atPath: puzzleDir(session.id).path))
-
-        store.delete(session.id)
-        XCTAssertFalse(store.puzzles.contains { $0.id == session.id })
-        XCTAssertNil(store.loadSession(id: session.id))
-        XCTAssertFalse(FileManager.default.fileExists(atPath: puzzleDir(session.id).path))
-    }
+    store.delete(session.id)
+    XCTAssertFalse(store.puzzles.contains { $0.id == session.id })
+    XCTAssertNil(store.loadSession(id: session.id))
+    XCTAssertFalse(FileManager.default.fileExists(atPath: puzzleDir(session.id).path))
+  }
 }

--- a/ios/README.md
+++ b/ios/README.md
@@ -65,7 +65,7 @@ first):
 ```bash
 make ios-run       # build → install → launch on the Simulator
 make ios-test      # run the unit tests on the Simulator
-make ios-deploy    # build → install → launch on a connected iPhone
+make ios-deploy    # build → install → launch on a connected device (iPhone/iPad)
 ```
 
 Override the simulator or target device on the command line:

--- a/ios/README.md
+++ b/ios/README.md
@@ -59,6 +59,28 @@ re-upload, then re-queues affected pieces.
 
 ## Build & test from the CLI
 
+The repo-root `Makefile` wraps the common flows (all run `xcodegen generate`
+first):
+
+```bash
+make ios-run       # build → install → launch on the Simulator
+make ios-test      # run the unit tests on the Simulator
+make ios-deploy    # build → install → launch on a connected iPhone
+```
+
+Override the simulator or target device on the command line:
+
+```bash
+make ios-run IOS_SIMULATOR="iPhone 17 Pro Max"
+make ios-deploy IOS_DEVICE=<name-or-udid>   # device is auto-detected otherwise
+```
+
+`ios-deploy` needs `DEVELOPMENT_TEAM` set in `Config/Secrets.xcconfig` (device
+signing) and a device that's connected and trusts this Mac.
+
+<details>
+<summary>Equivalent raw <code>xcodebuild</code> / <code>simctl</code> commands</summary>
+
 ```bash
 xcodebuild build -project Pussel.xcodeproj -scheme Pussel \
   -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath .build
@@ -68,6 +90,19 @@ xcodebuild test -project Pussel.xcodeproj -scheme Pussel \
 
 xcrun simctl install booted .build/Build/Products/Debug-iphonesimulator/Pussel.app
 xcrun simctl launch booted dk.delectosoft.pussel
+```
+
+</details>
+
+## Formatting
+
+Swift code is formatted with Apple's [swift-format](https://github.com/swiftlang/swift-format)
+(bundled with Xcode 26 — no extra install), using its default style (no
+project config).
+
+```bash
+make format-ios    # format all Swift sources in place
+make check-ios     # lint formatting without modifying files (--strict)
 ```
 
 ## Debug driving (Simulator has no camera)


### PR DESCRIPTION
## Summary

Adds iOS entries to the root `Makefile` and formats the Swift codebase with Apple's official `swift-format` (bundled with Xcode 26 — no extra install).

### Makefile targets
- `make format-ios` / `make check-ios` — format in place / strict lint via `swift-format`
- `make ios-generate` — regenerate the Xcode project from `project.yml` (xcodegen)
- `make ios-run` — build → install → launch on the Simulator (`IOS_SIMULATOR` override)
- `make ios-test` — run the unit tests on the Simulator
- `make ios-deploy` — build → install → launch on a connected iPhone via `devicectl` (auto-detects the device, `IOS_DEVICE` override; needs `DEVELOPMENT_TEAM` in `Config/Secrets.xcconfig`)

### Aggregate wiring
- `check-ios` / `format-ios` are wired into the root `make check` / `make format` aggregates, so a single `make check` covers everything on macOS.
- To keep those aggregates cross-platform, both iOS targets **self-skip**: they guard on `xcrun --find swift-format` and print a skip message (exit 0) when it's unavailable (non-macOS). CI also calls the per-component targets directly rather than the aggregate.

### Formatting
- Reformatted all Swift sources under `ios/Pussel` and `ios/PusselTests` using swift-format's **default** style (2-space indent, no project config file).

### Docs
- `ios/README.md`: "Build & test from the CLI" now leads with the `make` targets (raw `xcodebuild`/`simctl` tucked into a `<details>`), plus a new Formatting section.

## Verification
- `make check-ios` → exit 0 (clean lint) on macOS; skips cleanly (exit 0) where swift-format is absent.
- `make ios-run` → build + install + launch on the simulator succeeded (exit 0), confirming the reformat compiles and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)