### PR TITLE
ci(ios): build, test & lint iOS app on macOS runners

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -25,8 +25,9 @@ concurrency:
 jobs:
   build-test:
     name: Build, test & lint
-    # macos-15 ships Xcode 26 (the iOS 26 SDK this app's deployment target
-    # requires). Bump the image / Xcode version below together if that changes.
+    # macos-15 carries the Xcode 26 toolchain selected below (the iOS 26 SDK
+    # this app's deployment target requires). The "Select Xcode 26" step pins
+    # the exact version, so this only needs an image that has a 26.x installed.
     runs-on: macos-15
     defaults:
       run:
@@ -40,17 +41,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Pin the toolchain to the latest Xcode 26.x (the iOS 26 SDK this app's
+      # deployment target requires) rather than a hard-coded /Applications path,
+      # which can break across runner-image updates.
       - name: Select Xcode 26
-        run: sudo xcode-select -switch /Applications/Xcode_26.app
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '~> 26.0'
 
       - name: Show toolchain versions
         run: |
           xcodebuild -version
           xcrun simctl list runtimes | grep iOS || true
 
-      - name: Install tooling (XcodeGen + SwiftLint)
+      # xcbeautify is used to prettify xcodebuild output in the Build/Test steps;
+      # install it explicitly rather than relying on it being preinstalled.
+      - name: Install tooling (XcodeGen + SwiftLint + xcbeautify)
         run: |
-          brew install xcodegen swiftlint
+          brew install xcodegen swiftlint xcbeautify
 
       # Simulator builds need no signing and exercise no Google flow, so a
       # placeholder Secrets.xcconfig (gitignored, required by Debug.xcconfig's

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -1,0 +1,87 @@
+name: iOS CI
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main, release]
+    paths:
+      - 'ios/**'
+      - '.github/workflows/ios-ci.yml'
+  pull_request:
+    branches: [main, release]
+    paths:
+      - 'ios/**'
+      - '.github/workflows/ios-ci.yml'
+
+# macOS runner minutes bill at 10x the Linux rate on private repos, so the
+# path filter above keeps this off backend/frontend-only PRs. Cancel superseded
+# runs to avoid stacking expensive macOS jobs.
+concurrency:
+  group: ios-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: Build, test & lint
+    # macos-15 ships Xcode 26 (the iOS 26 SDK this app's deployment target
+    # requires). Bump the image / Xcode version below together if that changes.
+    runs-on: macos-15
+    defaults:
+      run:
+        working-directory: ios
+    env:
+      SCHEME: Pussel
+      # Concrete simulator so `xcodebuild test` has a bootable destination.
+      # iPhone 17 Pro ships with the Xcode 26 iOS 26 runtime (matches ios/README).
+      DESTINATION: 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode 26
+        run: sudo xcode-select -switch /Applications/Xcode_26.app
+
+      - name: Show toolchain versions
+        run: |
+          xcodebuild -version
+          xcrun simctl list runtimes | grep iOS || true
+
+      - name: Install tooling (XcodeGen + SwiftLint)
+        run: |
+          brew install xcodegen swiftlint
+
+      # Simulator builds need no signing and exercise no Google flow, so a
+      # placeholder Secrets.xcconfig (gitignored, required by Debug.xcconfig's
+      # non-optional #include) is enough. No repo secrets required.
+      - name: Stub Secrets.xcconfig
+        run: cp Config/Secrets.example.xcconfig Config/Secrets.xcconfig
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: SwiftLint
+        run: swiftlint lint --quiet
+
+      - name: Build
+        run: |
+          set -o pipefail
+          xcodebuild build-for-testing \
+            -project Pussel.xcodeproj \
+            -scheme "$SCHEME" \
+            -destination "$DESTINATION" \
+            -derivedDataPath .build \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcbeautify
+
+      - name: Test
+        run: |
+          set -o pipefail
+          xcodebuild test-without-building \
+            -project Pussel.xcodeproj \
+            -scheme "$SCHEME" \
+            -destination "$DESTINATION" \
+            -derivedDataPath .build \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcbeautify

--- a/ios/.swiftlint.yml
+++ b/ios/.swiftlint.yml
@@ -1,0 +1,60 @@
+# SwiftLint configuration for the Pussel iOS app.
+# Run locally with `swiftlint` from the `ios/` directory (brew install swiftlint).
+# CI runs `swiftlint lint --quiet`; by default only error-level violations fail
+# the build, so warnings surface in the log without blocking merges.
+
+included:
+  - Pussel
+  - PusselTests
+
+# The generated Xcode project and build output are gitignored, but exclude them
+# defensively so a local lint run never walks into generated sources.
+excluded:
+  - Pussel.xcodeproj
+  - .build
+  - DerivedData
+
+# Match the repo-wide 120-character line-length convention (see CLAUDE.md).
+line_length:
+  warning: 120
+  error: 160
+  ignores_comments: true
+  ignores_urls: true
+
+# SwiftUI view bodies and stores legitimately run long; keep these as warnings
+# with generous ceilings so they inform without failing CI.
+type_body_length:
+  warning: 400
+  error: 600
+
+file_length:
+  warning: 600
+  error: 1000
+  ignore_comment_only_lines: true
+
+function_body_length:
+  warning: 80
+  error: 150
+
+identifier_name:
+  # Allow short names common in SwiftUI/graphics code (x, y, id, to, dx, dy).
+  min_length:
+    warning: 2
+    error: 1
+  excluded:
+    - id
+    - x
+    - y
+    - to
+    - dx
+    - dy
+
+disabled_rules:
+  - todo # TODO/FIXME comments are tracked elsewhere, not a lint gate.
+
+opt_in_rules:
+  - empty_count
+  - closure_spacing
+  - contains_over_first_not_nil
+  - first_where
+  - toggle_bool

--- a/ios/Pussel/Features/Solve/PieceCaptureView.swift
+++ b/ios/Pussel/Features/Solve/PieceCaptureView.swift
@@ -69,6 +69,9 @@ struct CameraPreview: UIViewRepresentable {
 
     final class PreviewView: UIView {
         override class var layerClass: AnyClass { AVCaptureVideoPreviewLayer.self }
+        // Safe by construction: layerClass above guarantees `layer` is an
+        // AVCaptureVideoPreviewLayer, so this cast can never fail.
+        // swiftlint:disable:next force_cast
         var previewLayer: AVCaptureVideoPreviewLayer { layer as! AVCaptureVideoPreviewLayer }
     }
 


### PR DESCRIPTION
## Summary

Adds CI coverage for the new native iOS app, which was previously unbuilt because the existing runners are Linux and can't run `xcodebuild`. This runs on a GitHub-hosted **macOS runner** (`macos-15`).

The workflow mirrors the local dev flow from `ios/README.md`:

1. Select Xcode 26 (iOS 26 SDK — the app's deployment target)
2. Install XcodeGen + SwiftLint
3. Stub `Secrets.xcconfig` from the example — simulator builds need no code signing and exercise no Google flow, so **no repo secrets are required**
4. `xcodegen generate`
5. SwiftLint
6. `build-for-testing` → `test-without-building` on the iPhone 17 Pro simulator

Path-filtered to `ios/**` with `cancel-in-progress` concurrency to keep macOS runner minutes minimal.

## Changes

- **`.github/workflows/ios-ci.yml`** — the iOS CI workflow
- **`ios/.swiftlint.yml`** — SwiftLint config tuned to the repo's 120-char convention, lenient ceilings for SwiftUI view bodies (warnings surface in logs; only error-level violations fail CI)
- **`ios/Pussel/Features/Solve/PieceCaptureView.swift`** — inline `swiftlint:disable:next force_cast` on the provably-safe `AVCaptureVideoPreviewLayer` cast (guaranteed by the `layerClass` override), keeping the lint gate strict on real force-casts

## Validation

Ran the exact CI steps locally on Xcode 26.6 / iOS 26.5:

| Step | Result |
|---|---|
| `xcodegen generate` (stubbed secrets) | ✅ |
| `build-for-testing` (GoogleSignIn SPM resolves) | ✅ |
| `test-without-building` | ✅ all 16 tests pass |
| `swiftlint lint` | ✅ exit 0 |

## Note

First run should confirm the `/Applications/Xcode_26.app` path resolves on the `macos-15` image; if the image's Xcode 26 path differs, swap the "Select Xcode 26" step for `maxim-lobanov/setup-xcode@v1` with `xcode-version: '26.x'`. A comment in the workflow notes this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)