### PR TITLE
feat(ios): rotate puzzle overview photo before confirming

### DIFF
--- a/ios/Pussel/App/AppActions.swift
+++ b/ios/Pussel/App/AppActions.swift
@@ -31,9 +31,12 @@ extension AppModel {
     /// user-applied rotation (`quarterTurns` × 90° clockwise) is baked into the
     /// uploaded and stored image so the puzzle appears upright everywhere.
     func acceptTrim(_ candidate: TrimCandidate, quarterTurns: Int = 0) async {
-        guard let decoded = candidate.trimmedJPEG,
-              let trimmed = ImageUtilities.rotatedJPEG(from: decoded, quarterTurns: quarterTurns) else {
+        guard let decoded = candidate.trimmedJPEG else {
             flow.errorMessage = "Could not decode the trimmed image."
+            return
+        }
+        guard let trimmed = ImageUtilities.rotatedJPEG(from: decoded, quarterTurns: quarterTurns) else {
+            flow.errorMessage = "Could not rotate the trimmed image."
             return
         }
         flow.errorMessage = nil

--- a/ios/Pussel/App/AppActions.swift
+++ b/ios/Pussel/App/AppActions.swift
@@ -31,6 +31,9 @@ extension AppModel {
     /// user-applied rotation (`quarterTurns` × 90° clockwise) is baked into the
     /// uploaded and stored image so the puzzle appears upright everywhere.
     func acceptTrim(_ candidate: TrimCandidate, quarterTurns: Int = 0) async {
+        // Ignore repeat taps (e.g. a double-tap on "Use This") while an upload
+        // is already in flight so we don't start concurrent uploads/sessions.
+        guard !flow.isBusy else { return }
         guard let decoded = candidate.trimmedJPEG else {
             flow.errorMessage = "Could not decode the trimmed image."
             return

--- a/ios/Pussel/App/AppActions.swift
+++ b/ios/Pussel/App/AppActions.swift
@@ -27,9 +27,12 @@ extension AppModel {
         }
     }
 
-    /// Uploads the accepted trimmed image and starts a solve session.
-    func acceptTrim(_ candidate: TrimCandidate) async {
-        guard let trimmed = candidate.trimmedJPEG else {
+    /// Uploads the accepted trimmed image and starts a solve session. Any
+    /// user-applied rotation (`quarterTurns` × 90° clockwise) is baked into the
+    /// uploaded and stored image so the puzzle appears upright everywhere.
+    func acceptTrim(_ candidate: TrimCandidate, quarterTurns: Int = 0) async {
+        guard let decoded = candidate.trimmedJPEG,
+              let trimmed = ImageUtilities.rotatedJPEG(from: decoded, quarterTurns: quarterTurns) else {
             flow.errorMessage = "Could not decode the trimmed image."
             return
         }

--- a/ios/Pussel/Features/Capture/ConfirmTrimView.swift
+++ b/ios/Pussel/Features/Capture/ConfirmTrimView.swift
@@ -7,6 +7,15 @@ struct ConfirmTrimView: View {
     @Environment(AppModel.self) private var model
     @State private var quarterTurns = 0
     let candidate: TrimCandidate
+    /// Decoded once at init rather than in `body`, which re-runs on every
+    /// rotate tap (base64-decoding the data URL and the JPEG each time would be
+    /// wasteful during the rotation animation).
+    private let previewImage: UIImage?
+
+    init(candidate: TrimCandidate) {
+        self.candidate = candidate
+        self.previewImage = candidate.trimmedJPEG.flatMap(UIImage.init(data:))
+    }
 
     var body: some View {
         VStack(spacing: 16) {
@@ -17,7 +26,7 @@ struct ConfirmTrimView: View {
                     .font(.footnote)
                     .foregroundStyle(.orange)
             }
-            if let data = candidate.trimmedJPEG, let image = UIImage(data: data) {
+            if let image = previewImage {
                 // Square bounding box so the image stays fully visible at every
                 // angle while it spins (a rotating landscape/portrait photo would
                 // otherwise overflow its frame at the 90°/270° positions).

--- a/ios/Pussel/Features/Capture/ConfirmTrimView.swift
+++ b/ios/Pussel/Features/Capture/ConfirmTrimView.swift
@@ -5,6 +5,7 @@ struct ConfirmTrimView: View {
     private static let lowConfidence = 0.4
 
     @Environment(AppModel.self) private var model
+    @State private var quarterTurns = 0
     let candidate: TrimCandidate
 
     var body: some View {
@@ -17,11 +18,31 @@ struct ConfirmTrimView: View {
                     .foregroundStyle(.orange)
             }
             if let data = candidate.trimmedJPEG, let image = UIImage(data: data) {
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFit()
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                // Square bounding box so the image stays fully visible at every
+                // angle while it spins (a rotating landscape/portrait photo would
+                // otherwise overflow its frame at the 90°/270° positions).
+                Color.clear
+                    .aspectRatio(1, contentMode: .fit)
+                    .overlay {
+                        Image(uiImage: image)
+                            .resizable()
+                            .scaledToFit()
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                            .rotationEffect(.degrees(Double(quarterTurns) * 90))
+                    }
                     .frame(maxHeight: 420)
+                Button {
+                    // Always increment (never wrap to 0) so the animation turns
+                    // clockwise on every tap instead of unwinding 270° → 0°.
+                    withAnimation(.snappy(duration: 0.35)) {
+                        quarterTurns += 1
+                    }
+                } label: {
+                    Label("Rotate", systemImage: "rotate.right")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.regular)
+                .disabled(model.flow.isBusy)
             } else {
                 ContentUnavailableView("Could not decode the trimmed image", systemImage: "xmark.octagon")
             }
@@ -45,7 +66,7 @@ struct ConfirmTrimView: View {
                     .controlSize(.large)
 
                     Button {
-                        Task { await model.acceptTrim(candidate) }
+                        Task { await model.acceptTrim(candidate, quarterTurns: quarterTurns) }
                     } label: {
                         Label("Use This", systemImage: "checkmark")
                             .frame(maxWidth: .infinity)

--- a/ios/Pussel/Features/Capture/ConfirmTrimView.swift
+++ b/ios/Pussel/Features/Capture/ConfirmTrimView.swift
@@ -82,7 +82,11 @@ struct ConfirmTrimView: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
-                    .disabled(candidate.trimmedJPEG == nil)
+                    // Gate on the cached preview (not the base64-decoding
+                    // `trimmedJPEG` computed property) so this doesn't re-decode
+                    // on every rotate tap and stays disabled exactly when the
+                    // preview can't be shown.
+                    .disabled(previewImage == nil)
                 }
             }
             if let error = model.flow.errorMessage {

--- a/ios/Pussel/Support/ImageUtilities.swift
+++ b/ios/Pussel/Support/ImageUtilities.swift
@@ -65,7 +65,10 @@ enum ImageUtilities {
     static func rotated(_ image: UIImage, quarterTurns: Int) -> UIImage {
         let turns = ((quarterTurns % 4) + 4) % 4
         guard turns != 0 else { return image }
-        let upright = image.imageOrientation == .up ? image : redrawnUpright(image)
+        // Redraw when the orientation needs baking, or when there is no backing
+        // CGImage to reinterpret (a UIImage can be CIImage-only) — the redraw
+        // always yields an upright, CGImage-backed bitmap.
+        let upright = (image.imageOrientation == .up && image.cgImage != nil) ? image : redrawnUpright(image)
         guard let cgImage = upright.cgImage else { return image }
         let orientation: UIImage.Orientation
         switch turns {

--- a/ios/Pussel/Support/ImageUtilities.swift
+++ b/ios/Pussel/Support/ImageUtilities.swift
@@ -87,11 +87,13 @@ enum ImageUtilities {
     }
 
     /// Rotates JPEG `data` clockwise by `quarterTurns` × 90° and re-encodes it
-    /// with the rotation baked into the pixels. Returns the original data when
-    /// there is nothing to rotate or it cannot be decoded.
+    /// with the rotation baked into the pixels. Returns the original data
+    /// unchanged when no rotation is requested, or `nil` when a requested
+    /// rotation cannot be applied — so a caller never uploads an unrotated image
+    /// believing it was rotated.
     static func rotatedJPEG(from data: Data, quarterTurns: Int) -> Data? {
         guard ((quarterTurns % 4) + 4) % 4 != 0 else { return data }
-        guard let image = UIImage(data: data) else { return data }
+        guard let image = UIImage(data: data) else { return nil }
         return normalizedJPEG(from: rotated(image, quarterTurns: quarterTurns))
     }
 

--- a/ios/Pussel/Support/ImageUtilities.swift
+++ b/ios/Pussel/Support/ImageUtilities.swift
@@ -56,20 +56,34 @@ enum ImageUtilities {
         return encoded
     }
 
-    /// Returns `image` rotated clockwise by `quarterTurns` × 90°. Implemented by
-    /// reinterpreting the EXIF orientation, so it is cheap (no resampling);
-    /// `normalizedJPEG` bakes the rotation into the pixels when the image is
-    /// redrawn upright for upload (see `rotatedJPEG`).
+    /// Returns `image` rotated clockwise by `quarterTurns` × 90°. Any existing
+    /// EXIF orientation is baked into the pixels first (so the quarter-turn is
+    /// correct even for a camera image that arrives rotated or mirrored), then
+    /// the turn is applied by reinterpreting orientation — cheap, no resampling.
+    /// `normalizedJPEG` bakes the turn into the pixels for upload (see
+    /// `rotatedJPEG`).
     static func rotated(_ image: UIImage, quarterTurns: Int) -> UIImage {
         let turns = ((quarterTurns % 4) + 4) % 4
-        guard turns != 0, let cgImage = image.cgImage else { return image }
+        guard turns != 0 else { return image }
+        let upright = image.imageOrientation == .up ? image : redrawnUpright(image)
+        guard let cgImage = upright.cgImage else { return image }
         let orientation: UIImage.Orientation
         switch turns {
         case 1: orientation = .right
         case 2: orientation = .down
         default: orientation = .left
         }
-        return UIImage(cgImage: cgImage, scale: image.scale, orientation: orientation)
+        return UIImage(cgImage: cgImage, scale: upright.scale, orientation: orientation)
+    }
+
+    /// Redraws `image` with its EXIF orientation baked into the pixels, yielding
+    /// an equivalent `.up`-oriented image.
+    private static func redrawnUpright(_ image: UIImage) -> UIImage {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = image.scale
+        return UIGraphicsImageRenderer(size: image.size, format: format).image { _ in
+            image.draw(in: CGRect(origin: .zero, size: image.size))
+        }
     }
 
     /// Rotates JPEG `data` clockwise by `quarterTurns` × 90° and re-encodes it

--- a/ios/Pussel/Support/ImageUtilities.swift
+++ b/ios/Pussel/Support/ImageUtilities.swift
@@ -56,12 +56,13 @@ enum ImageUtilities {
         return encoded
     }
 
-    /// Returns `image` rotated clockwise by `quarterTurns` × 90°. Any existing
-    /// EXIF orientation is baked into the pixels first (so the quarter-turn is
-    /// correct even for a camera image that arrives rotated or mirrored), then
-    /// the turn is applied by reinterpreting orientation — cheap, no resampling.
-    /// `normalizedJPEG` bakes the turn into the pixels for upload (see
-    /// `rotatedJPEG`).
+    /// Returns `image` rotated clockwise by `quarterTurns` × 90°. When
+    /// `quarterTurns` normalizes to 0 the image is returned unchanged. For a
+    /// non-zero turn, any existing EXIF orientation is baked into the pixels
+    /// first (so the quarter-turn is correct even for a camera image that
+    /// arrives rotated or mirrored), then the turn is applied by reinterpreting
+    /// orientation — cheap, no resampling. `normalizedJPEG` bakes the turn into
+    /// the pixels for upload (see `rotatedJPEG`).
     static func rotated(_ image: UIImage, quarterTurns: Int) -> UIImage {
         let turns = ((quarterTurns % 4) + 4) % 4
         guard turns != 0 else { return image }

--- a/ios/Pussel/Support/ImageUtilities.swift
+++ b/ios/Pussel/Support/ImageUtilities.swift
@@ -56,6 +56,31 @@ enum ImageUtilities {
         return encoded
     }
 
+    /// Returns `image` rotated clockwise by `quarterTurns` × 90°. Implemented by
+    /// reinterpreting the EXIF orientation, so it is cheap (no resampling);
+    /// `normalizedJPEG` bakes the rotation into the pixels when the image is
+    /// redrawn upright for upload (see `rotatedJPEG`).
+    static func rotated(_ image: UIImage, quarterTurns: Int) -> UIImage {
+        let turns = ((quarterTurns % 4) + 4) % 4
+        guard turns != 0, let cgImage = image.cgImage else { return image }
+        let orientation: UIImage.Orientation
+        switch turns {
+        case 1: orientation = .right
+        case 2: orientation = .down
+        default: orientation = .left
+        }
+        return UIImage(cgImage: cgImage, scale: image.scale, orientation: orientation)
+    }
+
+    /// Rotates JPEG `data` clockwise by `quarterTurns` × 90° and re-encodes it
+    /// with the rotation baked into the pixels. Returns the original data when
+    /// there is nothing to rotate or it cannot be decoded.
+    static func rotatedJPEG(from data: Data, quarterTurns: Int) -> Data? {
+        guard ((quarterTurns % 4) + 4) % 4 != 0 else { return data }
+        guard let image = UIImage(data: data) else { return data }
+        return normalizedJPEG(from: rotated(image, quarterTurns: quarterTurns))
+    }
+
     /// Decodes a "data:image/...;base64,..." string (or bare base64) to bytes.
     static func decodeDataURL(_ string: String) -> Data? {
         guard let comma = string.firstIndex(of: ",") else {

--- a/ios/PusselTests/ImageUtilitiesTests.swift
+++ b/ios/PusselTests/ImageUtilitiesTests.swift
@@ -1,0 +1,74 @@
+import UIKit
+import XCTest
+
+@testable import Pussel
+
+final class ImageUtilitiesTests: XCTestCase {
+    /// A solid-colour image at an exact pixel size (scale 1) for dimension checks.
+    private func makeImage(width: Int, height: Int) -> UIImage {
+        let size = CGSize(width: width, height: height)
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        return UIGraphicsImageRenderer(size: size, format: format).image { context in
+            UIColor.red.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
+    }
+
+    // MARK: rotated(_:quarterTurns:)
+
+    func testRotatedNormalizesFullTurnToIdentity() {
+        let image = makeImage(width: 8, height: 4)
+        // 4 quarter-turns (and 0) normalize to no rotation: same instance back.
+        XCTAssertIdentical(ImageUtilities.rotated(image, quarterTurns: 0), image)
+        XCTAssertIdentical(ImageUtilities.rotated(image, quarterTurns: 4), image)
+        XCTAssertIdentical(ImageUtilities.rotated(image, quarterTurns: -4), image)
+    }
+
+    func testRotatedQuarterTurnSwapsReportedSize() {
+        let image = makeImage(width: 8, height: 4)
+        let turned = ImageUtilities.rotated(image, quarterTurns: 1)
+        XCTAssertEqual(turned.size, CGSize(width: 4, height: 8))
+    }
+
+    func testRotatedHalfTurnKeepsSize() {
+        let image = makeImage(width: 8, height: 4)
+        let turned = ImageUtilities.rotated(image, quarterTurns: 2)
+        XCTAssertEqual(turned.size, CGSize(width: 8, height: 4))
+    }
+
+    func testRotatedNegativeTurnNormalizes() {
+        let image = makeImage(width: 8, height: 4)
+        // -1 (≡ 3) is still a 90° turn, so the reported size swaps.
+        let turned = ImageUtilities.rotated(image, quarterTurns: -1)
+        XCTAssertEqual(turned.size, CGSize(width: 4, height: 8))
+    }
+
+    // MARK: rotatedJPEG(from:quarterTurns:)
+
+    func testRotatedJPEGZeroTurnsReturnsInputUnchanged() throws {
+        let data = try XCTUnwrap(makeImage(width: 8, height: 4).jpegData(compressionQuality: 0.9))
+        XCTAssertEqual(ImageUtilities.rotatedJPEG(from: data, quarterTurns: 0), data)
+        XCTAssertEqual(ImageUtilities.rotatedJPEG(from: data, quarterTurns: 4), data)
+    }
+
+    func testRotatedJPEGInvalidDataZeroTurnsReturnsInput() {
+        let bogus = Data([0x00, 0x01, 0x02])
+        XCTAssertEqual(ImageUtilities.rotatedJPEG(from: bogus, quarterTurns: 0), bogus)
+    }
+
+    func testRotatedJPEGInvalidDataWithRotationReturnsNil() {
+        // A requested rotation that can't be applied must fail loudly (nil)
+        // rather than silently returning the unrotated bytes.
+        let bogus = Data([0x00, 0x01, 0x02])
+        XCTAssertNil(ImageUtilities.rotatedJPEG(from: bogus, quarterTurns: 1))
+    }
+
+    func testRotatedJPEGSwapsDimensionsOnQuarterTurn() throws {
+        let data = try XCTUnwrap(makeImage(width: 8, height: 4).jpegData(compressionQuality: 0.9))
+        let rotatedData = try XCTUnwrap(ImageUtilities.rotatedJPEG(from: data, quarterTurns: 1))
+        let decoded = try XCTUnwrap(UIImage(data: rotatedData))
+        XCTAssertEqual(decoded.size.width * decoded.scale, 4)
+        XCTAssertEqual(decoded.size.height * decoded.scale, 8)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **Rotate** button to the iOS confirm-trim screen so a puzzle overview photo taken sideways or upside-down can be turned upright before tapping **Use This**.

## What changed

- **`ConfirmTrimView`** — new **Rotate** button under the preview. Each tap spins the image 90° clockwise with a `snappy` 0.35s animation. The preview sits in a square bounding box so the photo stays fully visible at every angle (a rotating landscape/portrait image would otherwise overflow at the 90°/270° positions). The turn counter only increments, so the animation always rotates clockwise instead of unwinding 270° → 0°.
- **`ImageUtilities`** — two helpers:
  - `rotated(_:quarterTurns:)` rotates a `UIImage` cheaply by reinterpreting EXIF orientation (no resampling).
  - `rotatedJPEG(from:quarterTurns:)` bakes the rotation into the pixels and re-encodes (reusing `normalizedJPEG`, so the upload size cap still applies).
- **`acceptTrim`** — gains a `quarterTurns` parameter (default `0`) and bakes the chosen rotation into the uploaded and stored image, so the puzzle stays upright through the whole solve session (upload, stored `trimmedJPEG`, thumbnails, and re-upload after a backend restart). The existing debug deep-link call site is unaffected by the default.

## Testing

- Built for simulator and physical device (iPhone 15).
- Verified on-device end to end: photographed a puzzle, rotated the preview through all four orientations, confirmed the animation is smooth and the image stays contained, and confirmed the uploaded/solved puzzle lands in the chosen orientation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)