### PR TITLE
build(ios): fail SwiftLint on warnings; fix existing warnings

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -69,8 +69,10 @@ jobs:
       - name: Generate Xcode project
         run: xcodegen generate
 
+      # --strict promotes every warning to an error so lint warnings block the
+      # merge instead of merely surfacing in the log (mirrors `make check-ios`).
       - name: SwiftLint
-        run: swiftlint lint --quiet
+        run: swiftlint lint --quiet --strict
 
       # swift-format (bundled with the selected Xcode) owns layout; enforce it
       # in CI so unformatted code can't merge. Mirrors `make check-ios` /

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ check-ios:
 		echo "Skipping swift-format lint (not found — needs macOS + Xcode)"; \
 	fi
 	@if command -v swiftlint >/dev/null 2>&1; then \
-		cd ios && swiftlint lint --quiet; \
+		cd ios && swiftlint lint --quiet --strict; \
 	else \
 		echo "Skipping SwiftLint (not found — install with: brew install swiftlint)"; \
 	fi

--- a/ios/.swiftlint.yml
+++ b/ios/.swiftlint.yml
@@ -1,7 +1,7 @@
 # SwiftLint configuration for the Pussel iOS app.
 # Run locally with `swiftlint` from the `ios/` directory (brew install swiftlint).
-# CI runs `swiftlint lint --quiet`; by default only error-level violations fail
-# the build, so warnings surface in the log without blocking merges.
+# CI runs `swiftlint lint --quiet --strict`, which promotes every warning to an
+# error so any lint violation blocks the merge (not just error-level rules).
 
 included:
   - Pussel

--- a/ios/Pussel/Features/Solve/PieceCaptureView.swift
+++ b/ios/Pussel/Features/Solve/PieceCaptureView.swift
@@ -69,6 +69,9 @@ struct CameraPreview: UIViewRepresentable {
   let session: AVCaptureSession
 
   final class PreviewView: UIView {
+    // Overrides UIView's class property, so `static` isn't an option (it can't
+    // be combined with `override`); silence static_over_final_class.
+    // swiftlint:disable:next static_over_final_class
     override class var layerClass: AnyClass { AVCaptureVideoPreviewLayer.self }
     // Safe by construction: layerClass above guarantees `layer` is an
     // AVCaptureVideoPreviewLayer, so this cast can never fail.

--- a/ios/Pussel/Support/DebugNavigation.swift
+++ b/ios/Pussel/Support/DebugNavigation.swift
@@ -56,42 +56,72 @@
     func handleDebugURL(_ url: URL) -> Bool {
       guard url.scheme == "pusseldebug" else { return false }
       let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
-      func value(_ name: String) -> String? {
-        items.first { $0.name == name }?.value
-      }
+      let host = url.host()
       Task { @MainActor in
-        switch url.host() {
-        case "reset":
-          flow.reset()
-        case "trim":
-          if let image = Self.hostImage(value("puzzle")) {
-            await startTrim(image: image, source: .library)
-          }
-        case "accept":
-          if case .confirmTrim(let candidate) = flow.phase {
-            await acceptTrim(candidate)
-          }
-        case "piece":
-          if let image = Self.hostImage(value("path")) {
-            addPiece(image: image)
-          }
-        case "reupload":
-          if case .solving(let session) = flow.phase {
-            await session.reupload(api: api)
-          }
-        case "open":
-          if let index = value("index").flatMap(Int.init), store.puzzles.indices.contains(index) {
-            openPuzzle(store.puzzles[index].id)
-          }
-        case "delete":
-          if let index = value("index").flatMap(Int.init), store.puzzles.indices.contains(index) {
-            deletePuzzle(store.puzzles[index].id)
-          }
-        default:
-          break
-        }
+        await runDebugCommand(host) { name in items.first { $0.name == name }?.value }
       }
       return true
+    }
+
+    // One thin case per command keeps this dispatcher's cyclomatic complexity
+    // low; each command's own guards live in its helper below.
+    private func runDebugCommand(_ host: String?, value: (String) -> String?) async {
+      switch host {
+      case "reset":
+        flow.reset()
+      case "trim":
+        await debugTrim(path: value("puzzle"))
+      case "accept":
+        await debugAccept()
+      case "piece":
+        debugAddPiece(path: value("path"))
+      case "reupload":
+        await debugReupload()
+      case "open":
+        debugOpen(index: value("index"))
+      case "delete":
+        debugDelete(index: value("index"))
+      default:
+        break
+      }
+    }
+
+    private func debugTrim(path: String?) async {
+      if let image = Self.hostImage(path) {
+        await startTrim(image: image, source: .library)
+      }
+    }
+
+    private func debugAccept() async {
+      if case .confirmTrim(let candidate) = flow.phase {
+        await acceptTrim(candidate)
+      }
+    }
+
+    private func debugAddPiece(path: String?) {
+      if let image = Self.hostImage(path) {
+        addPiece(image: image)
+      }
+    }
+
+    private func debugReupload() async {
+      if case .solving(let session) = flow.phase {
+        await session.reupload(api: api)
+      }
+    }
+
+    private func debugOpen(index: String?) {
+      guard let index = index.flatMap(Int.init), store.puzzles.indices.contains(index) else {
+        return
+      }
+      openPuzzle(store.puzzles[index].id)
+    }
+
+    private func debugDelete(index: String?) {
+      guard let index = index.flatMap(Int.init), store.puzzles.indices.contains(index) else {
+        return
+      }
+      deletePuzzle(store.puzzles[index].id)
     }
 
     private static func hostImage(_ path: String?) -> UIImage? {

--- a/ios/PusselTests/APIClientTests.swift
+++ b/ios/PusselTests/APIClientTests.swift
@@ -20,8 +20,12 @@ final class StubURLProtocol: URLProtocol {
     set { lock.withLock { _receivedRequests = newValue } }
   }
 
+  // These override URLProtocol's class members, so `static` isn't an option
+  // (it can't be combined with `override`); silence static_over_final_class.
+  // swiftlint:disable static_over_final_class
   override class func canInit(with request: URLRequest) -> Bool { true }
   override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+  // swiftlint:enable static_over_final_class
 
   override func startLoading() {
     let handler = Self.lock.withLock {
@@ -62,7 +66,7 @@ final class APIClientTests: XCTestCase {
     )
   }
 
-  func testMultipartRequestBuilding() {
+  func testMultipartRequestBuilding() throws {
     let request = client.makeMultipartRequest(
       path: "api/v1/puzzle/abc/piece",
       queryItems: [URLQueryItem(name: "remove_bg", value: "true")],
@@ -74,7 +78,7 @@ final class APIClientTests: XCTestCase {
       request.url?.absoluteString, "http://stub.local/api/v1/puzzle/abc/piece?remove_bg=true")
     let contentType = request.value(forHTTPHeaderField: "Content-Type") ?? ""
     XCTAssertTrue(contentType.hasPrefix("multipart/form-data; boundary="))
-    let body = String(decoding: request.httpBody ?? Data(), as: UTF8.self)
+    let body = try XCTUnwrap(String(bytes: request.httpBody ?? Data(), encoding: .utf8))
     XCTAssertTrue(body.contains("name=\"file\"; filename=\"piece.jpg\""))
     XCTAssertTrue(body.contains("Content-Type: image/jpeg"))
   }

--- a/ios/PusselTests/MultipartFormDataTests.swift
+++ b/ios/PusselTests/MultipartFormDataTests.swift
@@ -3,11 +3,11 @@ import XCTest
 @testable import Pussel
 
 final class MultipartFormDataTests: XCTestCase {
-  func testFilePartStructure() {
+  func testFilePartStructure() throws {
     var form = MultipartFormData(boundary: "TESTBOUNDARY")
     form.appendFile(
       name: "file", filename: "puzzle.jpg", mimeType: "image/jpeg", data: Data("JPEGBYTES".utf8))
-    let body = String(decoding: form.encoded(), as: UTF8.self)
+    let body = try XCTUnwrap(String(bytes: form.encoded(), encoding: .utf8))
 
     let expected =
       "--TESTBOUNDARY\r\n"
@@ -19,10 +19,10 @@ final class MultipartFormDataTests: XCTestCase {
     XCTAssertEqual(form.contentType, "multipart/form-data; boundary=TESTBOUNDARY")
   }
 
-  func testFieldPartStructure() {
+  func testFieldPartStructure() throws {
     var form = MultipartFormData(boundary: "TESTBOUNDARY")
     form.appendField(name: "corners", value: "{\"x\":0.1}")
-    let body = String(decoding: form.encoded(), as: UTF8.self)
+    let body = try XCTUnwrap(String(bytes: form.encoded(), encoding: .utf8))
 
     XCTAssertTrue(
       body.contains("Content-Disposition: form-data; name=\"corners\"\r\n\r\n{\"x\":0.1}\r\n"))


### PR DESCRIPTION
## Summary

Makes the iOS CI SwiftLint step fail on **any** warning (not just error-level rules) via `--strict`, then clears the current warning backlog.

## Changes

**Fail on warnings**
- `.github/workflows/ios-ci.yml` — `swiftlint lint --quiet` → `swiftlint lint --quiet --strict`
- `Makefile` (`check-ios`) — same, so local `make check-ios` matches CI
- `ios/.swiftlint.yml` — updated header comment to reflect the new behavior

**Warning fixes (7 total)**
- `static_over_final_class` (×3) — false positives on `override class` members (`static` can't be combined with `override`). Suppressed with a justified `swiftlint:disable` in `PieceCaptureView.PreviewView.layerClass` and `StubURLProtocol.canInit`/`canonicalRequest`.
- `optional_data_string_conversion` (×3) — switched the three affected tests from `String(decoding:as:)` to the failable `String(bytes:encoding:.utf8)` via `try XCTUnwrap` (methods made `throws`).
- `cyclomatic_complexity` — split `AppModel.handleDebugURL`'s command `switch` (complexity 15) into a thin `runDebugCommand` dispatcher plus one small helper per command.

## Verification

- `swiftlint lint --quiet --strict` → exit 0 (no warnings)
- `xcrun swift-format lint --strict --recursive Pussel PusselTests` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)