### PR TITLE
build(ios): auto-restore Secrets.xcconfig from machine-local canonical copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,15 +130,25 @@ IOS_PROJECT    = ios/Pussel.xcodeproj
 IOS_SIMULATOR ?= iPhone 17 Pro
 IOS_DERIVED    = ios/.build
 
+# Canonical (gitignored, machine-local) copy of the real secrets. It lives
+# outside every worktree so a fresh worktree or a `git clean` never loses it;
+# ios-generate restores ios/Config/Secrets.xcconfig from here automatically.
+IOS_SECRETS_CANONICAL ?= $(HOME)/.config/pussel/Secrets.xcconfig
+
 # Regenerate the (gitignored) Xcode project from project.yml. Requires
 # `brew install xcodegen`; needs Config/Secrets.xcconfig to exist first.
 ios-generate:
 	@command -v xcodegen >/dev/null 2>&1 || { \
 		echo "xcodegen not found. Install it with: brew install xcodegen"; exit 1; }
+	@if [ ! -f ios/Config/Secrets.xcconfig ] && [ -f "$(IOS_SECRETS_CANONICAL)" ]; then \
+		echo "ios/Config/Secrets.xcconfig missing; restoring from $(IOS_SECRETS_CANONICAL)"; \
+		cp "$(IOS_SECRETS_CANONICAL)" ios/Config/Secrets.xcconfig; \
+	fi
 	@test -f ios/Config/Secrets.xcconfig || { \
 		echo "ios/Config/Secrets.xcconfig is missing."; \
 		echo "The Debug/Release xcconfigs #include it, so xcodebuild fails without it."; \
-		echo "Create it with: cp ios/Config/Secrets.example.xcconfig ios/Config/Secrets.xcconfig"; \
+		echo "Restore your real values with: cp \"$(IOS_SECRETS_CANONICAL)\" ios/Config/Secrets.xcconfig"; \
+		echo "Or start from the template: cp ios/Config/Secrets.example.xcconfig ios/Config/Secrets.xcconfig"; \
 		exit 1; }
 	cd ios && xcodegen generate
 

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,11 @@ IOS_DERIVED    = ios/.build
 # outside every worktree so a fresh worktree or a `git clean` never loses it;
 # ios-generate restores ios/Config/Secrets.xcconfig from here automatically.
 IOS_SECRETS_CANONICAL ?= $(HOME)/.config/pussel/Secrets.xcconfig
+# Make does not expand a leading ~/, and the path is used inside quotes below,
+# so a `make IOS_SECRETS_CANONICAL=~/path` override would be taken literally.
+# Rewrite a leading ~/ to $(HOME)/ so such overrides work. `override` is needed
+# because a plain assignment cannot rewrite a command-line-supplied value.
+override IOS_SECRETS_CANONICAL := $(patsubst ~/%,$(HOME)/%,$(IOS_SECRETS_CANONICAL))
 
 # Regenerate the (gitignored) Xcode project from project.yml. Requires
 # `brew install xcodegen`; needs Config/Secrets.xcconfig to exist first.


### PR DESCRIPTION
## What

`make ios-generate` now restores `ios/Config/Secrets.xcconfig` from a machine-local canonical copy (`~/.config/pussel/Secrets.xcconfig`, override via `IOS_SECRETS_CANONICAL`) when the working file is missing.

## Why

`ios/Config/Secrets.xcconfig` is gitignored — it holds real Google OAuth iOS/web client IDs, `DEVELOPMENT_TEAM`, and `API_BASE_URL`. Because it's gitignored it does **not** travel between git worktrees, and a fresh worktree or a `git clean` silently loses it. The symptom is `make ios-run` failing with:

```
ios/Config/Secrets.xcconfig is missing.
```

The previous guidance was to `cp Secrets.example.xcconfig Secrets.xcconfig`, which writes **placeholder** values and quietly breaks Google Sign-In — the real file usually still exists in whichever worktree the app was last run from.

## What changed

- New Makefile var `IOS_SECRETS_CANONICAL` (default `~/.config/pussel/Secrets.xcconfig`).
- `ios-generate` copies the canonical file into place when the working file is absent.
- Only when **neither** file exists does the target error, and the error now points at the real-values copy first and the placeholder template second.

## Reviewer notes

- No behavior change when `ios/Config/Secrets.xcconfig` already exists (the common case) — the restore step is a no-op.
- The canonical path lives under the developer's home dir; on a machine without it, the target just falls through to the same error as before. Each developer seeds `~/.config/pussel/Secrets.xcconfig` once from their real values.
- Verified locally: deleting the working file and running `make ios-generate` restores the real values and regenerates the Xcode project.