### PR TITLE
Show Google profile picture in account menu icon

### DIFF
--- a/ios/Pussel/App/RootView.swift
+++ b/ios/Pussel/App/RootView.swift
@@ -56,29 +56,33 @@ struct AppFlowView: View {
 }
 
 /// The account menu icon: the user's Google profile picture when available
-/// (fetched via AsyncImage, cached by URLCache), otherwise the generic symbol.
+/// (fetched via AsyncImage), otherwise the generic person symbol.
 struct ProfileIconView: View {
   let pictureURL: URL?
 
   private static let iconSize: CGFloat = 28
 
   var body: some View {
-    if let pictureURL {
-      AsyncImage(url: pictureURL) { image in
-        image
-          .resizable()
-          .scaledToFill()
-          .frame(width: Self.iconSize, height: Self.iconSize)
-          .clipShape(Circle())
-      } placeholder: {
+    Group {
+      if let pictureURL {
+        AsyncImage(url: pictureURL) { image in
+          image
+            .resizable()
+            .scaledToFill()
+        } placeholder: {
+          fallbackIcon
+        }
+      } else {
         fallbackIcon
       }
-    } else {
-      fallbackIcon
     }
+    .frame(width: Self.iconSize, height: Self.iconSize)
+    .clipShape(Circle())
   }
 
   private var fallbackIcon: some View {
     Image(systemName: "person.crop.circle")
+      .resizable()
+      .scaledToFit()
   }
 }

--- a/ios/Pussel/App/RootView.swift
+++ b/ios/Pussel/App/RootView.swift
@@ -46,11 +46,39 @@ struct AppFlowView: View {
               model.flow.reset()
             }
           } label: {
-            Image(systemName: "person.crop.circle")
+            ProfileIconView(pictureURL: model.auth.user?.picture.flatMap(URL.init(string:)))
           }
           .accessibilityLabel("Account")
         }
       }
     }
+  }
+}
+
+/// The account menu icon: the user's Google profile picture when available
+/// (fetched via AsyncImage, cached by URLCache), otherwise the generic symbol.
+struct ProfileIconView: View {
+  let pictureURL: URL?
+
+  private static let iconSize: CGFloat = 28
+
+  var body: some View {
+    if let pictureURL {
+      AsyncImage(url: pictureURL) { image in
+        image
+          .resizable()
+          .scaledToFill()
+          .frame(width: Self.iconSize, height: Self.iconSize)
+          .clipShape(Circle())
+      } placeholder: {
+        fallbackIcon
+      }
+    } else {
+      fallbackIcon
+    }
+  }
+
+  private var fallbackIcon: some View {
+    Image(systemName: "person.crop.circle")
   }
 }

--- a/ios/Pussel/App/RootView.swift
+++ b/ios/Pussel/App/RootView.swift
@@ -57,7 +57,7 @@ struct AppFlowView: View {
 
 /// The account menu icon: the user's Google profile picture when available
 /// (fetched via AsyncImage), otherwise the generic person symbol.
-struct ProfileIconView: View {
+private struct ProfileIconView: View {
   let pictureURL: URL?
 
   private static let iconSize: CGFloat = 28


### PR DESCRIPTION
Use the picture URL already returned by the backend auth response
(UserDTO.picture) to render the signed-in user's Google avatar in the
toolbar account menu via AsyncImage, falling back to the generic
person.crop.circle symbol while loading or when no picture is set.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013WuHTEmCRuszZhnEmrS2xq