### PR TITLE
Keep the screen awake while a camera viewfinder is open

### DIFF
--- a/ios/Pussel/Features/Capture/CapturePuzzleView.swift
+++ b/ios/Pussel/Features/Capture/CapturePuzzleView.swift
@@ -27,6 +27,7 @@ struct CapturePuzzleView: View {
         Task { await handle(image: image, source: .camera) }
       }
       .ignoresSafeArea()
+      .keepsScreenAwake()
     }
     .photosPicker(isPresented: $showLibrary, selection: $photoItem, matching: .images)
     .onChange(of: photoItem) { _, item in

--- a/ios/Pussel/Features/Solve/PieceCaptureView.swift
+++ b/ios/Pussel/Features/Solve/PieceCaptureView.swift
@@ -25,6 +25,7 @@ struct PieceCaptureView: View {
           .onDisappear {
             camera.stop()
           }
+          .keepsScreenAwake()
       }
       PhotosPicker(selection: $photoItem, matching: .images) {
         Label(

--- a/ios/Pussel/Support/KeepScreenAwake.swift
+++ b/ios/Pussel/Support/KeepScreenAwake.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+import UIKit
+
+/// Ref-counted holder for the idle timer. Counted rather than a plain
+/// set/clear because SwiftUI can bring the next view on screen before the
+/// previous one disappears, and the last `onDisappear` would otherwise
+/// release a lock the newly-appeared view still wants.
+@MainActor
+final class ScreenAwakeCounter {
+  static let shared = ScreenAwakeCounter()
+
+  /// Number of views currently asking for the screen to stay awake.
+  private(set) var holders = 0
+
+  func acquire() {
+    holders += 1
+    UIApplication.shared.isIdleTimerDisabled = true
+  }
+
+  func release() {
+    holders = max(0, holders - 1)
+    if holders == 0 {
+      UIApplication.shared.isIdleTimerDisabled = false
+    }
+  }
+}
+
+private struct KeepScreenAwakeModifier: ViewModifier {
+  func body(content: Content) -> some View {
+    content
+      .onAppear { ScreenAwakeCounter.shared.acquire() }
+      .onDisappear { ScreenAwakeCounter.shared.release() }
+  }
+}
+
+extension View {
+  /// Keeps the screen from dimming while this view is on screen. Meant for the
+  /// camera viewfinders: lining up a shot of the puzzle or a piece means
+  /// holding still without touching the screen, which is exactly when the idle
+  /// timer would fire. iOS ignores the flag while the app isn't frontmost, so
+  /// backgrounding needs no extra handling.
+  func keepsScreenAwake() -> some View {
+    modifier(KeepScreenAwakeModifier())
+  }
+}

--- a/ios/PusselTests/ScreenAwakeCounterTests.swift
+++ b/ios/PusselTests/ScreenAwakeCounterTests.swift
@@ -1,0 +1,60 @@
+import UIKit
+import XCTest
+
+@testable import Pussel
+
+/// The idle timer is only observable on a real device (the Simulator never
+/// dims), so these tests pin the ref-counting instead: the screen stays awake
+/// for exactly as long as at least one viewfinder is on screen.
+@MainActor
+final class ScreenAwakeCounterTests: XCTestCase {
+  private var counter = ScreenAwakeCounter()
+
+  override func setUp() {
+    super.setUp()
+    // A fresh counter per test — the app uses a shared one, and leaked state
+    // would make these pass or fail depending on ordering.
+    counter = ScreenAwakeCounter()
+    UIApplication.shared.isIdleTimerDisabled = false
+  }
+
+  override func tearDown() {
+    UIApplication.shared.isIdleTimerDisabled = false
+    super.tearDown()
+  }
+
+  func testAcquireDisablesIdleTimer() {
+    counter.acquire()
+    XCTAssertTrue(UIApplication.shared.isIdleTimerDisabled)
+  }
+
+  func testBalancedReleaseReenablesIdleTimer() {
+    counter.acquire()
+    counter.release()
+    XCTAssertEqual(counter.holders, 0)
+    XCTAssertFalse(UIApplication.shared.isIdleTimerDisabled)
+  }
+
+  /// The case the counter exists for: SwiftUI appears the next view before it
+  /// disappears the last one, so the overlapping release must not drop the lock.
+  func testOverlappingHoldersKeepScreenAwakeUntilLastRelease() {
+    counter.acquire()
+    counter.acquire()
+    counter.release()
+    XCTAssertTrue(UIApplication.shared.isIdleTimerDisabled, "still one viewfinder on screen")
+
+    counter.release()
+    XCTAssertFalse(UIApplication.shared.isIdleTimerDisabled)
+  }
+
+  /// An unbalanced release must not push the count negative — that would make
+  /// the next acquire/release pair leave the idle timer disabled forever.
+  func testUnbalancedReleaseDoesNotGoNegative() {
+    counter.release()
+    XCTAssertEqual(counter.holders, 0)
+
+    counter.acquire()
+    counter.release()
+    XCTAssertFalse(UIApplication.shared.isIdleTimerDisabled)
+  }
+}


### PR DESCRIPTION
## Problem

The screen dims and locks while the app is in use. It bites hardest at the camera: lining up a straight-on shot of the puzzle or a piece means holding the phone still without touching the screen, which is exactly what the idle timer counts as idle.

## Change

Hold the idle timer while a camera viewfinder is on screen — not app-wide, so the flag isn't held during the parts of the flow where normal touch activity already keeps the screen alive.

There are two viewfinders, so the logic lives in one reusable `.keepsScreenAwake()` modifier (`ios/Pussel/Support/KeepScreenAwake.swift`) applied at both:

- `CapturePuzzleView` — the `CameraPicker` full-screen cover for the puzzle overview photo.
- `PieceCaptureView` — the live `CameraPreview` for piece capture.

The modifier acquires on `onAppear` and releases on `onDisappear` through a **ref count** rather than setting `isIdleTimerDisabled` directly. SwiftUI often appears the incoming view before disappearing the outgoing one, so a plain set/clear would let a stale `onDisappear` release a lock the new view still wants. Backgrounding needs no handling — iOS ignores `isIdleTimerDisabled` for apps that aren't frontmost.

## Testing

`make check-ios` clean; all 30 tests pass (`xcodebuild test`, iPhone 17 Pro sim), including 4 new ones.

**Caveat worth knowing:** neither viewfinder exists on the Simulator (`CameraPicker.isAvailable` and `PieceCameraSession.isCameraAvailable` are both false there), and the Simulator never dims anyway — so the end-to-end "screen stays lit" behavior is **unverified** and needs a device run. The new tests in `ScreenAwakeCounterTests` cover the part that can be checked: the ref counting, including the overlapping-holders case and an unbalanced release that would otherwise strand the count negative.

## Note for reviewers

`PieceCaptureView` sits in a non-lazy `ScrollView` inside `SolvingView`, so its preview stays "appeared" for the whole solving phase even when scrolled out of view — in practice the lock is held for as long as you're solving. That matches the camera session's own lifetime, so it's left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)