### PR TITLE
Rotate the trim preview by tapping it

### DIFF
--- a/ios/Pussel/Features/Capture/ConfirmTrimView.swift
+++ b/ios/Pussel/Features/Capture/ConfirmTrimView.swift
@@ -135,13 +135,15 @@ struct ConfirmTrimView: View {
     withAnimation(.easeOut(duration: 0.45)) { hintOpacity = 0 }
   }
 
-  /// Sleeps, reporting whether the wait finished — a cancelled `.task` (the
-  /// view went away mid-demo) must stop the sequence rather than run the rest
-  /// of its animation steps back to back.
+  /// Sleeps between demo steps, reporting whether the sequence should carry on.
+  /// It stops when the `.task` is cancelled (the view went away mid-demo) or
+  /// once the user has rotated — a tap during an early step would otherwise be
+  /// followed by the demo fading itself back in to advertise a gesture the user
+  /// has already found.
   private func pause(for duration: Duration) async -> Bool {
     do {
       try await Task.sleep(for: duration)
-      return true
+      return quarterTurns == 0
     } catch {
       return false
     }

--- a/ios/Pussel/Features/Capture/ConfirmTrimView.swift
+++ b/ios/Pussel/Features/Capture/ConfirmTrimView.swift
@@ -5,7 +5,11 @@ struct ConfirmTrimView: View {
   private static let lowConfidence = 0.4
 
   @Environment(AppModel.self) private var model
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @State private var quarterTurns = 0
+  @State private var hintOpacity = 0.0
+  @State private var hintTurns = 0
+  @State private var didPlayHint = false
   let candidate: TrimCandidate
   /// Decoded once at init rather than in `body`, which re-runs on every
   /// rotate tap (base64-decoding the data URL and the JPEG each time would be
@@ -43,18 +47,15 @@ struct ConfirmTrimView: View {
               .rotationEffect(.degrees(Double(quarterTurns) * 90))
           }
           .frame(maxHeight: 420)
-        Button {
-          // Always increment (never wrap to 0) so the animation turns
-          // clockwise on every tap instead of unwinding 270° → 0°.
-          withAnimation(.snappy(duration: 0.35)) {
-            quarterTurns += 1
-          }
-        } label: {
-          Label("Rotate", systemImage: "rotate.right")
-        }
-        .buttonStyle(.bordered)
-        .controlSize(.regular)
-        .disabled(model.flow.isBusy)
+          .overlay { tapHint }
+          .contentShape(Rectangle())
+          .onTapGesture { rotate() }
+          .accessibilityElement()
+          .accessibilityLabel("Trimmed puzzle photo")
+          .accessibilityHint("Double tap to rotate 90 degrees clockwise.")
+          .accessibilityAddTraits(.isButton)
+          .accessibilityAction { rotate() }
+          .task { await playTapHint() }
       } else {
         ContentUnavailableView("Could not decode the trimmed image", systemImage: "xmark.octagon")
       }
@@ -100,5 +101,61 @@ struct ConfirmTrimView: View {
       }
     }
     .padding(24)
+  }
+
+  /// One-shot "tap here to rotate" demo drawn over the photo: a tapping finger
+  /// beside a rotate glyph that turns a quarter clockwise. Purely decorative —
+  /// hidden from VoiceOver (which gets the accessibility hint instead) and
+  /// non-interactive so it never swallows the tap it is advertising.
+  private var tapHint: some View {
+    ZStack(alignment: .bottomTrailing) {
+      Image(systemName: "rotate.right")
+        .font(.system(size: 52, weight: .semibold))
+        .rotationEffect(.degrees(Double(hintTurns) * 90))
+      Image(systemName: "hand.tap.fill")
+        .font(.system(size: 26, weight: .semibold))
+        .offset(x: 12, y: 10)
+    }
+    .foregroundStyle(.white)
+    .padding(24)
+    .background(.black.opacity(0.55), in: Circle())
+    .opacity(hintOpacity)
+    .allowsHitTesting(false)
+    .accessibilityHidden(true)
+  }
+
+  private func playTapHint() async {
+    guard previewImage != nil, !didPlayHint else { return }
+    didPlayHint = true
+    guard await pause(for: .milliseconds(500)) else { return }
+    withAnimation(.easeIn(duration: 0.25)) { hintOpacity = 1 }
+    guard await pause(for: .milliseconds(550)) else { return }
+    withAnimation(reduceMotion ? nil : .snappy(duration: 0.45)) { hintTurns = 1 }
+    guard await pause(for: .milliseconds(950)) else { return }
+    withAnimation(.easeOut(duration: 0.45)) { hintOpacity = 0 }
+  }
+
+  /// Sleeps, reporting whether the wait finished — a cancelled `.task` (the
+  /// view went away mid-demo) must stop the sequence rather than run the rest
+  /// of its animation steps back to back.
+  private func pause(for duration: Duration) async -> Bool {
+    do {
+      try await Task.sleep(for: duration)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  private func rotate() {
+    guard !model.flow.isBusy else { return }
+    // The demo has served its purpose once the user taps; leaving it to finish
+    // would have it spinning over an image that is already spinning.
+    withAnimation(.easeOut(duration: 0.2)) { hintOpacity = 0 }
+    // Always increment (never wrap to 0) so the animation turns clockwise on
+    // every tap instead of unwinding 270° → 0°.
+    withAnimation(.snappy(duration: 0.35)) {
+      quarterTurns += 1
+    }
   }
 }


### PR DESCRIPTION
## What

On the "Does this look right?" confirm screen, the **Rotate** button is gone. Tapping the puzzle photo itself now turns it 90° clockwise.

To advertise the gesture, a one-shot demo overlay plays over the image when the screen appears: a tapping-finger glyph beside a rotate glyph that quarter-turns, fading in and back out. It dismisses early if the user taps first.

## Why

A tappable image is a nicer interaction than a button, but it carries no affordance — nothing tells the user the photo responds to a tap, and an `Image` isn't focusable as a control. The demo overlay covers discoverability for sighted users; an accessibility label/hint/action covers VoiceOver, where the animation is no help. The overlay is `allowsHitTesting(false)` so it can never swallow the tap it advertises.

## Notes

- Rotation semantics are unchanged: `quarterTurns` still monotonically increments (so the animation always spins clockwise rather than unwinding 270° → 0°), and `ImageUtilities` still normalizes and bakes the turns into the accepted image.
- The busy guard moved from the button's `.disabled(model.flow.isBusy)` into `rotate()`, so taps are still ignored mid-upload.
- The demo honors Reduce Motion by skipping the turn animation.
- The `.task` sequence stops on cancellation rather than firing its remaining animation steps back to back if the view goes away mid-demo.

## Testing

- 26/26 unit tests pass (`make ios-test`); `make check-ios` clean.
- Verified end to end in the Simulator: drove a real photo to the confirm screen, confirmed the button is gone, the demo overlay plays, and tapping the image rotates it 90° clockwise. The author also confirmed the animation looks right on device-scale playback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)