### PR TITLE
iOS: show predicted rotation on queued piece tiles

### DIFF
--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -34,9 +34,12 @@ private struct QueueTile: View {
   /// The model reports how far the piece is turned from its place in the
   /// puzzle, so undoing it shows the piece as it will sit there — the same
   /// counter-clockwise correction PuzzleOverlayView applies to its markers.
+  /// Normalized to (-180, 180] so the tile animates the short way round
+  /// rather than spinning three quarter turns to reach the same place.
   private var uprightRotation: Double {
     guard let piece = entry.result else { return 0 }
-    return -Double(piece.rotation)
+    let degrees = (360 - piece.rotation % 360) % 360
+    return Double(degrees > 180 ? degrees - 360 : degrees)
   }
 
   var body: some View {

--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -31,6 +31,14 @@ private struct QueueTile: View {
   let onRetry: () -> Void
   let onDelete: () -> Void
 
+  /// The model reports how far the piece is turned from its place in the
+  /// puzzle, so undoing it shows the piece as it will sit there — the same
+  /// counter-clockwise correction PuzzleOverlayView applies to its markers.
+  private var uprightRotation: Double {
+    guard let piece = entry.result else { return 0 }
+    return -Double(piece.rotation)
+  }
+
   var body: some View {
     VStack(spacing: 6) {
       ZStack {
@@ -39,7 +47,9 @@ private struct QueueTile: View {
             .resizable()
             .scaledToFill()
             .frame(width: 84, height: 84)
+            .rotationEffect(.degrees(uprightRotation))
             .clipShape(RoundedRectangle(cornerRadius: 10))
+            .animation(.easeInOut(duration: 0.25), value: uprightRotation)
         }
         if entry.status == .predicting {
           RoundedRectangle(cornerRadius: 10)


### PR DESCRIPTION
## What

After a piece prediction lands, the tile in the "Pieces" strip below the puzzle kept showing the piece exactly as photographed. It now turns to the predicted rotation.

## How

The model reports how far a piece is turned *away* from where it belongs, so the tile is rotated by `-rotation` to show it as it will sit in the puzzle. That matches the correction `PuzzleOverlayView` already applies to its markers, so a tile and its marker on the picture now always agree.

The `rotationEffect` sits between the 84×84 frame and the clip shape, so the square tile stays filled at every quarter turn.

Note: the web frontend's `piece-card.tsx` uses `+rotation`, which turns the piece *further* from upright. That looks like a bug, but it's left alone here.

## Verification

Built and drove the app in the Simulator via the debug command channel: capture → accept → three piece fixtures generated from `puzzle_001.jpg` and pre-rotated by 90°, 180° and 270°. The backend predicted exactly 90/180/270 back, and all three tiles rendered upright, matching their overlay markers.

`make check-ios` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)