### PR TITLE
Size puzzle pieces realistically via piece count and measured spans

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ import base64
 import io
 import os
 import uuid
-from typing import Annotated, Dict, Optional
+from typing import Annotated, Dict, Optional, Tuple
 
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
@@ -31,7 +31,7 @@ from app.models.user_model import GoogleAuthRequest, TokenResponse, User
 from app.services.classical_matcher import get_classical_matcher
 from app.services.image_processor import get_image_processor
 from app.services.piece_detector import get_piece_detector
-from app.services.piece_shape import PieceShapeGenerator
+from app.services.piece_shape import PieceShapeGenerator, calculate_grid_dimensions
 from app.services.puzzle_cutter import get_puzzle_cutter
 from app.services.puzzle_detector import get_puzzle_detector
 
@@ -49,6 +49,15 @@ app.add_middleware(
 
 # Store puzzle images in memory for demo
 puzzle_images: Dict[str, str] = {}
+# Grid (rows, cols) estimated from an optional client-supplied piece count at
+# upload time; used to size the classical matcher's NCC template. Only present
+# for puzzles uploaded with piece_count.
+puzzle_grids: Dict[str, Tuple[int, int]] = {}
+
+# piece_count must produce a sane grid: a puzzle can't reasonably have fewer
+# than 4 pieces, and this backend isn't tuned for four-digit piece counts.
+MIN_PIECE_COUNT = 4
+MAX_PIECE_COUNT = 2000
 
 
 @app.get("/health")
@@ -129,18 +138,29 @@ async def get_current_user_profile(
 async def upload_puzzle(
     current_user: Annotated[User, Depends(get_current_user)],
     file: Optional[UploadFile] = None,
+    piece_count: Annotated[
+        Optional[int],
+        Form(description="Total number of pieces in the puzzle; used to estimate the grid (rows x cols)"),
+    ] = None,
 ) -> PuzzleResponse:
     """Upload a complete puzzle image.
 
     Args:
         current_user: The authenticated user.
         file: The puzzle image file.
+        piece_count: Optional total piece count supplied by the client (e.g. the
+            iOS app). When provided, the grid is estimated from this count and
+            the image's aspect ratio and stored alongside the puzzle.
 
     Returns:
-        PuzzleResponse: Response containing the puzzle ID.
+        PuzzleResponse: Response containing the puzzle ID, and — when
+        piece_count was provided — the echoed piece_count and estimated
+        rows/cols.
 
     Raises:
-        HTTPException: If file size exceeds limit or file type is invalid.
+        HTTPException: If file size exceeds limit, piece_count is out of
+            range, or (when piece_count is given) the file isn't a decodable
+            image.
     """
     # Note: current_user can be used to associate puzzles with users in the future
     _ = current_user  # Acknowledge the parameter is intentionally unused for now
@@ -150,14 +170,35 @@ async def upload_puzzle(
     if file.size and file.size > settings.MAX_UPLOAD_SIZE:
         raise HTTPException(status_code=413, detail="File too large")
 
+    if piece_count is not None and not (MIN_PIECE_COUNT <= piece_count <= MAX_PIECE_COUNT):
+        raise HTTPException(
+            status_code=400,
+            detail=f"piece_count must be between {MIN_PIECE_COUNT} and {MAX_PIECE_COUNT}",
+        )
+
+    contents = await file.read()
+
+    rows: Optional[int] = None
+    cols: Optional[int] = None
+    if piece_count is not None:
+        try:
+            image = Image.open(io.BytesIO(contents))
+            image.load()
+        except (UnidentifiedImageError, OSError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail="Invalid image file") from exc
+        rows, cols = calculate_grid_dimensions(image.width, image.height, piece_count)
+
     puzzle_id = str(uuid.uuid4())
     file_path = os.path.join(settings.UPLOAD_DIR, f"{puzzle_id}.jpg")
 
     with open(file_path, "wb") as f:
-        f.write(await file.read())
+        f.write(contents)
 
     puzzle_images[puzzle_id] = file_path
-    return PuzzleResponse(puzzle_id=puzzle_id)
+    if rows is not None and cols is not None:
+        puzzle_grids[puzzle_id] = (rows, cols)
+
+    return PuzzleResponse(puzzle_id=puzzle_id, piece_count=piece_count, rows=rows, cols=cols)
 
 
 @app.post("/api/v1/puzzle/detect-frame", response_model=DetectFrameResponse)
@@ -311,8 +352,15 @@ async def process_piece(
     if puzzle_id not in puzzle_images:
         raise HTTPException(status_code=404, detail="Puzzle not found")
 
-    processor = get_image_processor() if settings.MATCHER == "cnn" else get_classical_matcher()
-    return await processor.process_piece(file, puzzle_id, remove_background=remove_bg)
+    if settings.MATCHER == "cnn":
+        return await get_image_processor().process_piece(file, puzzle_id, remove_background=remove_bg)
+
+    # Pass along the grid estimated at upload time (if any) so the NCC fallback's
+    # nominal template size uses the puzzle's real grid instead of the defaults.
+    grid_hint = puzzle_grids.get(puzzle_id)
+    return await get_classical_matcher().process_piece(
+        file, puzzle_id, remove_background=remove_bg, grid_hint=grid_hint
+    )
 
 
 @app.post("/api/v1/puzzle/{puzzle_id}/generate-piece", response_model=GeneratePieceResponse)

--- a/backend/app/models/puzzle_model.py
+++ b/backend/app/models/puzzle_model.py
@@ -12,6 +12,13 @@ class Position(BaseModel):
     y: float
 
 
+class PieceSpan(BaseModel):
+    """Normalized size of the piece image frame on the puzzle, in [0,1] of puzzle width/height."""
+
+    width: float
+    height: float
+
+
 class PieceResponse(BaseModel):
     """Response model for puzzle piece processing."""
 
@@ -20,6 +27,14 @@ class PieceResponse(BaseModel):
     rotation: int
     rotation_confidence: float
     cleaned_image: Optional[str] = None  # Base64 encoded PNG with background removed
+    piece_span: Optional[PieceSpan] = Field(
+        default=None,
+        description=(
+            "Normalized size of the full piece image frame (as sent by the client, in its own "
+            "orientation) as a fraction of the puzzle's width/height. Null when no measurement "
+            "exists (CNN path, or matcher failure fallback)."
+        ),
+    )
 
 
 class PuzzleResponse(BaseModel):
@@ -27,6 +42,11 @@ class PuzzleResponse(BaseModel):
 
     puzzle_id: str
     image_url: Optional[str] = None
+    piece_count: Optional[int] = Field(
+        default=None, description="Client-supplied total piece count, echoed back when provided"
+    )
+    rows: Optional[int] = Field(default=None, description="Estimated grid rows, present when piece_count was given")
+    cols: Optional[int] = Field(default=None, description="Estimated grid cols, present when piece_count was given")
 
 
 # Models for puzzle frame detection (real mode)

--- a/backend/app/services/classical_matcher.py
+++ b/backend/app/services/classical_matcher.py
@@ -26,9 +26,9 @@ from fastapi import UploadFile
 from PIL import Image
 
 from app.config import settings
-from app.models.puzzle_model import PieceResponse, Position
+from app.models.puzzle_model import PieceResponse, PieceSpan, Position
 from app.services.background_remover import get_background_remover
-from app.services.piece_detector import crop_to_alpha_region
+from app.services.piece_detector import crop_to_alpha_region, harden_alpha
 
 # Pixels whose grayscale value is above this count as piece content (the
 # segmented crops have pure-black backgrounds).
@@ -65,6 +65,17 @@ def _resize_max_side(rgb: "np.ndarray", side: int) -> "np.ndarray":
     if scale >= 1.0:
         return rgb
     return cv2.resize(rgb, (int(round(w * scale)), int(round(h * scale))), interpolation=cv2.INTER_AREA)
+
+
+@dataclass
+class MatchResult:
+    """Result of a classical (SIFT or NCC) piece match."""
+
+    nx: float
+    ny: float
+    rotation_degrees: int
+    confidence: float
+    piece_span: Optional[PieceSpan] = None
 
 
 @dataclass
@@ -148,17 +159,15 @@ class ClassicalMatcher:
         else:
             self._puzzle_cache.clear()
 
-    def _predict_sift(
-        self, piece_rgb: "np.ndarray", features: PuzzleFeatures
-    ) -> Optional[tuple[float, float, int, float]]:
-        """Predict (position, rotation, confidence) via SIFT + FLANN + partial-affine RANSAC.
+    def _predict_sift(self, piece_rgb: "np.ndarray", features: PuzzleFeatures) -> Optional[MatchResult]:
+        """Predict (position, rotation, confidence, span) via SIFT + FLANN + partial-affine RANSAC.
 
         Args:
             piece_rgb: Observed piece image, RGB uint8, black background.
             features: Cached puzzle features.
 
         Returns:
-            (nx, ny, rotation_degrees, confidence), or None when matching fails.
+            A MatchResult, or None when matching fails.
         """
         piece_resized = _resize_max_side(piece_rgb, SIFT_PIECE_SIDE)
         gray = cv2.cvtColor(piece_resized, cv2.COLOR_RGB2GRAY)
@@ -187,12 +196,25 @@ class ClassicalMatcher:
         nx = float(centroid[0]) / puz_w
         ny = float(centroid[1]) / puz_h
         confidence = min(1.0, int(inliers.sum()) / 30.0)
-        return nx, ny, rotation_idx * 90, confidence
+
+        # Uniform scale of the partial-affine transform maps the SIFT-resized piece
+        # image into the SIFT-resized puzzle overview; apply it to the piece frame's
+        # own pixel size to get the full piece frame's span on the puzzle.
+        scale = float(np.sqrt(transform[0, 0] ** 2 + transform[1, 0] ** 2))
+        piece_resized_h, piece_resized_w = piece_resized.shape[:2]
+        span = PieceSpan(
+            width=piece_resized_w * scale / puz_w,
+            height=piece_resized_h * scale / puz_h,
+        )
+        return MatchResult(nx=nx, ny=ny, rotation_degrees=rotation_idx * 90, confidence=confidence, piece_span=span)
 
     def _predict_ncc(
-        self, piece_rgb: "np.ndarray", features: PuzzleFeatures
-    ) -> Optional[tuple[float, float, int, float]]:
-        """Predict (position, rotation, confidence) via masked multi-scale NCC.
+        self,
+        piece_rgb: "np.ndarray",
+        features: PuzzleFeatures,
+        grid_hint: Optional[tuple[int, int]] = None,
+    ) -> Optional[MatchResult]:
+        """Predict (position, rotation, confidence, span) via masked multi-scale NCC.
 
         Tries all 4 candidate un-rotations of the piece x each of NCC_SCALES,
         matched against the NCC overview with a content mask.
@@ -200,16 +222,27 @@ class ClassicalMatcher:
         Args:
             piece_rgb: Observed piece image, RGB uint8, black background.
             features: Cached puzzle features.
+            grid_hint: Optional (rows, cols) for this puzzle, e.g. estimated from a
+                client-supplied piece count at upload time. When absent, falls back
+                to the ``CLASSICAL_GRID_ROWS``/``CLASSICAL_GRID_COLS`` settings.
 
         Returns:
-            (nx, ny, rotation_degrees, confidence), or None when no scale/rotation
-            candidate produced a usable template (e.g. an all-black piece).
+            A MatchResult, or None when no scale/rotation candidate produced a
+            usable template (e.g. an all-black piece).
         """
         puzzle_bgr = features.ncc_overview_bgr
         puz_h, puz_w = puzzle_bgr.shape[:2]
-        nominal = max(puz_w / settings.CLASSICAL_GRID_COLS, puz_h / settings.CLASSICAL_GRID_ROWS)
+        grid_rows, grid_cols = (
+            grid_hint
+            if grid_hint is not None
+            else (
+                settings.CLASSICAL_GRID_ROWS,
+                settings.CLASSICAL_GRID_COLS,
+            )
+        )
+        nominal = max(puz_w / grid_cols, puz_h / grid_rows)
         best_score = -np.inf
-        best: Optional[tuple[float, float, int]] = None
+        best: Optional[tuple[float, float, int, int]] = None
         for candidate_idx in range(4):
             unrot = np.rot90(piece_rgb, k=candidate_idx)
             for scale in NCC_SCALES:
@@ -227,18 +260,23 @@ class ClassicalMatcher:
                     best_score = max_val
                     nx = (max_loc[0] + side / 2) / puz_w
                     ny = (max_loc[1] + side / 2) / puz_h
-                    best = (nx, ny, candidate_idx)
+                    best = (nx, ny, candidate_idx, side)
         if best is None:
             return None
-        nx, ny, candidate_idx = best
+        nx, ny, candidate_idx, side = best
         confidence = max(0.0, min(1.0, float(best_score)))
-        return nx, ny, candidate_idx * 90, confidence
+        # The winning template is the whole piece image squashed to a `side`x`side`
+        # square matched against the overview, so the span is square in overview
+        # pixel space; it's an aspect-squashed, scale-quantized approximation.
+        span = PieceSpan(width=side / puz_w, height=side / puz_h)
+        return MatchResult(nx=nx, ny=ny, rotation_degrees=candidate_idx * 90, confidence=confidence, piece_span=span)
 
     async def process_piece(
         self,
         piece_file: UploadFile,
         puzzle_id: str,
         remove_background: bool = True,
+        grid_hint: Optional[tuple[int, int]] = None,
     ) -> PieceResponse:
         """Process a puzzle piece image and predict its position and rotation.
 
@@ -250,6 +288,9 @@ class ClassicalMatcher:
             piece_file: The puzzle piece image file.
             puzzle_id: The ID of the puzzle to match against.
             remove_background: Whether to remove background from piece image.
+            grid_hint: Optional (rows, cols) for this puzzle, used to size the NCC
+                fallback's nominal template instead of the CLASSICAL_GRID_ROWS/COLS
+                settings defaults. See ``_predict_ncc``.
 
         Returns:
             PieceResponse with predicted position, confidence, rotation, and optionally cleaned image.
@@ -263,6 +304,10 @@ class ClassicalMatcher:
 
                 # Get RGBA image with transparent background for frontend display
                 rgba_image = remover.remove_background(contents)
+
+                # Drop the matte's faint background ghost before cropping so
+                # neither the client nor the crop sees it.
+                rgba_image = harden_alpha(rgba_image)
 
                 # Crop to the segmented subject so the piece fills the frame,
                 # matching the deployed preview path.
@@ -289,16 +334,16 @@ class ClassicalMatcher:
             features = self._load_puzzle_features(puzzle_id)
 
             sift_result = self._predict_sift(piece_rgb, features)
-            result = sift_result if sift_result is not None else self._predict_ncc(piece_rgb, features)
+            result = sift_result if sift_result is not None else self._predict_ncc(piece_rgb, features, grid_hint)
 
             if result is not None:
-                nx, ny, rotation_degrees, confidence = result
                 return PieceResponse(
-                    position=Position(x=nx, y=ny),
-                    position_confidence=confidence,
-                    rotation=rotation_degrees,
-                    rotation_confidence=confidence,
+                    position=Position(x=result.nx, y=result.ny),
+                    position_confidence=result.confidence,
+                    rotation=result.rotation_degrees,
+                    rotation_confidence=result.confidence,
                     cleaned_image=cleaned_image_b64,
+                    piece_span=result.piece_span,
                 )
 
             # Both SIFT and NCC failed to find a usable match.

--- a/backend/app/services/image_processor.py
+++ b/backend/app/services/image_processor.py
@@ -22,7 +22,7 @@ from app.config import settings
 from app.models.model import FastBackboneModel
 from app.models.puzzle_model import PieceResponse, Position
 from app.services.background_remover import get_background_remover
-from app.services.piece_detector import crop_to_alpha_region
+from app.services.piece_detector import crop_to_alpha_region, harden_alpha
 
 # Path to checkpoint (exp20 4x4 grid model, realistic pieces, ~72.9% cell accuracy)
 DEFAULT_CHECKPOINT_PATH = str(
@@ -240,6 +240,10 @@ class ImageProcessor:
 
                 # Get RGBA image with transparent background for frontend display
                 rgba_image = remover.remove_background(contents)
+
+                # Drop the matte's faint background ghost before cropping so
+                # neither the client nor the crop sees it.
+                rgba_image = harden_alpha(rgba_image)
 
                 # Crop to the segmented subject so the piece fills the frame for the
                 # model (training pieces fill the image) instead of floating in a

--- a/backend/app/services/piece_detector.py
+++ b/backend/app/services/piece_detector.py
@@ -81,6 +81,30 @@ def largest_alpha_component(rgba: Image.Image, alpha_threshold: int = 128) -> Op
     return max(contours, key=cv2.contourArea)
 
 
+def harden_alpha(rgba: Image.Image, alpha_threshold: int = 128) -> Image.Image:
+    """Zero out low-alpha pixels left behind by soft segmentation mattes.
+
+    rembg's matte keeps a faint semi-transparent ghost of the background
+    (alpha well below the subject's) across much of the frame; rendered over a
+    bright surface it shows up as visible background imagery. Pixels at or
+    below the threshold become fully transparent; pixels above it keep their
+    alpha, preserving soft subject edges.
+
+    Args:
+        rgba: RGBA image, e.g. rembg output.
+        alpha_threshold: Alpha value at or below which a pixel is cleared.
+
+    Returns:
+        The hardened image, or the input unchanged when it has no alpha channel.
+    """
+    if rgba.mode != "RGBA":
+        return rgba
+    arr = np.array(rgba)
+    alpha = arr[..., 3]
+    arr[..., 3] = np.where(alpha > alpha_threshold, alpha, 0)
+    return Image.fromarray(arr)
+
+
 def crop_to_alpha_region(rgba: Image.Image, margin: float = 0.08) -> Image.Image:
     """Crop an RGBA image to the bounding box of its largest opaque region.
 

--- a/backend/tests/test_classical_matcher.py
+++ b/backend/tests/test_classical_matcher.py
@@ -17,7 +17,7 @@ from PIL import Image, ImageDraw
 
 from app.config import settings
 from app.main import app
-from app.models.puzzle_model import PieceResponse, Position
+from app.models.puzzle_model import PieceResponse, PieceSpan, Position
 from app.services import classical_matcher as cm_module
 from app.services.classical_matcher import ClassicalMatcher, PuzzleFeatures, get_classical_matcher
 
@@ -32,6 +32,13 @@ CROP_X2, CROP_Y2 = CROP_X1 + CROP_SIZE, CROP_Y1 + CROP_SIZE
 EXPECTED_NX = (CROP_X1 + CROP_X2) / 2 / PUZZLE_SIZE
 EXPECTED_NY = (CROP_Y1 + CROP_Y2) / 2 / PUZZLE_SIZE
 POSITION_TOLERANCE = 0.15
+
+# make_piece_canvas pads the crop with a black border on each side; the full
+# piece frame (crop + padding) is what piece_span should describe.
+CANVAS_PAD = 20
+CANVAS_SIDE = CROP_SIZE + 2 * CANVAS_PAD
+EXPECTED_SPAN = CANVAS_SIDE / PUZZLE_SIZE
+SPAN_TOLERANCE = 0.3  # generous: SIFT/NCC scale estimation is approximate
 
 
 def make_synthetic_puzzle(size: int = PUZZLE_SIZE, seed: int = 42) -> Image.Image:
@@ -115,6 +122,9 @@ def test_sift_happy_path(matcher: ClassicalMatcher, puzzle_id: str) -> None:
     assert result.rotation == 0
     assert result.position_confidence > 0
     assert result.rotation_confidence > 0
+    assert result.piece_span is not None
+    assert abs(result.piece_span.width - EXPECTED_SPAN) < SPAN_TOLERANCE
+    assert abs(result.piece_span.height - EXPECTED_SPAN) < SPAN_TOLERANCE
 
 
 def test_sift_rotation(matcher: ClassicalMatcher, puzzle_id: str) -> None:
@@ -147,6 +157,12 @@ def test_sift_fail_falls_back_to_ncc(
     assert result.position_confidence > 0
     assert result.rotation_confidence > 0
     assert not (result.position.x == 0.5 and result.position.y == 0.5 and result.position_confidence == 0.0)
+    # The NCC template is square in overview pixel space, so the span should be
+    # square-ish even when the puzzle overview itself isn't perfectly square.
+    assert result.piece_span is not None
+    assert result.piece_span.width > 0
+    assert result.piece_span.height > 0
+    assert abs(result.piece_span.width - result.piece_span.height) < 0.05
 
 
 def test_both_fail_returns_neutral(matcher: ClassicalMatcher, puzzle_id: str) -> None:
@@ -163,6 +179,7 @@ def test_both_fail_returns_neutral(matcher: ClassicalMatcher, puzzle_id: str) ->
     assert result.rotation == 0
     assert result.rotation_confidence == 0.0
     assert result.cleaned_image is None
+    assert result.piece_span is None
 
 
 def test_unexpected_exception_returns_neutral_fallback(
@@ -181,6 +198,7 @@ def test_unexpected_exception_returns_neutral_fallback(
     assert result.rotation == 0
     assert result.rotation_confidence == 0.0
     assert result.cleaned_image is None
+    assert result.piece_span is None
 
 
 def test_cache_populated_after_process_piece(matcher: ClassicalMatcher, puzzle_id: str) -> None:
@@ -275,7 +293,11 @@ def test_endpoint_uses_classical_matcher_when_configured(upload_dir: Path, monke
     mock_matcher = MagicMock()
     mock_matcher.process_piece = AsyncMock(
         return_value=PieceResponse(
-            position=Position(x=0.1, y=0.2), position_confidence=0.5, rotation=90, rotation_confidence=0.5
+            position=Position(x=0.1, y=0.2),
+            position_confidence=0.5,
+            rotation=90,
+            rotation_confidence=0.5,
+            piece_span=PieceSpan(width=0.3, height=0.35),
         )
     )
 
@@ -292,7 +314,10 @@ def test_endpoint_uses_classical_matcher_when_configured(upload_dir: Path, monke
     assert response.status_code == 200
     mock_get_classical.assert_called_once()
     mock_get_cnn.assert_not_called()
-    assert response.json()["rotation"] == 90
+    body = response.json()
+    assert body["rotation"] == 90
+    # Confirms the wire shape: snake_case "piece_span" with "width"/"height" sub-keys.
+    assert body["piece_span"] == {"width": 0.3, "height": 0.35}
 
 
 def test_endpoint_uses_cnn_processor_when_configured(upload_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -20,6 +20,7 @@ from typing_extensions import TypeAlias
 from app.main import app, settings
 from app.models.puzzle_model import PieceResponse, Position
 from app.services.piece_detector import DetectedRegion
+from app.services.piece_shape import calculate_grid_dimensions
 
 # Add the backend directory to the Python path
 backend_dir = Path(__file__).parent.parent
@@ -94,6 +95,114 @@ def test_upload_puzzle() -> None:
         # Cleanup test image
         if os.path.exists(test_image_path):
             os.remove(test_image_path)
+
+
+def test_upload_puzzle_with_piece_count() -> None:
+    """Uploading with piece_count estimates and returns the grid (rows x cols)."""
+    response = client.post(
+        "/api/v1/puzzle/upload",
+        files=photo_files(make_photo_jpeg()),
+        data={"piece_count": "24"},
+        headers=get_auth_header(),
+    )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["piece_count"] == 24
+    # make_photo_jpeg() produces an 800x600 image.
+    expected_rows, expected_cols = calculate_grid_dimensions(800, 600, 24)
+    assert result["rows"] == expected_rows
+    assert result["cols"] == expected_cols
+
+
+def test_upload_puzzle_without_piece_count_is_backwards_compatible() -> None:
+    """Uploading without piece_count leaves piece_count/rows/cols null."""
+    response = client.post(
+        "/api/v1/puzzle/upload",
+        files=photo_files(make_photo_jpeg()),
+        headers=get_auth_header(),
+    )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["piece_count"] is None
+    assert result["rows"] is None
+    assert result["cols"] is None
+
+
+@pytest.mark.parametrize("piece_count", ["2", "3", "2001", "3000"])
+def test_upload_puzzle_rejects_out_of_range_piece_count(piece_count: str) -> None:
+    """piece_count outside [4, 2000] is rejected with a 4xx, not a crash."""
+    response = client.post(
+        "/api/v1/puzzle/upload",
+        files=photo_files(make_photo_jpeg()),
+        data={"piece_count": piece_count},
+        headers=get_auth_header(),
+    )
+    assert 400 <= response.status_code < 500
+
+
+def test_upload_puzzle_rejects_non_integer_piece_count() -> None:
+    """A non-integer piece_count is rejected with a 4xx, not a crash."""
+    response = client.post(
+        "/api/v1/puzzle/upload",
+        files=photo_files(make_photo_jpeg()),
+        data={"piece_count": "not-a-number"},
+        headers=get_auth_header(),
+    )
+    assert 400 <= response.status_code < 500
+
+
+def test_upload_puzzle_with_piece_count_and_invalid_image_bytes() -> None:
+    """piece_count with undecodable image bytes returns 400 rather than crashing."""
+    response = client.post(
+        "/api/v1/puzzle/upload",
+        files=photo_files(b"fake image content"),
+        data={"piece_count": "16"},
+        headers=get_auth_header(),
+    )
+    assert response.status_code == 400
+
+
+def test_piece_grid_hint_reaches_classical_matcher() -> None:
+    """The grid estimated at upload time is forwarded to the classical matcher."""
+    mock_response = PieceResponse(
+        position=Position(x=0.5, y=0.5),
+        position_confidence=0.5,
+        rotation=0,
+        rotation_confidence=0.5,
+    )
+    mock_matcher = MagicMock()
+    mock_matcher.process_piece = AsyncMock(return_value=mock_response)
+
+    upload_response = client.post(
+        "/api/v1/puzzle/upload",
+        files=photo_files(make_photo_jpeg()),
+        data={"piece_count": "24"},
+        headers=get_auth_header(),
+    )
+    puzzle_id = upload_response.json()["puzzle_id"]
+    expected_grid = calculate_grid_dimensions(800, 600, 24)
+
+    with (
+        patch.object(settings, "MATCHER", "classical"),
+        patch("app.main.get_classical_matcher", return_value=mock_matcher),
+    ):
+        with tempfile.NamedTemporaryFile(suffix=".jpg") as temp_file:
+            temp_file.write(b"fake piece content")
+            temp_file.seek(0)
+            file_tuple = cast(FileUpload, ("test_piece.jpg", temp_file, "image/jpeg"))
+            files = {"file": file_tuple}
+            response = client.post(
+                f"/api/v1/puzzle/{puzzle_id}/piece",
+                files=files,
+                headers=get_auth_header(),
+            )
+
+    assert response.status_code == 200
+    mock_matcher.process_piece.assert_awaited_once()
+    _, kwargs = mock_matcher.process_piece.call_args
+    assert kwargs["grid_hint"] == expected_grid
 
 
 def test_process_piece_invalid_puzzle() -> None:
@@ -173,6 +282,7 @@ def test_process_piece() -> None:
         assert result["position_confidence"] == 0.85
         assert result["rotation"] == 90
         assert result["rotation_confidence"] == 0.90
+        assert result["piece_span"] is None
 
     finally:
         # Cleanup test image

--- a/backend/tests/test_piece_detector.py
+++ b/backend/tests/test_piece_detector.py
@@ -14,6 +14,7 @@ from app.services.piece_detector import (
     _band_score,
     crop_to_alpha_region,
     get_piece_detector,
+    harden_alpha,
     largest_alpha_component,
     skin_fraction,
 )
@@ -39,6 +40,37 @@ def make_rgba_with_region(
     left, top, right, bottom = region
     rgba[top:bottom, left:right] = (*color, 255)
     return Image.fromarray(rgba, mode="RGBA")
+
+
+class TestHardenAlpha:
+    """Tests for harden_alpha."""
+
+    def test_clears_faint_halo_and_keeps_subject(self) -> None:
+        """Alpha at or below the threshold is zeroed; higher alpha is preserved."""
+        rgba = np.zeros((10, 10, 4), dtype=np.uint8)
+        rgba[..., :3] = 200
+        rgba[..., 3] = 60  # faint background ghost everywhere
+        rgba[2:8, 2:8, 3] = 230  # the subject
+
+        hardened = np.array(harden_alpha(Image.fromarray(rgba, mode="RGBA")))
+
+        assert hardened[0, 0, 3] == 0
+        assert hardened[5, 5, 3] == 230
+
+    def test_soft_edges_above_threshold_survive(self) -> None:
+        """Partially transparent pixels above the threshold keep their alpha."""
+        rgba = np.zeros((4, 4, 4), dtype=np.uint8)
+        rgba[..., 3] = 150
+
+        hardened = np.array(harden_alpha(Image.fromarray(rgba, mode="RGBA")))
+
+        assert (hardened[..., 3] == 150).all()
+
+    def test_non_rgba_image_is_unchanged(self) -> None:
+        """Images without an alpha channel pass through untouched."""
+        rgb = Image.new("RGB", (10, 10), (5, 5, 5))
+
+        assert harden_alpha(rgb) is rgb
 
 
 class TestCropToAlphaRegion:

--- a/ios/Pussel/App/AppActions.swift
+++ b/ios/Pussel/App/AppActions.swift
@@ -30,7 +30,10 @@ extension AppModel {
   /// Uploads the accepted trimmed image and starts a solve session. Any
   /// user-applied rotation (`quarterTurns` × 90° clockwise) is baked into the
   /// uploaded and stored image so the puzzle appears upright everywhere.
-  func acceptTrim(_ candidate: TrimCandidate, quarterTurns: Int = 0) async {
+  /// `pieceCount` is the user-entered total piece count; the grid (rows,
+  /// cols) is estimated from it and the final rotated image's pixel
+  /// dimensions, then persisted on the session for overlay marker sizing.
+  func acceptTrim(_ candidate: TrimCandidate, quarterTurns: Int = 0, pieceCount: Int) async {
     // Ignore repeat taps (e.g. a double-tap on "Use This") while an upload
     // is already in flight so we don't start concurrent uploads/sessions.
     guard !flow.isBusy else { return }
@@ -42,15 +45,24 @@ extension AppModel {
       flow.errorMessage = "Could not rotate the trimmed image."
       return
     }
+    guard let trimmedSize = UIImage(data: trimmed)?.size else {
+      flow.errorMessage = "Could not measure the trimmed image."
+      return
+    }
+    let grid = GridEstimator.estimate(
+      pieceCount: pieceCount, imageWidth: trimmedSize.width, imageHeight: trimmedSize.height)
     flow.errorMessage = nil
     flow.isBusy = true
     defer { flow.isBusy = false }
     do {
-      let response = try await api.uploadPuzzle(jpegData: trimmed)
+      let response = try await api.uploadPuzzle(jpegData: trimmed, pieceCount: pieceCount)
       let session = SolveSession(
         name: Self.puzzleNameFormatter.string(from: Date()),
         puzzleId: response.puzzleId,
         trimmedJPEG: trimmed,
+        pieceCount: pieceCount,
+        rows: grid.rows,
+        cols: grid.cols,
         store: store
       )
       // Persist immediately so the puzzle survives even before any pieces

--- a/ios/Pussel/App/AppFlow.swift
+++ b/ios/Pussel/App/AppFlow.swift
@@ -61,6 +61,12 @@ final class SolveSession {
   let createdAt: Date
   var puzzleId: String
   let trimmedJPEG: Data
+  /// Total piece count entered by the user when the puzzle was added.
+  let pieceCount: Int
+  /// Grid estimated by `GridEstimator` from `pieceCount` and `trimmedJPEG`'s
+  /// pixel dimensions; drives the overlay's marker sizing.
+  let rows: Int
+  let cols: Int
   var entries: [CaptureEntry] = []
   var isProcessing = false
   var puzzleExpired = false
@@ -73,6 +79,9 @@ final class SolveSession {
     name: String,
     puzzleId: String,
     trimmedJPEG: Data,
+    pieceCount: Int,
+    rows: Int,
+    cols: Int,
     createdAt: Date = Date(),
     store: PuzzleStore? = nil
   ) {
@@ -80,6 +89,9 @@ final class SolveSession {
     self.name = name
     self.puzzleId = puzzleId
     self.trimmedJPEG = trimmedJPEG
+    self.pieceCount = pieceCount
+    self.rows = rows
+    self.cols = cols
     self.createdAt = createdAt
     self.store = store
   }
@@ -155,7 +167,7 @@ final class SolveSession {
   func reupload(api: APIClient) async {
     errorMessage = nil
     do {
-      let response = try await api.uploadPuzzle(jpegData: trimmedJPEG)
+      let response = try await api.uploadPuzzle(jpegData: trimmedJPEG, pieceCount: pieceCount)
       puzzleId = response.puzzleId
       puzzleExpired = false
       for index in entries.indices where entries[index].status == .expired {

--- a/ios/Pussel/Features/Capture/ConfirmTrimView.swift
+++ b/ios/Pussel/Features/Capture/ConfirmTrimView.swift
@@ -3,9 +3,14 @@ import SwiftUI
 struct ConfirmTrimView: View {
   /// Mirrors LOW_CONFIDENCE_THRESHOLD in frontend/src/app/real/page.tsx.
   private static let lowConfidence = 0.4
+  /// Piece-count quick-pick presets shown as chips above the numeric field.
+  private static let pieceCountPresets = [12, 24, 48, 100, 500, 1000]
+  private static let pieceCountRange = 4...2000
 
   @Environment(AppModel.self) private var model
   @State private var quarterTurns = 0
+  @State private var pieceCountText = ""
+  @FocusState private var pieceCountFieldFocused: Bool
   let candidate: TrimCandidate
   /// Decoded once at init rather than in `body`, which re-runs on every
   /// rotate tap (base64-decoding the data URL and the JPEG each time would be
@@ -15,6 +20,26 @@ struct ConfirmTrimView: View {
   init(candidate: TrimCandidate) {
     self.candidate = candidate
     self.previewImage = candidate.trimmedJPEG.flatMap(UIImage.init(data:))
+  }
+
+  /// The entered piece count, or nil while the field is empty/out of range.
+  private var pieceCount: Int? {
+    guard let value = Int(pieceCountText), Self.pieceCountRange.contains(value) else {
+      return nil
+    }
+    return value
+  }
+
+  /// Grid estimate from the current piece count and the preview image's
+  /// aspect ratio, accounting for the rotation applied so far (a 90°/270°
+  /// turn swaps width and height).
+  private var estimatedGrid: (rows: Int, cols: Int)? {
+    guard let pieceCount, let image = previewImage else { return nil }
+    let turns = ((quarterTurns % 4) + 4) % 4
+    let swapped = turns == 1 || turns == 3
+    let width = swapped ? image.size.height : image.size.width
+    let height = swapped ? image.size.width : image.size.height
+    return GridEstimator.estimate(pieceCount: pieceCount, imageWidth: width, imageHeight: height)
   }
 
   var body: some View {
@@ -61,6 +86,7 @@ struct ConfirmTrimView: View {
       Text("Detection confidence: \(Int(candidate.detection.confidence * 100))%")
         .font(.footnote)
         .foregroundStyle(.secondary)
+      pieceCountSection
       Spacer()
       if model.flow.isBusy {
         ProgressView("Uploading puzzle…")
@@ -78,7 +104,10 @@ struct ConfirmTrimView: View {
           .controlSize(.large)
 
           Button {
-            Task { await model.acceptTrim(candidate, quarterTurns: quarterTurns) }
+            guard let pieceCount else { return }
+            Task {
+              await model.acceptTrim(candidate, quarterTurns: quarterTurns, pieceCount: pieceCount)
+            }
           } label: {
             Label("Use This", systemImage: "checkmark")
               .frame(maxWidth: .infinity)
@@ -88,8 +117,9 @@ struct ConfirmTrimView: View {
           // Gate on the cached preview (not the base64-decoding
           // `trimmedJPEG` computed property) so this doesn't re-decode
           // on every rotate tap and stays disabled exactly when the
-          // preview can't be shown.
-          .disabled(previewImage == nil)
+          // preview can't be shown — and on a valid piece count, since the
+          // grid estimate (and thus overlay marker sizing) depends on it.
+          .disabled(previewImage == nil || pieceCount == nil)
         }
       }
       if let error = model.flow.errorMessage {
@@ -100,5 +130,49 @@ struct ConfirmTrimView: View {
       }
     }
     .padding(24)
+  }
+
+  private var pieceCountSection: some View {
+    VStack(spacing: 10) {
+      Text("How many pieces?")
+        .font(.subheadline.bold())
+      ScrollView(.horizontal, showsIndicators: false) {
+        HStack(spacing: 8) {
+          ForEach(Self.pieceCountPresets, id: \.self) { preset in
+            Button {
+              pieceCountText = String(preset)
+              pieceCountFieldFocused = false
+            } label: {
+              Text("\(preset)")
+                .font(.subheadline.weight(.medium))
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(
+                  pieceCount == preset ? Color.accentColor : Color.secondary.opacity(0.15),
+                  in: Capsule()
+                )
+                .foregroundStyle(pieceCount == preset ? Color.white : Color.primary)
+            }
+            .buttonStyle(.plain)
+          }
+        }
+        .padding(.horizontal, 1)
+      }
+      TextField("Piece count (4–2000)", text: $pieceCountText)
+        .keyboardType(.numberPad)
+        .multilineTextAlignment(.center)
+        .textFieldStyle(.roundedBorder)
+        .focused($pieceCountFieldFocused)
+        .frame(maxWidth: 220)
+      if let grid = estimatedGrid, let pieceCount {
+        Text("\(pieceCount) pieces → \(grid.rows) × \(grid.cols) grid")
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+      } else if !pieceCountText.isEmpty {
+        Text("Enter a piece count between 4 and 2000.")
+          .font(.footnote)
+          .foregroundStyle(.red)
+      }
+    }
   }
 }

--- a/ios/Pussel/Features/Solve/PieceMarkerGeometry.swift
+++ b/ios/Pussel/Features/Solve/PieceMarkerGeometry.swift
@@ -1,0 +1,67 @@
+import CoreGraphics
+
+/// Pure sizing math for a solve-screen piece marker (`PuzzleOverlayView`'s
+/// `PieceMarker`), factored out so it's unit-testable without SwiftUI.
+enum PieceMarkerGeometry {
+  /// The cell-relative multiple a piece's SMALLER image dimension is scaled
+  /// to in the null-span fallback (see `size(span:imageSize:canvas:cellSize:rotation:)`).
+  /// A jigsaw piece's tabs/blanks make it span more than one bare grid
+  /// cell — real pieces overhang their cell by roughly this multiple along
+  /// their narrower axis.
+  static let fallbackMinCellSpan: CGFloat = 1.1
+
+  /// Returns the marker's frame size, in canvas points, *before*
+  /// `.rotationEffect` is applied.
+  ///
+  /// - Parameters:
+  ///   - span: the backend-measured full-image-frame span, or `nil` when
+  ///     unmeasured (CNN path / matcher failure).
+  ///   - imageSize: size of the *displayed* piece image. In the null-span
+  ///     fallback this should be the alpha-trimmed image (see
+  ///     `ImageUtilities.croppedToAlphaBounds`), so the backend's
+  ///     transparent margin doesn't inflate the marker.
+  ///   - canvas: the overlay's full drawing size (the trimmed puzzle
+  ///     image's rendered size).
+  ///   - cellSize: `canvas` divided by the puzzle's (cols, rows) — one grid
+  ///     cell's rendered size.
+  ///   - rotation: the piece's predicted rotation in degrees (0/90/180/270).
+  ///
+  /// When `span` is present, the frame is `canvas × span` directly, in the
+  /// displayed image's own (pre-rotation) axes — no cell-overhang factor
+  /// and no rotation swap, since the span already describes the full
+  /// displayed image frame and `.rotationEffect` handles orientation on
+  /// top. When `span` is `nil`, falls back to grid-based sizing: scale
+  /// `imageSize` uniformly so its smaller cell-relative dimension renders
+  /// at `fallbackMinCellSpan` cells, then swap width/height for a
+  /// 90°/270° rotation (cells are generally non-square, so the
+  /// pre-rotation, canvas-axis frame must swap when the image's own
+  /// width/height swap onto the canvas).
+  static func size(
+    span: PieceSpan?, imageSize: CGSize, canvas: CGSize, cellSize: CGSize, rotation: Int
+  ) -> CGSize {
+    if let span {
+      return CGSize(width: canvas.width * span.width, height: canvas.height * span.height)
+    }
+    return fallbackSize(imageSize: imageSize, cellSize: cellSize, rotation: rotation)
+  }
+
+  private static func fallbackSize(imageSize: CGSize, cellSize: CGSize, rotation: Int) -> CGSize {
+    guard imageSize.width > 0, imageSize.height > 0, cellSize.width > 0, cellSize.height > 0 else {
+      return CGSize(
+        width: cellSize.width * fallbackMinCellSpan, height: cellSize.height * fallbackMinCellSpan)
+    }
+    let imageWidthCells = imageSize.width / cellSize.width
+    let imageHeightCells = imageSize.height / cellSize.height
+    let scale = fallbackMinCellSpan / min(imageWidthCells, imageHeightCells)
+    var width = imageSize.width * scale
+    var height = imageSize.height * scale
+
+    // A 90°/270° rotation swaps how the piece's own width/height map onto
+    // the canvas axes, so the pre-rotation frame must swap too.
+    let turns = ((rotation / 90) % 4 + 4) % 4
+    if turns == 1 || turns == 3 {
+      swap(&width, &height)
+    }
+    return CGSize(width: width, height: height)
+  }
+}

--- a/ios/Pussel/Features/Solve/PuzzleOverlayView.swift
+++ b/ios/Pussel/Features/Solve/PuzzleOverlayView.swift
@@ -1,12 +1,10 @@
 import SwiftUI
 
-/// PIECE_SIZE_RATIO in puzzle-detail.tsx.
-private let pieceSizeRatio: CGFloat = 0.12
-
 /// The trimmed puzzle image with each predicted piece drawn at its normalized
-/// position. Mirrors frontend/src/components/puzzle/puzzle-detail.tsx:
-/// fixed piece size (12% of image dimensions), counter-clockwise rotation,
-/// confidence bar along the bottom edge.
+/// position. Mirrors frontend/src/components/puzzle/puzzle-detail.tsx, except
+/// marker size is derived from the session's estimated grid (rows/cols)
+/// rather than a fixed ratio of the image, so pieces mismatched to the actual
+/// grid density scale correctly.
 struct PuzzleOverlayView: View {
   let session: SolveSession
 
@@ -20,7 +18,7 @@ struct PuzzleOverlayView: View {
           GeometryReader { geo in
             ForEach(session.placedEntries) { entry in
               if let piece = entry.result {
-                PieceMarker(entry: entry, piece: piece, canvas: geo.size)
+                PieceMarker(entry: entry, piece: piece, canvas: geo.size, session: session)
               }
             }
           }
@@ -34,23 +32,39 @@ private struct PieceMarker: View {
   let entry: CaptureEntry
   let piece: PieceResponse
   let canvas: CGSize
+  let session: SolveSession
 
   var body: some View {
-    let width = canvas.width * pieceSizeRatio
-    let height = canvas.height * pieceSizeRatio
-    VStack(spacing: 0) {
-      if let image = UIImage(data: entry.displayImage) {
-        Image(uiImage: image)
+    let cellSize = CGSize(
+      width: canvas.width / CGFloat(session.cols), height: canvas.height / CGFloat(session.rows))
+    // The span (when present) describes the FULL displayed image frame,
+    // including the backend's transparent margin, so don't trim it there.
+    // In the null-span fallback, trim the margin from both display and
+    // aspect math so it doesn't inflate the marker.
+    let displayData = piece.pieceSpan == nil ? entry.trimmedDisplayImage : entry.displayImage
+    let displayImage = UIImage(data: displayData)
+    let markerSize = PieceMarkerGeometry.size(
+      span: piece.pieceSpan,
+      imageSize: displayImage?.size ?? cellSize,
+      canvas: canvas,
+      cellSize: cellSize,
+      rotation: piece.rotation
+    )
+    Group {
+      if let displayImage {
+        Image(uiImage: displayImage)
           .resizable()
           .scaledToFit()
           .frame(maxWidth: .infinity, maxHeight: .infinity)
       }
+    }
+    .frame(width: markerSize.width, height: markerSize.height)
+    .background(.black.opacity(0.25))
+    .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(.white, lineWidth: 1.5))
+    .overlay(alignment: .bottom) {
       ConfidenceBar(value: piece.positionConfidence)
         .frame(height: 4)
     }
-    .frame(width: width, height: height)
-    .background(.black.opacity(0.25))
-    .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(.white, lineWidth: 1.5))
     .rotationEffect(.degrees(-Double(piece.rotation)))
     .position(x: canvas.width * piece.position.x, y: canvas.height * piece.position.y)
   }

--- a/ios/Pussel/Models/PieceModels.swift
+++ b/ios/Pussel/Models/PieceModels.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+/// Normalized [0,1] fraction of the puzzle's width/height covered by the
+/// full piece image frame — the image as sent/displayed, in its own
+/// orientation (rotation NOT factored out). Present only when the backend
+/// matcher measured the piece (SIFT/NCC); nil for the CNN path or a matcher
+/// failure fallback.
+struct PieceSpan: Codable, Equatable {
+  let width: Double
+  let height: Double
+}
+
 /// Response of POST /api/v1/puzzle/{id}/piece.
 struct PieceResponse: Codable, Equatable {
   /// Predicted piece center, normalized to the trimmed puzzle image.
@@ -10,6 +20,9 @@ struct PieceResponse: Codable, Equatable {
   let rotationConfidence: Double
   /// data:image/png;base64,... with background removed, when available.
   let cleanedImage: String?
+  /// Measured size of the full piece image frame, when available. See
+  /// `PieceSpan`.
+  let pieceSpan: PieceSpan?
 }
 
 /// A captured piece moving through the prediction queue.
@@ -34,7 +47,19 @@ struct CaptureEntry: Identifiable, Equatable {
   /// JPEG sent to the backend; kept for retry.
   let uploadJPEG: Data
   /// Image shown in the UI — the raw capture until a cleaned PNG replaces it.
-  var displayImage: Data
+  /// `didSet` keeps `trimmedDisplayImage` in sync when the cleaned PNG
+  /// arrives (`SolveSession.process`); init assignments don't fire it, so
+  /// both inits set the trimmed copy explicitly.
+  var displayImage: Data {
+    didSet { trimmedDisplayImage = ImageUtilities.alphaTrimmedPNG(from: displayImage) }
+  }
+  /// `displayImage` cropped to its alpha bounding box, trimming the
+  /// backend's ~8% transparent margin around a cleaned piece PNG. Computed
+  /// once whenever `displayImage` changes, rather than per render —
+  /// PuzzleOverlayView reads it on every layout pass. Equal to
+  /// `displayImage` itself for images with no transparent margin to trim
+  /// (e.g. the raw JPEG capture before a cleaned PNG replaces it).
+  var trimmedDisplayImage: Data
   var status: Status = .queued
   var result: PieceResponse?
 
@@ -42,6 +67,7 @@ struct CaptureEntry: Identifiable, Equatable {
     self.id = UUID()
     self.uploadJPEG = jpeg
     self.displayImage = jpeg
+    self.trimmedDisplayImage = ImageUtilities.alphaTrimmedPNG(from: jpeg)
   }
 
   /// Rehydrates an entry loaded from disk (see PuzzleStore.loadSession).
@@ -49,6 +75,7 @@ struct CaptureEntry: Identifiable, Equatable {
     self.id = id
     self.uploadJPEG = uploadJPEG
     self.displayImage = displayImage
+    self.trimmedDisplayImage = ImageUtilities.alphaTrimmedPNG(from: displayImage)
     self.status = status
     self.result = result
   }

--- a/ios/Pussel/Models/PuzzleModels.swift
+++ b/ios/Pussel/Models/PuzzleModels.swift
@@ -25,4 +25,10 @@ struct DetectFrameResponse: Codable, Equatable {
 struct PuzzleUploadResponse: Codable, Equatable {
   let puzzleId: String
   let imageUrl: String?
+  /// Backend-computed grid, decoded for parity but not used for display —
+  /// the app always sizes the overlay from its own local `GridEstimator`
+  /// estimate (see `AppActions.acceptTrim`).
+  let pieceCount: Int?
+  let rows: Int?
+  let cols: Int?
 }

--- a/ios/Pussel/Networking/APIClient.swift
+++ b/ios/Pussel/Networking/APIClient.swift
@@ -46,9 +46,13 @@ final class APIClient {
     return try await sendDecoding(request)
   }
 
-  func uploadPuzzle(jpegData: Data) async throws -> PuzzleUploadResponse {
+  func uploadPuzzle(jpegData: Data, pieceCount: Int) async throws -> PuzzleUploadResponse {
     let request = makeMultipartRequest(
-      path: "api/v1/puzzle/upload", jpegData: jpegData, filename: "puzzle.jpg")
+      path: "api/v1/puzzle/upload",
+      jpegData: jpegData,
+      filename: "puzzle.jpg",
+      fields: ["piece_count": String(pieceCount)]
+    )
     return try await sendDecoding(request)
   }
 
@@ -67,7 +71,8 @@ final class APIClient {
   // MARK: - Request building & sending
 
   func makeMultipartRequest(
-    path: String, queryItems: [URLQueryItem] = [], jpegData: Data, filename: String
+    path: String, queryItems: [URLQueryItem] = [], jpegData: Data, filename: String,
+    fields: [String: String] = [:]
   )
     -> URLRequest
   {
@@ -76,6 +81,9 @@ final class APIClient {
       url.append(queryItems: queryItems)
     }
     var form = MultipartFormData()
+    for (name, value) in fields {
+      form.appendField(name: name, value: value)
+    }
     form.appendFile(name: "file", filename: filename, mimeType: "image/jpeg", data: jpegData)
     var request = URLRequest(url: url)
     request.httpMethod = "POST"

--- a/ios/Pussel/Persistence/PuzzleStore.swift
+++ b/ios/Pussel/Persistence/PuzzleStore.swift
@@ -10,6 +10,11 @@ struct PuzzleSummary: Identifiable, Equatable {
   let updatedAt: Date
   let pieceCount: Int
   let placedCount: Int
+  /// Total piece count entered by the user for this puzzle (distinct from
+  /// `pieceCount`, which counts captured pieces).
+  let targetPieceCount: Int
+  let rows: Int
+  let cols: Int
   /// Bytes of the small downsampled thumbnail (thumb.jpg), used as the card
   /// image — not the full-size trimmed puzzle JPEG.
   let thumbnail: Data?
@@ -25,6 +30,10 @@ private struct PuzzleManifest: Codable {
   let createdAt: Date
   var updatedAt: Date
   var pieces: [StoredPiece]
+  /// Total piece count entered by the user, and the grid estimated from it.
+  var pieceCount: Int
+  var rows: Int
+  var cols: Int
 }
 
 private struct StoredPiece: Codable {
@@ -38,6 +47,7 @@ private struct StoredResult: Codable {
   let positionConfidence: Double
   let rotation: Int
   let rotationConfidence: Double
+  let pieceSpan: PieceSpan?
 }
 
 /// Local, on-device persistence for solved/in-progress puzzles. Everything is
@@ -130,11 +140,15 @@ final class PuzzleStore {
               position: $0.position,
               positionConfidence: $0.positionConfidence,
               rotation: $0.rotation,
-              rotationConfidence: $0.rotationConfidence
+              rotationConfidence: $0.rotationConfidence,
+              pieceSpan: $0.pieceSpan
             )
           }
         )
-      }
+      },
+      pieceCount: session.pieceCount,
+      rows: session.rows,
+      cols: session.cols
     )
     do {
       let data = try encoder.encode(manifest)
@@ -159,6 +173,9 @@ final class PuzzleStore {
         // Counts reflect what was persisted, matching the manifest.
         pieceCount: persistedEntries.count,
         placedCount: persistedEntries.filter { $0.result != nil }.count,
+        targetPieceCount: session.pieceCount,
+        rows: session.rows,
+        cols: session.cols,
         thumbnail: thumbnailData
       )
     )
@@ -204,6 +221,9 @@ final class PuzzleStore {
       name: manifest.name,
       puzzleId: manifest.serverPuzzleId,
       trimmedJPEG: trimmed,
+      pieceCount: manifest.pieceCount,
+      rows: manifest.rows,
+      cols: manifest.cols,
       createdAt: manifest.createdAt,
       store: self
     )
@@ -216,7 +236,8 @@ final class PuzzleStore {
           positionConfidence: $0.positionConfidence,
           rotation: $0.rotation,
           rotationConfidence: $0.rotationConfidence,
-          cleanedImage: nil
+          cleanedImage: nil,
+          pieceSpan: $0.pieceSpan
         )
       }
       return CaptureEntry(
@@ -268,6 +289,9 @@ final class PuzzleStore {
         updatedAt: manifest.updatedAt,
         pieceCount: manifest.pieces.count,
         placedCount: manifest.pieces.filter { $0.result != nil }.count,
+        targetPieceCount: manifest.pieceCount,
+        rows: manifest.rows,
+        cols: manifest.cols,
         thumbnail: thumbnail
       )
     }

--- a/ios/Pussel/Support/DebugNavigation.swift
+++ b/ios/Pussel/Support/DebugNavigation.swift
@@ -7,7 +7,7 @@
   /// promptless path is a Darwin notification plus a command file:
   ///   echo "pusseldebug://trim?puzzle=/host/path.jpg" > /tmp/pussel-debug-command
   ///   xcrun simctl spawn booted notifyutil -p dk.delectosoft.pussel.debug
-  /// Commands: trim?puzzle=, accept, piece?path=, reupload, reset,
+  /// Commands: trim?puzzle=, accept[?pieces=], piece?path=, reupload, reset,
   ///   open?index=, delete?index= (index into the saved-puzzles list).
   /// Simulator apps can read host file paths directly. Compiled out of
   /// Release builds; the handler runs the same actions as the real UI.
@@ -72,7 +72,7 @@
       case "trim":
         await debugTrim(path: value("puzzle"))
       case "accept":
-        await debugAccept()
+        await debugAccept(pieces: value("pieces"))
       case "piece":
         debugAddPiece(path: value("path"))
       case "reupload":
@@ -92,9 +92,12 @@
       }
     }
 
-    private func debugAccept() async {
+    /// `pieces` is an optional `?pieces=<n>` query value; the debug driver
+    /// has no UI to enter a count, so it defaults to a plausible test value.
+    private func debugAccept(pieces: String?) async {
       if case .confirmTrim(let candidate) = flow.phase {
-        await acceptTrim(candidate)
+        let pieceCount = pieces.flatMap(Int.init) ?? 100
+        await acceptTrim(candidate, pieceCount: pieceCount)
       }
     }
 

--- a/ios/Pussel/Support/GridEstimator.swift
+++ b/ios/Pussel/Support/GridEstimator.swift
@@ -1,0 +1,53 @@
+import CoreGraphics
+import Foundation
+
+/// Estimates a puzzle's (rows, cols) grid from a target piece count and the
+/// image's aspect ratio. Exact port of `calculate_grid_dimensions` in
+/// shared/puzzle_shapes/puzzle_shapes/edge_grid.py:60-110 — keep both in sync.
+enum GridEstimator {
+  /// Returns the estimated (rows, cols) grid for `pieceCount` pieces spread
+  /// over an image of `imageWidth` × `imageHeight`.
+  ///
+  /// Mirrors the Python reference candidate-by-candidate: `Int(...)` on a
+  /// positive `Double` truncates toward zero just like Python's `int()`, and
+  /// candidates are scored in the same (rows-floor, rows-floor+1) ×
+  /// (cols-floor, cols-floor+1) order, keeping the *first* maximal-score
+  /// candidate (Python's `max()` returns the first maximum) by only
+  /// replacing the best on a *strictly greater* score.
+  static func estimate(pieceCount: Int, imageWidth: CGFloat, imageHeight: CGFloat) -> (
+    rows: Int, cols: Int
+  ) {
+    guard pieceCount >= 4 else { return (2, 2) }
+
+    let aspectRatio = Double(imageWidth) / Double(imageHeight)
+    let targetPieces = Double(pieceCount)
+    let colsFloat = (targetPieces * aspectRatio).squareRoot()
+    let rowsFloat = (targetPieces / aspectRatio).squareRoot()
+
+    let rowChoices = [max(2, Int(rowsFloat)), max(2, Int(rowsFloat) + 1)]
+    let colChoices = [max(2, Int(colsFloat)), max(2, Int(colsFloat) + 1)]
+
+    var bestRows = rowChoices[0]
+    var bestCols = colChoices[0]
+    var bestScore = -Double.infinity
+
+    for rows in rowChoices {
+      for cols in colChoices {
+        let count = rows * cols
+        let pieceWidth = Double(imageWidth) / Double(cols)
+        let pieceHeight = Double(imageHeight) / Double(rows)
+        let pieceAspectRatio = pieceWidth / pieceHeight
+        let squareness = min(pieceAspectRatio, 1 / pieceAspectRatio)
+        let countDiff = abs(Double(count) - targetPieces) / targetPieces
+        let score = squareness - countDiff * 0.5
+        if score > bestScore {
+          bestScore = score
+          bestRows = rows
+          bestCols = cols
+        }
+      }
+    }
+
+    return (bestRows, bestCols)
+  }
+}

--- a/ios/Pussel/Support/ImageUtilities.swift
+++ b/ios/Pussel/Support/ImageUtilities.swift
@@ -118,4 +118,98 @@ enum ImageUtilities {
     }
     return Data(base64Encoded: String(string[string.index(after: comma)...]))
   }
+
+  // MARK: Alpha trimming
+
+  /// Returns the smallest pixel-space rect containing every pixel whose
+  /// alpha exceeds `threshold` (0...255), or `nil` when `image` is empty or
+  /// every pixel is at/below the threshold (fully transparent). Works in
+  /// `image`'s own `cgImage` pixel space, so it assumes `.up` orientation —
+  /// true for the images this app feeds it (backend-generated PNGs and
+  /// already-baked captures; see `rotated(_:quarterTurns:)`).
+  ///
+  /// The default threshold is high because segmentation mattes (rembg) can
+  /// leave a faint alpha halo of background across the frame; counting those
+  /// pixels would inflate the box to well beyond the actual subject.
+  static func alphaBoundingBox(of image: UIImage, threshold: UInt8 = 128) -> CGRect? {
+    guard let cgImage = image.cgImage, cgImage.width > 0, cgImage.height > 0 else { return nil }
+    guard let pixels = rgbaPixels(of: cgImage) else { return nil }
+    return opaqueBounds(
+      in: pixels, width: cgImage.width, height: cgImage.height, threshold: threshold)
+  }
+
+  /// Renders `cgImage` into a top-left-origin RGBA8 buffer the same pixel
+  /// size as the image, so alpha can be read byte-by-byte.
+  private static func rgbaPixels(of cgImage: CGImage) -> [UInt8]? {
+    let width = cgImage.width
+    let height = cgImage.height
+    let bytesPerRow = 4 * width
+    var pixels = [UInt8](repeating: 0, count: height * bytesPerRow)
+    guard
+      let context = CGContext(
+        data: &pixels,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: bytesPerRow,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+    else { return nil }
+    context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+    return pixels
+  }
+
+  /// Scans an RGBA8 `pixels` buffer for the smallest rect containing every
+  /// pixel whose alpha exceeds `threshold`, or `nil` when none does.
+  private static func opaqueBounds(in pixels: [UInt8], width: Int, height: Int, threshold: UInt8)
+    -> CGRect?
+  {
+    let bytesPerRow = 4 * width
+    var minX = width
+    var minY = height
+    var maxX = -1
+    var maxY = -1
+    for y in 0..<height {
+      let rowStart = y * bytesPerRow
+      for x in 0..<width where pixels[rowStart + x * 4 + 3] > threshold {
+        minX = min(minX, x)
+        maxX = max(maxX, x)
+        minY = min(minY, y)
+        maxY = max(maxY, y)
+      }
+    }
+    guard maxX >= minX, maxY >= minY else { return nil }
+    return CGRect(x: minX, y: minY, width: maxX - minX + 1, height: maxY - minY + 1)
+  }
+
+  /// Crops `image` to its alpha bounding box (see `alphaBoundingBox`),
+  /// trimming a transparent margin such as the backend's cleaned piece
+  /// PNGs. Returns `image` itself (same instance) when there is no alpha
+  /// bbox, or it already covers the whole image, so callers can cheaply
+  /// detect "nothing to trim" via reference identity.
+  static func croppedToAlphaBounds(_ image: UIImage) -> UIImage {
+    guard let cgImage = image.cgImage,
+      let bbox = alphaBoundingBox(of: image),
+      bbox.width > 0, bbox.height > 0,
+      Int(bbox.width) < cgImage.width || Int(bbox.height) < cgImage.height
+    else {
+      return image
+    }
+    guard let cropped = cgImage.cropping(to: bbox) else { return image }
+    return UIImage(cgImage: cropped, scale: image.scale, orientation: image.imageOrientation)
+  }
+
+  private static let pngSignature: [UInt8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+
+  /// Crops PNG `data` to its alpha bounding box and re-encodes as PNG.
+  /// Returns `data` unchanged when it isn't PNG (a raw JPEG capture has no
+  /// alpha channel at all, so skip the decode+scan entirely — cheap
+  /// signature check), can't be decoded, or has no transparent margin to
+  /// trim.
+  static func alphaTrimmedPNG(from data: Data) -> Data {
+    guard data.starts(with: pngSignature), let image = UIImage(data: data) else { return data }
+    let cropped = croppedToAlphaBounds(image)
+    guard cropped !== image, let pngData = cropped.pngData() else { return data }
+    return pngData
+  }
 }

--- a/ios/Pussel/Support/ImageUtilities.swift
+++ b/ios/Pussel/Support/ImageUtilities.swift
@@ -153,7 +153,10 @@ enum ImageUtilities {
         bitsPerComponent: 8,
         bytesPerRow: bytesPerRow,
         space: CGColorSpaceCreateDeviceRGB(),
-        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        // Explicit big-endian byte order pins the memory layout to R,G,B,A
+        // regardless of host endianness, so index 3 is always alpha.
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+          | CGBitmapInfo.byteOrder32Big.rawValue)
     else { return nil }
     context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
     return pixels

--- a/ios/PusselTests/APIClientTests.swift
+++ b/ios/PusselTests/APIClientTests.swift
@@ -83,12 +83,25 @@ final class APIClientTests: XCTestCase {
     XCTAssertTrue(body.contains("Content-Type: image/jpeg"))
   }
 
+  func testMultipartRequestBuildingIncludesTextFields() throws {
+    let request = client.makeMultipartRequest(
+      path: "api/v1/puzzle/upload",
+      jpegData: Data("JPEG".utf8),
+      filename: "puzzle.jpg",
+      fields: ["piece_count": "500"]
+    )
+    let body = try XCTUnwrap(String(bytes: request.httpBody ?? Data(), encoding: .utf8))
+    XCTAssertTrue(
+      body.contains("Content-Disposition: form-data; name=\"piece_count\"\r\n\r\n500\r\n"))
+    XCTAssertTrue(body.contains("name=\"file\"; filename=\"puzzle.jpg\""))
+  }
+
   func testAuthorizationHeaderAttached() async throws {
     authStore.backendToken = "token123"
     StubURLProtocol.handler = { _ in
       (200, Data(#"{"puzzle_id": "p1", "image_url": null}"#.utf8))
     }
-    _ = try await client.uploadPuzzle(jpegData: Data("JPEG".utf8))
+    _ = try await client.uploadPuzzle(jpegData: Data("JPEG".utf8), pieceCount: 48)
     let auth = StubURLProtocol.receivedRequests.first?.value(forHTTPHeaderField: "Authorization")
     XCTAssertEqual(auth, "Bearer token123")
   }
@@ -120,7 +133,7 @@ final class APIClientTests: XCTestCase {
       authStore?.backendToken = "fresh"
       return true
     }
-    let response = try await client.uploadPuzzle(jpegData: Data("J".utf8))
+    let response = try await client.uploadPuzzle(jpegData: Data("J".utf8), pieceCount: 48)
     XCTAssertEqual(response.puzzleId, "p2")
     // The lock-guarded request log stands in for a hand-rolled counter,
     // which would race with URLSession's internal threads.
@@ -133,7 +146,7 @@ final class APIClientTests: XCTestCase {
       (401, Data(#"{"detail": "Invalid or expired token"}"#.utf8))
     }
     do {
-      _ = try await client.uploadPuzzle(jpegData: Data("J".utf8))
+      _ = try await client.uploadPuzzle(jpegData: Data("J".utf8), pieceCount: 48)
       XCTFail("Expected APIError")
     } catch let error as APIError {
       XCTAssertEqual(error.status, 401)

--- a/ios/PusselTests/GridEstimatorTests.swift
+++ b/ios/PusselTests/GridEstimatorTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+
+@testable import Pussel
+
+/// One (image size, piece count) → expected (rows, cols) case generated from
+/// the Python reference implementation.
+private struct GridVector {
+  let width: Int
+  let height: Int
+  let pieces: Int
+  let expectedRows: Int
+  let expectedCols: Int
+}
+
+/// Parity tests against `calculate_grid_dimensions` in
+/// shared/puzzle_shapes/puzzle_shapes/edge_grid.py:60-110.
+final class GridEstimatorTests: XCTestCase {
+  func testBelowFourPiecesAlwaysReturnsTwoByTwo() {
+    for pieces in [0, 1, 2, 3] {
+      let result = GridEstimator.estimate(pieceCount: pieces, imageWidth: 1234, imageHeight: 567)
+      XCTAssertEqual(result.rows, 2, "pieces=\(pieces)")
+      XCTAssertEqual(result.cols, 2, "pieces=\(pieces)")
+    }
+  }
+
+  /// 114 vectors generated from the Python reference implementation.
+  private static let vectors: [GridVector] = [
+    GridVector(width: 1000, height: 1000, pieces: 4, expectedRows: 2, expectedCols: 2),
+    GridVector(width: 1000, height: 1000, pieces: 6, expectedRows: 2, expectedCols: 2),
+    GridVector(width: 1000, height: 1000, pieces: 9, expectedRows: 3, expectedCols: 3),
+    GridVector(width: 1000, height: 1000, pieces: 12, expectedRows: 3, expectedCols: 3),
+    GridVector(width: 1000, height: 1000, pieces: 16, expectedRows: 4, expectedCols: 4),
+    GridVector(width: 1000, height: 1000, pieces: 20, expectedRows: 4, expectedCols: 4),
+    GridVector(width: 1000, height: 1000, pieces: 24, expectedRows: 5, expectedCols: 5),
+    GridVector(width: 1000, height: 1000, pieces: 25, expectedRows: 5, expectedCols: 5),
+    GridVector(width: 1000, height: 1000, pieces: 30, expectedRows: 5, expectedCols: 5),
+    GridVector(width: 1000, height: 1000, pieces: 35, expectedRows: 6, expectedCols: 6),
+    GridVector(width: 1000, height: 1000, pieces: 48, expectedRows: 7, expectedCols: 7),
+    GridVector(width: 1000, height: 1000, pieces: 54, expectedRows: 7, expectedCols: 7),
+    GridVector(width: 1000, height: 1000, pieces: 100, expectedRows: 10, expectedCols: 10),
+    GridVector(width: 1000, height: 1000, pieces: 204, expectedRows: 14, expectedCols: 14),
+    GridVector(width: 1000, height: 1000, pieces: 300, expectedRows: 17, expectedCols: 17),
+    GridVector(width: 1000, height: 1000, pieces: 500, expectedRows: 22, expectedCols: 22),
+    GridVector(width: 1000, height: 1000, pieces: 1000, expectedRows: 32, expectedCols: 32),
+    GridVector(width: 1000, height: 1000, pieces: 1500, expectedRows: 39, expectedCols: 39),
+    GridVector(width: 1000, height: 1000, pieces: 2000, expectedRows: 45, expectedCols: 45),
+    GridVector(width: 1200, height: 900, pieces: 4, expectedRows: 2, expectedCols: 2),
+    GridVector(width: 1200, height: 900, pieces: 6, expectedRows: 2, expectedCols: 3),
+    GridVector(width: 1200, height: 900, pieces: 9, expectedRows: 3, expectedCols: 4),
+    GridVector(width: 1200, height: 900, pieces: 12, expectedRows: 3, expectedCols: 4),
+    GridVector(width: 1200, height: 900, pieces: 16, expectedRows: 3, expectedCols: 4),
+    GridVector(width: 1200, height: 900, pieces: 20, expectedRows: 4, expectedCols: 5),
+    GridVector(width: 1200, height: 900, pieces: 24, expectedRows: 4, expectedCols: 6),
+    GridVector(width: 1200, height: 900, pieces: 25, expectedRows: 4, expectedCols: 6),
+    GridVector(width: 1200, height: 900, pieces: 30, expectedRows: 5, expectedCols: 6),
+    GridVector(width: 1200, height: 900, pieces: 35, expectedRows: 5, expectedCols: 7),
+    GridVector(width: 1200, height: 900, pieces: 48, expectedRows: 6, expectedCols: 8),
+    GridVector(width: 1200, height: 900, pieces: 54, expectedRows: 6, expectedCols: 8),
+    GridVector(width: 1200, height: 900, pieces: 100, expectedRows: 9, expectedCols: 12),
+    GridVector(width: 1200, height: 900, pieces: 204, expectedRows: 12, expectedCols: 16),
+    GridVector(width: 1200, height: 900, pieces: 300, expectedRows: 15, expectedCols: 20),
+    GridVector(width: 1200, height: 900, pieces: 500, expectedRows: 19, expectedCols: 26),
+    GridVector(width: 1200, height: 900, pieces: 1000, expectedRows: 27, expectedCols: 36),
+    GridVector(width: 1200, height: 900, pieces: 1500, expectedRows: 33, expectedCols: 44),
+    GridVector(width: 1200, height: 900, pieces: 2000, expectedRows: 39, expectedCols: 52),
+    GridVector(width: 1500, height: 1000, pieces: 4, expectedRows: 2, expectedCols: 3),
+    GridVector(width: 1500, height: 1000, pieces: 6, expectedRows: 2, expectedCols: 3),
+    GridVector(width: 1500, height: 1000, pieces: 9, expectedRows: 2, expectedCols: 3),
+    GridVector(width: 1500, height: 1000, pieces: 12, expectedRows: 3, expectedCols: 4),
+    GridVector(width: 1500, height: 1000, pieces: 16, expectedRows: 3, expectedCols: 5),
+    GridVector(width: 1500, height: 1000, pieces: 20, expectedRows: 4, expectedCols: 6),
+    GridVector(width: 1500, height: 1000, pieces: 24, expectedRows: 4, expectedCols: 6),
+    GridVector(width: 1500, height: 1000, pieces: 25, expectedRows: 4, expectedCols: 6),
+    GridVector(width: 1500, height: 1000, pieces: 30, expectedRows: 4, expectedCols: 6),
+    GridVector(width: 1500, height: 1000, pieces: 35, expectedRows: 5, expectedCols: 7),
+    GridVector(width: 1500, height: 1000, pieces: 48, expectedRows: 6, expectedCols: 9),
+    GridVector(width: 1500, height: 1000, pieces: 54, expectedRows: 6, expectedCols: 9),
+    GridVector(width: 1500, height: 1000, pieces: 100, expectedRows: 8, expectedCols: 12),
+    GridVector(width: 1500, height: 1000, pieces: 204, expectedRows: 12, expectedCols: 18),
+    GridVector(width: 1500, height: 1000, pieces: 300, expectedRows: 14, expectedCols: 21),
+    GridVector(width: 1500, height: 1000, pieces: 500, expectedRows: 18, expectedCols: 27),
+    GridVector(width: 1500, height: 1000, pieces: 1000, expectedRows: 26, expectedCols: 39),
+    GridVector(width: 1500, height: 1000, pieces: 1500, expectedRows: 32, expectedCols: 48),
+    GridVector(width: 1500, height: 1000, pieces: 2000, expectedRows: 36, expectedCols: 54),
+    GridVector(width: 900, height: 1200, pieces: 4, expectedRows: 2, expectedCols: 2),
+    GridVector(width: 900, height: 1200, pieces: 6, expectedRows: 3, expectedCols: 2),
+    GridVector(width: 900, height: 1200, pieces: 9, expectedRows: 4, expectedCols: 3),
+    GridVector(width: 900, height: 1200, pieces: 12, expectedRows: 4, expectedCols: 3),
+    GridVector(width: 900, height: 1200, pieces: 16, expectedRows: 4, expectedCols: 3),
+    GridVector(width: 900, height: 1200, pieces: 20, expectedRows: 5, expectedCols: 4),
+    GridVector(width: 900, height: 1200, pieces: 24, expectedRows: 6, expectedCols: 4),
+    GridVector(width: 900, height: 1200, pieces: 25, expectedRows: 6, expectedCols: 4),
+    GridVector(width: 900, height: 1200, pieces: 30, expectedRows: 6, expectedCols: 5),
+    GridVector(width: 900, height: 1200, pieces: 35, expectedRows: 7, expectedCols: 5),
+    GridVector(width: 900, height: 1200, pieces: 48, expectedRows: 8, expectedCols: 6),
+    GridVector(width: 900, height: 1200, pieces: 54, expectedRows: 8, expectedCols: 6),
+    GridVector(width: 900, height: 1200, pieces: 100, expectedRows: 12, expectedCols: 9),
+    GridVector(width: 900, height: 1200, pieces: 204, expectedRows: 16, expectedCols: 12),
+    GridVector(width: 900, height: 1200, pieces: 300, expectedRows: 20, expectedCols: 15),
+    GridVector(width: 900, height: 1200, pieces: 500, expectedRows: 26, expectedCols: 19),
+    GridVector(width: 900, height: 1200, pieces: 1000, expectedRows: 36, expectedCols: 27),
+    GridVector(width: 900, height: 1200, pieces: 1500, expectedRows: 44, expectedCols: 33),
+    GridVector(width: 900, height: 1200, pieces: 2000, expectedRows: 52, expectedCols: 39),
+    GridVector(width: 1000, height: 1500, pieces: 4, expectedRows: 3, expectedCols: 2),
+    GridVector(width: 1000, height: 1500, pieces: 6, expectedRows: 3, expectedCols: 2),
+    GridVector(width: 1000, height: 1500, pieces: 9, expectedRows: 3, expectedCols: 2),
+    GridVector(width: 1000, height: 1500, pieces: 12, expectedRows: 4, expectedCols: 3),
+    GridVector(width: 1000, height: 1500, pieces: 16, expectedRows: 5, expectedCols: 3),
+    GridVector(width: 1000, height: 1500, pieces: 20, expectedRows: 6, expectedCols: 4),
+    GridVector(width: 1000, height: 1500, pieces: 24, expectedRows: 6, expectedCols: 4),
+    GridVector(width: 1000, height: 1500, pieces: 25, expectedRows: 6, expectedCols: 4),
+    GridVector(width: 1000, height: 1500, pieces: 30, expectedRows: 6, expectedCols: 4),
+    GridVector(width: 1000, height: 1500, pieces: 35, expectedRows: 7, expectedCols: 5),
+    GridVector(width: 1000, height: 1500, pieces: 48, expectedRows: 9, expectedCols: 6),
+    GridVector(width: 1000, height: 1500, pieces: 54, expectedRows: 9, expectedCols: 6),
+    GridVector(width: 1000, height: 1500, pieces: 100, expectedRows: 12, expectedCols: 8),
+    GridVector(width: 1000, height: 1500, pieces: 204, expectedRows: 18, expectedCols: 12),
+    GridVector(width: 1000, height: 1500, pieces: 300, expectedRows: 21, expectedCols: 14),
+    GridVector(width: 1000, height: 1500, pieces: 500, expectedRows: 27, expectedCols: 18),
+    GridVector(width: 1000, height: 1500, pieces: 1000, expectedRows: 39, expectedCols: 26),
+    GridVector(width: 1000, height: 1500, pieces: 1500, expectedRows: 48, expectedCols: 32),
+    GridVector(width: 1000, height: 1500, pieces: 2000, expectedRows: 54, expectedCols: 36),
+    GridVector(width: 1600, height: 900, pieces: 4, expectedRows: 2, expectedCols: 3),
+    GridVector(width: 1600, height: 900, pieces: 6, expectedRows: 2, expectedCols: 3),
+    GridVector(width: 1600, height: 900, pieces: 9, expectedRows: 2, expectedCols: 4),
+    GridVector(width: 1600, height: 900, pieces: 12, expectedRows: 3, expectedCols: 5),
+    GridVector(width: 1600, height: 900, pieces: 16, expectedRows: 3, expectedCols: 5),
+    GridVector(width: 1600, height: 900, pieces: 20, expectedRows: 3, expectedCols: 6),
+    GridVector(width: 1600, height: 900, pieces: 24, expectedRows: 4, expectedCols: 7),
+    GridVector(width: 1600, height: 900, pieces: 25, expectedRows: 4, expectedCols: 7),
+    GridVector(width: 1600, height: 900, pieces: 30, expectedRows: 4, expectedCols: 7),
+    GridVector(width: 1600, height: 900, pieces: 35, expectedRows: 4, expectedCols: 7),
+    GridVector(width: 1600, height: 900, pieces: 48, expectedRows: 5, expectedCols: 9),
+    GridVector(width: 1600, height: 900, pieces: 54, expectedRows: 5, expectedCols: 9),
+    GridVector(width: 1600, height: 900, pieces: 100, expectedRows: 8, expectedCols: 14),
+    GridVector(width: 1600, height: 900, pieces: 204, expectedRows: 11, expectedCols: 19),
+    GridVector(width: 1600, height: 900, pieces: 300, expectedRows: 13, expectedCols: 23),
+    GridVector(width: 1600, height: 900, pieces: 500, expectedRows: 17, expectedCols: 30),
+    GridVector(width: 1600, height: 900, pieces: 1000, expectedRows: 24, expectedCols: 42),
+    GridVector(width: 1600, height: 900, pieces: 1500, expectedRows: 29, expectedCols: 52),
+    GridVector(width: 1600, height: 900, pieces: 2000, expectedRows: 34, expectedCols: 60),
+  ]
+
+  func testParityAgainstPythonReference() {
+    for vector in Self.vectors {
+      let result = GridEstimator.estimate(
+        pieceCount: vector.pieces, imageWidth: CGFloat(vector.width),
+        imageHeight: CGFloat(vector.height))
+      let label = "\(vector.width)x\(vector.height) pieces=\(vector.pieces)"
+      XCTAssertEqual(result.rows, vector.expectedRows, "rows mismatch for \(label): got \(result)")
+      XCTAssertEqual(result.cols, vector.expectedCols, "cols mismatch for \(label): got \(result)")
+    }
+  }
+}

--- a/ios/PusselTests/ImageUtilitiesTests.swift
+++ b/ios/PusselTests/ImageUtilitiesTests.swift
@@ -71,4 +71,97 @@ final class ImageUtilitiesTests: XCTestCase {
     XCTAssertEqual(decoded.size.width * decoded.scale, 4)
     XCTAssertEqual(decoded.size.height * decoded.scale, 8)
   }
+
+  // MARK: alphaBoundingBox(of:) / croppedToAlphaBounds(_:) / alphaTrimmedPNG(from:)
+
+  /// A 20x20 transparent image with a 10x10 opaque red square centered at
+  /// (5, 5)...(14, 14) — mirrors the backend's cleaned piece PNGs, which
+  /// have a transparent margin around the actual piece.
+  private func makeImageWithTransparentBorder() -> UIImage {
+    let size = CGSize(width: 20, height: 20)
+    let format = UIGraphicsImageRendererFormat()
+    format.opaque = false
+    format.scale = 1
+    return UIGraphicsImageRenderer(size: size, format: format).image { context in
+      UIColor.clear.setFill()
+      context.fill(CGRect(origin: .zero, size: size))
+      UIColor.red.setFill()
+      context.fill(CGRect(x: 5, y: 5, width: 10, height: 10))
+    }
+  }
+
+  private func makeFullyTransparentImage(width: Int = 10, height: Int = 10) -> UIImage {
+    let size = CGSize(width: width, height: height)
+    let format = UIGraphicsImageRendererFormat()
+    format.opaque = false
+    format.scale = 1
+    return UIGraphicsImageRenderer(size: size, format: format).image { context in
+      UIColor.clear.setFill()
+      context.fill(CGRect(origin: .zero, size: size))
+    }
+  }
+
+  func testAlphaBoundingBoxFindsOpaqueRegion() throws {
+    let bbox = try XCTUnwrap(ImageUtilities.alphaBoundingBox(of: makeImageWithTransparentBorder()))
+    XCTAssertEqual(bbox, CGRect(x: 5, y: 5, width: 10, height: 10))
+  }
+
+  func testAlphaBoundingBoxNilForFullyTransparentImage() {
+    XCTAssertNil(ImageUtilities.alphaBoundingBox(of: makeFullyTransparentImage()))
+  }
+
+  func testAlphaBoundingBoxCoversWholeImageWhenFullyOpaque() throws {
+    let image = makeImage(width: 8, height: 4)
+    let bbox = try XCTUnwrap(ImageUtilities.alphaBoundingBox(of: image))
+    XCTAssertEqual(bbox, CGRect(x: 0, y: 0, width: 8, height: 4))
+  }
+
+  func testCroppedToAlphaBoundsTrimsTransparentMargin() {
+    let cropped = ImageUtilities.croppedToAlphaBounds(makeImageWithTransparentBorder())
+    XCTAssertEqual(cropped.size, CGSize(width: 10, height: 10))
+  }
+
+  func testCroppedToAlphaBoundsReturnsSameInstanceWhenFullyOpaque() {
+    let image = makeImage(width: 8, height: 4)
+    XCTAssertIdentical(ImageUtilities.croppedToAlphaBounds(image), image)
+  }
+
+  func testAlphaTrimmedPNGTrimsTransparentMargin() throws {
+    let data = try XCTUnwrap(makeImageWithTransparentBorder().pngData())
+    let trimmed = ImageUtilities.alphaTrimmedPNG(from: data)
+    let decoded = try XCTUnwrap(UIImage(data: trimmed))
+    XCTAssertEqual(decoded.size, CGSize(width: 10, height: 10))
+  }
+
+  /// Regression: when the backend's cleaned PNG replaces `displayImage`
+  /// mid-session (SolveSession.process), the overlay's pre-trimmed copy must
+  /// refresh too — it used to keep the raw capture's (untrimmable) bytes.
+  func testCaptureEntryRetrimsWhenDisplayImageChanges() throws {
+    var entry = CaptureEntry(jpeg: Data("fake jpeg".utf8))
+    XCTAssertEqual(entry.trimmedDisplayImage, Data("fake jpeg".utf8))
+
+    let cleaned = try XCTUnwrap(makeImageWithTransparentBorder().pngData())
+    entry.displayImage = cleaned
+
+    let decoded = try XCTUnwrap(UIImage(data: entry.trimmedDisplayImage))
+    XCTAssertEqual(decoded.size, CGSize(width: 10, height: 10))
+  }
+
+  func testAlphaTrimmedPNGReturnsInputUnchangedForNonPNGData() {
+    let data = Data("not a png".utf8)
+    XCTAssertEqual(ImageUtilities.alphaTrimmedPNG(from: data), data)
+  }
+
+  func testAlphaTrimmedPNGReturnsInputUnchangedWhenFullyOpaque() throws {
+    let size = CGSize(width: 8, height: 4)
+    let format = UIGraphicsImageRendererFormat()
+    format.opaque = false
+    format.scale = 1
+    let image = UIGraphicsImageRenderer(size: size, format: format).image { context in
+      UIColor.red.setFill()
+      context.fill(CGRect(origin: .zero, size: size))
+    }
+    let data = try XCTUnwrap(image.pngData())
+    XCTAssertEqual(ImageUtilities.alphaTrimmedPNG(from: data), data)
+  }
 }

--- a/ios/PusselTests/ImageUtilitiesTests.swift
+++ b/ios/PusselTests/ImageUtilitiesTests.swift
@@ -106,6 +106,25 @@ final class ImageUtilitiesTests: XCTestCase {
     XCTAssertEqual(bbox, CGRect(x: 5, y: 5, width: 10, height: 10))
   }
 
+  /// Opaque BLACK content (all color bytes 0, only alpha 255) placed
+  /// off-center in a non-square canvas: fails if the buffer scan reads a
+  /// color byte instead of alpha (channel-order regression) or if rows are
+  /// vertically flipped relative to CGImage pixel space.
+  func testAlphaBoundingBoxScansAlphaChannelNotColor() throws {
+    let size = CGSize(width: 20, height: 30)
+    let format = UIGraphicsImageRendererFormat()
+    format.opaque = false
+    format.scale = 1
+    let image = UIGraphicsImageRenderer(size: size, format: format).image { context in
+      UIColor.clear.setFill()
+      context.fill(CGRect(origin: .zero, size: size))
+      UIColor.black.setFill()
+      context.fill(CGRect(x: 2, y: 3, width: 5, height: 7))
+    }
+    let bbox = try XCTUnwrap(ImageUtilities.alphaBoundingBox(of: image))
+    XCTAssertEqual(bbox, CGRect(x: 2, y: 3, width: 5, height: 7))
+  }
+
   func testAlphaBoundingBoxNilForFullyTransparentImage() {
     XCTAssertNil(ImageUtilities.alphaBoundingBox(of: makeFullyTransparentImage()))
   }

--- a/ios/PusselTests/ModelDecodingTests.swift
+++ b/ios/PusselTests/ModelDecodingTests.swift
@@ -60,6 +60,19 @@ final class ModelDecodingTests: XCTestCase {
     let response = try decoder.decode(PuzzleUploadResponse.self, from: Data(json.utf8))
     XCTAssertEqual(response.puzzleId, "3f2b9c")
     XCTAssertNil(response.imageUrl)
+    XCTAssertNil(response.pieceCount)
+    XCTAssertNil(response.rows)
+    XCTAssertNil(response.cols)
+  }
+
+  func testDecodePuzzleUploadResponseWithGrid() throws {
+    let json = """
+      {"puzzle_id": "3f2b9c", "image_url": null, "piece_count": 500, "rows": 22, "cols": 22}
+      """
+    let response = try decoder.decode(PuzzleUploadResponse.self, from: Data(json.utf8))
+    XCTAssertEqual(response.pieceCount, 500)
+    XCTAssertEqual(response.rows, 22)
+    XCTAssertEqual(response.cols, 22)
   }
 
   func testDecodePieceResponse() throws {
@@ -91,6 +104,36 @@ final class ModelDecodingTests: XCTestCase {
       """
     let response = try decoder.decode(PieceResponse.self, from: Data(json.utf8))
     XCTAssertNil(response.cleanedImage)
+  }
+
+  func testDecodePieceResponseWithPieceSpan() throws {
+    let json = """
+      {
+        "position": {"x": 0.25, "y": 0.75},
+        "position_confidence": 0.91,
+        "rotation": 270,
+        "rotation_confidence": 0.66,
+        "cleaned_image": null,
+        "piece_span": {"width": 0.34, "height": 0.25}
+      }
+      """
+    let response = try decoder.decode(PieceResponse.self, from: Data(json.utf8))
+    XCTAssertEqual(response.pieceSpan, PieceSpan(width: 0.34, height: 0.25))
+  }
+
+  func testDecodePieceResponseWithNullPieceSpan() throws {
+    let json = """
+      {
+        "position": {"x": 0.25, "y": 0.75},
+        "position_confidence": 0.91,
+        "rotation": 270,
+        "rotation_confidence": 0.66,
+        "cleaned_image": null,
+        "piece_span": null
+      }
+      """
+    let response = try decoder.decode(PieceResponse.self, from: Data(json.utf8))
+    XCTAssertNil(response.pieceSpan)
   }
 
   func testDecodeBareBase64DataURL() {

--- a/ios/PusselTests/PieceMarkerGeometryTests.swift
+++ b/ios/PusselTests/PieceMarkerGeometryTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+
+@testable import Pussel
+
+final class PieceMarkerGeometryTests: XCTestCase {
+  private let canvas = CGSize(width: 1000, height: 500)
+  private let cellSize = CGSize(width: 100, height: 100)
+
+  // MARK: span present
+
+  func testSpanPresentIgnoresImageSizeAndUsesCanvasFraction() {
+    let span = PieceSpan(width: 0.34, height: 0.25)
+    let size = PieceMarkerGeometry.size(
+      span: span, imageSize: CGSize(width: 999, height: 1), canvas: canvas, cellSize: cellSize,
+      rotation: 0)
+    XCTAssertEqual(size, CGSize(width: canvas.width * 0.34, height: canvas.height * 0.25))
+  }
+
+  func testSpanPresentIgnoresRotationSwap() {
+    let span = PieceSpan(width: 0.34, height: 0.25)
+    let size0 = PieceMarkerGeometry.size(
+      span: span, imageSize: .zero, canvas: canvas, cellSize: cellSize, rotation: 0)
+    let size90 = PieceMarkerGeometry.size(
+      span: span, imageSize: .zero, canvas: canvas, cellSize: cellSize, rotation: 90)
+    // Unlike the fallback path, a span-present marker's pre-rotation frame
+    // never swaps — `.rotationEffect` alone handles orientation.
+    XCTAssertEqual(size0, size90)
+  }
+
+  // MARK: null-span fallback
+
+  func testFallbackWideImageMinDimensionRendersAtTarget() {
+    // 200x50 image: width-cells = 2, height-cells = 0.5 -> smaller is height.
+    let size = PieceMarkerGeometry.size(
+      span: nil, imageSize: CGSize(width: 200, height: 50), canvas: canvas, cellSize: cellSize,
+      rotation: 0)
+    // scale = 1.1 / 0.5 = 2.2 -> width = 200*2.2 = 440, height = 50*2.2 = 110
+    XCTAssertEqual(size.width, 440, accuracy: 0.001)
+    XCTAssertEqual(size.height, 110, accuracy: 0.001)
+    // The smaller cell-relative dimension (height here) lands at exactly
+    // fallbackMinCellSpan cells.
+    XCTAssertEqual(
+      size.height / cellSize.height, PieceMarkerGeometry.fallbackMinCellSpan, accuracy: 0.001)
+  }
+
+  func testFallbackTallImageMinDimensionRendersAtTarget() {
+    // 50x200 image: width-cells = 0.5, height-cells = 2 -> smaller is width.
+    let size = PieceMarkerGeometry.size(
+      span: nil, imageSize: CGSize(width: 50, height: 200), canvas: canvas, cellSize: cellSize,
+      rotation: 0)
+    // scale = 1.1 / 0.5 = 2.2 -> width = 50*2.2 = 110, height = 200*2.2 = 440
+    XCTAssertEqual(size.width, 110, accuracy: 0.001)
+    XCTAssertEqual(size.height, 440, accuracy: 0.001)
+    XCTAssertEqual(
+      size.width / cellSize.width, PieceMarkerGeometry.fallbackMinCellSpan, accuracy: 0.001)
+  }
+
+  func testFallbackSquareImageBothDimensionsRenderAtTarget() {
+    let size = PieceMarkerGeometry.size(
+      span: nil, imageSize: CGSize(width: 80, height: 80), canvas: canvas, cellSize: cellSize,
+      rotation: 0)
+    // width-cells = height-cells = 0.8 -> scale = 1.1/0.8 = 1.375
+    XCTAssertEqual(size.width, 80 * 1.375, accuracy: 0.001)
+    XCTAssertEqual(size.height, 80 * 1.375, accuracy: 0.001)
+    XCTAssertEqual(size.width, size.height, accuracy: 0.001)
+  }
+
+  func testFallbackNonSquareCellsScaleAxesIndependently() {
+    // A non-square cell (2x wide) still yields correct per-axis scaling.
+    let wideCellSize = CGSize(width: 200, height: 100)
+    let size = PieceMarkerGeometry.size(
+      span: nil, imageSize: CGSize(width: 100, height: 100), canvas: canvas, cellSize: wideCellSize,
+      rotation: 0)
+    // width-cells = 100/200 = 0.5, height-cells = 100/100 = 1.0 -> smaller
+    // is width-cells, scale = 1.1/0.5 = 2.2.
+    XCTAssertEqual(size.width, 220, accuracy: 0.001)
+    XCTAssertEqual(size.height, 220, accuracy: 0.001)
+  }
+
+  func test90DegreeRotationSwapsFallbackDimensions() {
+    let imageSize = CGSize(width: 200, height: 50)
+    let unrotated = PieceMarkerGeometry.size(
+      span: nil, imageSize: imageSize, canvas: canvas, cellSize: cellSize, rotation: 0)
+    let rotated90 = PieceMarkerGeometry.size(
+      span: nil, imageSize: imageSize, canvas: canvas, cellSize: cellSize, rotation: 90)
+    let rotated270 = PieceMarkerGeometry.size(
+      span: nil, imageSize: imageSize, canvas: canvas, cellSize: cellSize, rotation: 270)
+    let rotated180 = PieceMarkerGeometry.size(
+      span: nil, imageSize: imageSize, canvas: canvas, cellSize: cellSize, rotation: 180)
+
+    XCTAssertEqual(rotated90.width, unrotated.height, accuracy: 0.001)
+    XCTAssertEqual(rotated90.height, unrotated.width, accuracy: 0.001)
+    XCTAssertEqual(rotated270.width, unrotated.height, accuracy: 0.001)
+    XCTAssertEqual(rotated270.height, unrotated.width, accuracy: 0.001)
+    // A half turn doesn't swap axes.
+    XCTAssertEqual(rotated180, unrotated)
+  }
+
+  func testFallbackZeroSizedImageFallsBackToBareCell() {
+    let size = PieceMarkerGeometry.size(
+      span: nil, imageSize: .zero, canvas: canvas, cellSize: cellSize, rotation: 0)
+    XCTAssertEqual(
+      size,
+      CGSize(
+        width: cellSize.width * PieceMarkerGeometry.fallbackMinCellSpan,
+        height: cellSize.height * PieceMarkerGeometry.fallbackMinCellSpan))
+  }
+}

--- a/ios/PusselTests/PuzzleStoreTests.swift
+++ b/ios/PusselTests/PuzzleStoreTests.swift
@@ -38,6 +38,9 @@ final class PuzzleStoreTests: XCTestCase {
       name: name,
       puzzleId: "server-123",
       trimmedJPEG: tinyJPEG(),
+      pieceCount: 48,
+      rows: 6,
+      cols: 8,
       store: store
     )
   }
@@ -58,7 +61,8 @@ final class PuzzleStoreTests: XCTestCase {
           positionConfidence: 0.77,
           rotation: 90,
           rotationConfidence: 0.77,
-          cleanedImage: nil
+          cleanedImage: nil,
+          pieceSpan: PieceSpan(width: 0.34, height: 0.25)
         )
       )
     ]
@@ -68,6 +72,9 @@ final class PuzzleStoreTests: XCTestCase {
     XCTAssertEqual(summary.name, "Frosty field")
     XCTAssertEqual(summary.pieceCount, 1)
     XCTAssertEqual(summary.placedCount, 1)
+    XCTAssertEqual(summary.targetPieceCount, 48)
+    XCTAssertEqual(summary.rows, 6)
+    XCTAssertEqual(summary.cols, 8)
     XCTAssertNotNil(summary.thumbnail)
 
     // A brand-new store instance reads purely from disk.
@@ -75,12 +82,16 @@ final class PuzzleStoreTests: XCTestCase {
     XCTAssertEqual(reloaded.name, "Frosty field")
     XCTAssertEqual(reloaded.puzzleId, "server-123")
     XCTAssertEqual(reloaded.trimmedJPEG, session.trimmedJPEG)
+    XCTAssertEqual(reloaded.pieceCount, 48)
+    XCTAssertEqual(reloaded.rows, 6)
+    XCTAssertEqual(reloaded.cols, 8)
     XCTAssertEqual(reloaded.entries.count, 1)
     let entry = try XCTUnwrap(reloaded.entries.first)
     XCTAssertEqual(entry.status, .done)
     XCTAssertEqual(entry.displayImage, Data("piece-display".utf8))
     XCTAssertEqual(entry.result?.position, NormalizedPoint(x: 0.34, y: 0.4))
     XCTAssertEqual(entry.result?.rotation, 90)
+    XCTAssertEqual(entry.result?.pieceSpan, PieceSpan(width: 0.34, height: 0.25))
   }
 
   func testUnpredictedPieceReloadsAsQueued() throws {


### PR DESCRIPTION
## Summary

Puzzle pieces were drawn on the iOS overlay at a fixed 12% of the canvas, unrelated to the actual puzzle. This PR sizes them realistically, in three layers:

1. **User-entered piece count → grid estimate (iOS + backend)**
   - New "How many pieces?" input (preset chips + numeric field, 4–2000) on the trim-confirm screen, with a live "500 pieces → 25 × 20 grid" readout that tracks rotation.
   - `GridEstimator` is an exact Swift port of the shared `calculate_grid_dimensions` (aspect-ratio-aware rows×cols), verified against 114 parity vectors generated from the Python reference.
   - The count is sent as a `piece_count` form field on puzzle upload; the backend computes and stores the grid (via the already-existing shared function) and returns `rows`/`cols`. The stored grid also feeds the classical matcher's NCC template sizing instead of the hardcoded 4×4 default.
   - Piece count and grid are persisted in the local puzzle manifest (required fields; pre-release breaking change by design).

2. **Measured piece size (`piece_span`)**
   - The classical matcher internally discovers each photographed piece's true size but discarded it. It now returns an optional normalized `piece_span`: exact from the SIFT similarity-transform scale, approximate from the winning NCC template scale.
   - The overlay renders the marker at exactly `span × canvas` when present; when null (CNN path or matcher failure) it falls back to grid-based sizing with the piece's narrow axis pinned to 1.1 cells.

3. **Segmentation-halo fixes (found testing on a real device)**
   - rembg's soft matte leaves a faint alpha ghost of the background across the frame; it rendered visibly over bright puzzle areas and inflated the client's alpha-trim bounding box. The backend now zeroes alpha ≤128 after segmentation (`harden_alpha`), and the client bbox threshold was raised 10 → 128.
   - Fixed the overlay showing the raw capture instead of the cleaned piece mid-session: replacing `displayImage` now refreshes the pre-trimmed overlay copy via `didSet` (regression-tested).

## Testing

- Backend: 127 tests pass, `make check-backend` clean (black, isort, flake8, pyright).
- iOS: 49 unit tests pass (incl. 114 grid parity vectors, marker geometry, alpha-trim helpers), `make check-ios` clean.
- Verified end to end on a physical iPhone against a real 12-piece puzzle: correct 3×4 grid estimate, correct placement, marker size matching the printed piece area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)