### PR TITLE
Delete puzzle pieces via long press instead of a trash icon

### DIFF
--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -12,11 +12,6 @@ struct PieceQueueView: View {
   @State private var showLibrary = false
   @State private var photoItem: PhotosPickerItem?
 
-  /// Slack around the tile strip, sized to clear the delete badge's tappable
-  /// box (the widest thing that spills past a tile) plus a little for the tilt
-  /// the wiggle adds at the corners.
-  private static let stripSpill = QueueTile.badgeCornerOffset + 2
-
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
       HStack {
@@ -47,15 +42,11 @@ struct PieceQueueView: View {
           }
         }
         .padding(.vertical, 2)
-        // Room for the wiggle and the delete badge to spill outside the tiles.
-        // The negative padding on the ScrollView widens its bounds by the same
-        // amount, so the spill stays inside the clip region (and stays
-        // tappable) without shifting where the tiles actually sit.
-        .padding(.horizontal, Self.stripSpill)
-        .padding(.top, Self.stripSpill)
       }
-      .padding(.horizontal, -Self.stripSpill)
-      .padding(.top, -Self.stripSpill)
+      // The delete badge hangs past its tile's top-right corner. Without this
+      // the scroll view clips it flat; a negative-padding trick would work too
+      // but silently widens the scroll bounds over the header's Done button.
+      .scrollClipDisabled()
     }
     // The strip outlives the pieces — it always shows the add tile — so delete
     // mode has to be left explicitly once the last piece goes, or the Done
@@ -131,9 +122,9 @@ private struct QueueTile: View {
   /// How far the circle's centre sits inside the tile's corner.
   private static let badgeCircleInset: CGFloat = 3
   /// Distance the badge box is pushed past the corner to land the circle there.
-  /// Also how far the box spills outside the tile, which
-  /// `PieceQueueView`'s strip padding has to clear or the ScrollView clips it.
-  static let badgeCornerOffset = badgeHitSize / 2 - badgeCircleInset
+  /// The circle spills outside the tile by design, which is why the strip
+  /// disables scroll clipping — otherwise the scroll view slices it flat.
+  private static let badgeCornerOffset = badgeHitSize / 2 - badgeCircleInset
 
   /// The model reports how far the piece is turned from its place in the
   /// puzzle, so undoing it shows the piece as it will sit there — the same

--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -7,6 +7,11 @@ struct PieceQueueView: View {
   let session: SolveSession
   @State private var isDeleteMode = false
 
+  /// Slack around the tile strip, sized to clear the delete badge's tappable
+  /// box (the widest thing that spills past a tile) plus a little for the tilt
+  /// the wiggle adds at the corners.
+  private static let stripSpill = QueueTile.badgeCornerOffset + 2
+
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
       HStack {
@@ -35,11 +40,14 @@ struct PieceQueueView: View {
         }
         .padding(.vertical, 2)
         // Room for the wiggle and the delete badge to spill outside the tiles.
-        .padding(.horizontal, 6)
-        .padding(.top, 6)
+        // The negative padding on the ScrollView widens its bounds by the same
+        // amount, so the spill stays inside the clip region (and stays
+        // tappable) without shifting where the tiles actually sit.
+        .padding(.horizontal, Self.stripSpill)
+        .padding(.top, Self.stripSpill)
       }
-      .padding(.horizontal, -6)
-      .padding(.top, -6)
+      .padding(.horizontal, -Self.stripSpill)
+      .padding(.top, -Self.stripSpill)
     }
     // No need to leave delete mode when the last piece goes: SolvingView drops
     // this view once `entries` is empty, which resets `isDeleteMode` with it.
@@ -53,6 +61,20 @@ private struct QueueTile: View {
   let onDelete: () -> Void
   let onEnterDeleteMode: () -> Void
   let onExitDeleteMode: () -> Void
+
+  /// Diameter of the visible badge circle.
+  private static let badgeCircleSize: CGFloat = 22
+  /// Tappable box around the circle. Bigger than the circle, because 22pt is
+  /// well under the 44pt guideline — but deliberately short of a full 44pt,
+  /// which would turn much of the tile's corner into a delete zone for an
+  /// action that has no undo.
+  private static let badgeHitSize: CGFloat = 32
+  /// How far the circle's centre sits inside the tile's corner.
+  private static let badgeCircleInset: CGFloat = 3
+  /// Distance the badge box is pushed past the corner to land the circle there.
+  /// Also how far the box spills outside the tile, which
+  /// `PieceQueueView`'s strip padding has to clear or the ScrollView clips it.
+  static let badgeCornerOffset = badgeHitSize / 2 - badgeCircleInset
 
   var body: some View {
     VStack(spacing: 6) {
@@ -75,7 +97,10 @@ private struct QueueTile: View {
       .overlay(alignment: .topTrailing) {
         if isDeleteMode {
           deleteBadge
-            .offset(x: 8, y: -8)
+            // The badge's box is `hitSize`, but only the circle inside it is
+            // visible, so offset by half the box to park the circle's centre
+            // `circleInset` in from the tile's corner.
+            .offset(x: Self.badgeCornerOffset, y: -Self.badgeCornerOffset)
             .transition(.scale.combined(with: .opacity))
         }
       }
@@ -112,9 +137,11 @@ private struct QueueTile: View {
       Image(systemName: "xmark")
         .font(.system(size: 10, weight: .bold))
         .foregroundStyle(.white)
-        .frame(width: 22, height: 22)
+        .frame(width: Self.badgeCircleSize, height: Self.badgeCircleSize)
         .background(Circle().fill(.black.opacity(0.7)))
         .overlay(Circle().stroke(.white.opacity(0.9), lineWidth: 1))
+        .frame(width: Self.badgeHitSize, height: Self.badgeHitSize)
+        .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
     .accessibilityLabel("Delete piece")

--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -1,5 +1,6 @@
 import PhotosUI
 import SwiftUI
+import UIKit
 
 /// Horizontal strip of captured pieces with their prediction status, led by an
 /// "add piece" tile that opens the camera full screen. Mirrors

--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -5,31 +5,54 @@ import SwiftUI
 struct PieceQueueView: View {
   @Environment(AppModel.self) private var model
   let session: SolveSession
+  @State private var isDeleteMode = false
 
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
-      Text("Pieces (\(session.entries.count))")
-        .font(.headline)
+      HStack {
+        Text("Pieces (\(session.entries.count))")
+          .font(.headline)
+        Spacer()
+        if isDeleteMode {
+          Button("Done") {
+            withAnimation { isDeleteMode = false }
+          }
+          .font(.subheadline.weight(.semibold))
+        }
+      }
       ScrollView(.horizontal, showsIndicators: false) {
         HStack(spacing: 12) {
           ForEach(session.entries) { entry in
             QueueTile(
               entry: entry,
+              isDeleteMode: isDeleteMode,
               onRetry: { session.retry(id: entry.id, api: model.api) },
-              onDelete: { session.remove(id: entry.id) }
+              onDelete: { withAnimation { session.remove(id: entry.id) } },
+              onEnterDeleteMode: { withAnimation { isDeleteMode = true } },
+              onExitDeleteMode: { withAnimation { isDeleteMode = false } }
             )
           }
         }
         .padding(.vertical, 2)
+        // Room for the wiggle and the delete badge to spill outside the tiles.
+        .padding(.horizontal, 6)
+        .padding(.top, 6)
       }
+      .padding(.horizontal, -6)
+      .padding(.top, -6)
     }
+    // No need to leave delete mode when the last piece goes: SolvingView drops
+    // this view once `entries` is empty, which resets `isDeleteMode` with it.
   }
 }
 
 private struct QueueTile: View {
   let entry: CaptureEntry
+  let isDeleteMode: Bool
   let onRetry: () -> Void
   let onDelete: () -> Void
+  let onEnterDeleteMode: () -> Void
+  let onExitDeleteMode: () -> Void
 
   var body: some View {
     VStack(spacing: 6) {
@@ -49,22 +72,52 @@ private struct QueueTile: View {
             .tint(.white)
         }
       }
-      statusLabel
-      HStack(spacing: 10) {
-        if entry.status.isRetryable {
-          Button(action: onRetry) {
-            Image(systemName: "arrow.clockwise")
-          }
-          .accessibilityLabel("Retry piece")
+      .overlay(alignment: .topTrailing) {
+        if isDeleteMode {
+          deleteBadge
+            .offset(x: 8, y: -8)
+            .transition(.scale.combined(with: .opacity))
         }
-        Button(role: .destructive, action: onDelete) {
-          Image(systemName: "trash")
-        }
-        .accessibilityLabel("Delete piece")
       }
-      .font(.footnote)
-      .buttonStyle(.borderless)
+      statusLabel
+      if entry.status.isRetryable {
+        Button(action: onRetry) {
+          Image(systemName: "arrow.clockwise")
+        }
+        .accessibilityLabel("Retry piece")
+        .font(.footnote)
+        .buttonStyle(.borderless)
+      }
     }
+    // Seeded off the piece itself, not its position, so deleting a tile doesn't
+    // reshuffle how its neighbours rock.
+    .wiggle(isActive: isDeleteMode, seed: Int(entry.id.uuid.0))
+    .contentShape(Rectangle())
+    .onTapGesture {
+      if isDeleteMode { onExitDeleteMode() }
+    }
+    // Simultaneous, because a plain `.onLongPressGesture` alongside
+    // `.onTapGesture` loses the race and never fires.
+    .simultaneousGesture(
+      LongPressGesture(minimumDuration: 0.45).onEnded { _ in
+        guard !isDeleteMode else { return }
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        onEnterDeleteMode()
+      }
+    )
+  }
+
+  private var deleteBadge: some View {
+    Button(action: onDelete) {
+      Image(systemName: "xmark")
+        .font(.system(size: 10, weight: .bold))
+        .foregroundStyle(.white)
+        .frame(width: 22, height: 22)
+        .background(Circle().fill(.black.opacity(0.7)))
+        .overlay(Circle().stroke(.white.opacity(0.9), lineWidth: 1))
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel("Delete piece")
   }
 
   @ViewBuilder
@@ -92,6 +145,44 @@ private struct QueueTile: View {
         .foregroundStyle(.red)
         .lineLimit(1)
         .frame(maxWidth: 96)
+    }
+  }
+}
+
+extension View {
+  /// Home-screen style jiggle. `seed` desynchronises neighbouring tiles so the
+  /// strip doesn't rock in unison.
+  fileprivate func wiggle(isActive: Bool, seed: Int) -> some View {
+    modifier(WiggleModifier(isActive: isActive, seed: seed))
+  }
+}
+
+private struct WiggleModifier: ViewModifier {
+  let isActive: Bool
+  let seed: Int
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  private var enabled: Bool { isActive && !reduceMotion }
+
+  /// Slight per-tile variation, mirroring how the home screen's icons drift
+  /// out of phase with each other.
+  private var angle: Double { seed.isMultiple(of: 2) ? 1.7 : 1.4 }
+  private var duration: Double { 0.13 + Double(seed % 3) * 0.012 }
+
+  // PhaseAnimator owns its own looping animation, so deleting a piece can't
+  // cancel the jiggle: a plain `.repeatForever` on `rotationEffect` is
+  // overridden by the ambient `withAnimation` transaction that removal runs in,
+  // and nothing restarts it for the tiles that survive.
+  @ViewBuilder
+  func body(content: Content) -> some View {
+    if enabled {
+      content.phaseAnimator([false, true]) { view, isRocked in
+        view.rotationEffect(.degrees(isRocked ? angle : -angle))
+      } animation: { _ in
+        .easeInOut(duration: duration)
+      }
+    } else {
+      content
     }
   }
 }

--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -108,7 +108,7 @@ private struct QueueTile: View {
   }
 
   private var deleteBadge: some View {
-    Button(action: onDelete) {
+    Button(role: .destructive, action: onDelete) {
       Image(systemName: "xmark")
         .font(.system(size: 10, weight: .bold))
         .foregroundStyle(.white)

--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -68,6 +68,13 @@ private struct QueueTile: View {
   /// well under the 44pt guideline — but deliberately short of a full 44pt,
   /// which would turn much of the tile's corner into a delete zone for an
   /// action that has no undo.
+  ///
+  /// Note the *effective* target is smaller than this: hit testing is bounded
+  /// by the tile's 84pt frame, so the part of this box hanging outside the
+  /// tile is drawn but never tapped. This buys the corner region inside the
+  /// tile (~19pt square, up from ~14pt), and raising the number further only
+  /// grows the untappable spill — a real 44pt target would need the badge
+  /// re-parented outside the tile, not a bigger box here.
   private static let badgeHitSize: CGFloat = 32
   /// How far the circle's centre sits inside the tile's corner.
   private static let badgeCircleInset: CGFloat = 3


### PR DESCRIPTION
Replaces the small trash icon under each puzzle piece with the delete
interaction people already know from the iOS home screen.

## Behaviour

- **Long press** any piece to enter delete mode.
- Tiles **jiggle**, and each gets an **✕ badge** on its top right corner.
- A **Done** button appears in the `Pieces (N)` header.
- Tapping the ✕ deletes that piece; tapping a tile body or Done exits.
- Deleting the last piece leaves delete mode, via an `.onChange` reset.

The badge sits top **right** as requested. Note iOS itself puts the remove
badge top *left* — easy to flip if we'd rather match Apple exactly.

Reduce Motion is honoured (no jiggle), and entering the mode fires a haptic.

## Non-obvious details

All are called out in code comments, since the simpler-looking form is wrong in
each case and would likely get "cleaned up" back:

- The long press is a `simultaneousGesture`. A plain `.onLongPressGesture`
  next to `.onTapGesture` loses the race and **never fires**.
- The jiggle is a `PhaseAnimator`, not `.repeatForever` on `rotationEffect`.
  The latter is cancelled by the ambient `withAnimation` transaction that piece
  removal runs in, and nothing restarts it for the surviving tiles — so the
  strip froze mid-delete-mode right after a deletion.
- The badge's ✕ is 22pt visually with a 32pt hit box. Its **effective** target
  is smaller still: hit testing is bounded by the tile's 84pt frame, so the
  part of the box hanging outside the tile is drawn but never tapped. That
  buys ~19pt square (up from ~14pt). A real 44pt target isn't reachable by
  growing the constant — the badge would need re-parenting outside the tile.
  It also stops short of 44pt deliberately: the badge straddles the corner, so
  a big box turns much of the tile into a delete zone for an action with **no
  undo**.
- The strip uses `.scrollClipDisabled()` so the badge can overflow. A
  negative-padding trick also works but widens the scroll view's bounds over
  the header's Done button.

The wiggle phase is seeded off the piece's UUID rather than its `ForEach`
index, so deleting a tile doesn't reshuffle its neighbours' amplitude and
duration mid-jiggle. (`uuidString.hashValue` would be wrong here — Swift seeds
`Hasher` per process, so the phase would change every launch.)

## Merge note

`main` grew an `AddPieceTile` and now renders `PieceQueueView` unconditionally
so the "+" tile is always reachable. That made the "leave delete mode when the
last piece goes" reset load-bearing again — earlier it was genuinely dead code,
because `SolvingView` used to unmount the strip when `entries` emptied. Without
the reset, deleting your last piece strands a Done button over an empty strip.

## Verification

Driven end to end in the Simulator, with the installed binary checksum-matched
to the build under test each time, and screenshots to back each claim:

- long press enters delete mode; ✕ deletes the right piece; Done and tile-body
  taps exit without deleting
- survivors keep jiggling after a delete (6 frames, all 15 pairs differ; the
  same sampling with delete mode off returns byte-identical frames, so the
  check distinguishes motion from stillness)
- Reduce Motion disables the jiggle (consecutive frames byte-identical)
- the 32pt hit box works: a tap 18.4pt from the circle's centre deletes on this
  build; on the previous build the same tap registers but doesn't delete
- the badge circle did not move when the box grew — centre identical to the
  pixel between two checksum-verified builds, with Reduce Motion on so the
  jiggle couldn't confound it
- post-merge: `Pieces (1)` + Done → delete last piece → `Pieces (0)` with no
  Done and the "+" tile still there

🤖 Generated with [Claude Code](https://claude.com/claude-code)
