### PR TITLE
feat(ios): capture pieces from a full-screen camera behind a "+" tile

### DIFF
--- a/ios/Pussel/App/AppActions.swift
+++ b/ios/Pussel/App/AppActions.swift
@@ -88,6 +88,13 @@ extension AppModel {
     session.enqueue(jpeg: jpeg, api: api)
   }
 
+  /// Surfaces a piece-capture failure on the solve screen. The capture UI
+  /// sits in a full-screen cover, so callers dismiss after reporting.
+  func reportPieceError(_ message: String) {
+    guard case .solving(let session) = flow.phase else { return }
+    session.errorMessage = message
+  }
+
   /// Adds a piece picked from the photo library. Both piece pickers route
   /// here so a failed load reports itself on the solve screen instead of
   /// looking like a dropped tap.

--- a/ios/Pussel/App/AppActions.swift
+++ b/ios/Pussel/App/AppActions.swift
@@ -1,3 +1,5 @@
+import PhotosUI
+import SwiftUI
 import UIKit
 
 /// Wizard actions shared by the UI and the debug deep links.
@@ -76,10 +78,28 @@ extension AppModel {
 
   /// Queues a captured piece photo for prediction in the current session.
   func addPiece(image: UIImage) {
-    guard case .solving(let session) = flow.phase,
-      let jpeg = ImageUtilities.normalizedJPEG(from: image, maxDimension: 1600, quality: 0.9)
-    else { return }
+    guard case .solving(let session) = flow.phase else { return }
+    guard let jpeg = ImageUtilities.normalizedJPEG(from: image, maxDimension: 1600, quality: 0.9)
+    else {
+      session.errorMessage = "Could not process the photo."
+      return
+    }
+    session.errorMessage = nil
     session.enqueue(jpeg: jpeg, api: api)
+  }
+
+  /// Adds a piece picked from the photo library. Both piece pickers route
+  /// here so a failed load reports itself on the solve screen instead of
+  /// looking like a dropped tap.
+  func addPiece(from item: PhotosPickerItem) async {
+    guard case .solving(let session) = flow.phase else { return }
+    guard let data = try? await item.loadTransferable(type: Data.self),
+      let image = UIImage(data: data)
+    else {
+      session.errorMessage = "Could not load the selected photo."
+      return
+    }
+    addPiece(image: image)
   }
 
   /// Reopens a stored puzzle from disk and resumes solving it. Pieces that

--- a/ios/Pussel/Features/Solve/PieceCameraSession.swift
+++ b/ios/Pussel/Features/Solve/PieceCameraSession.swift
@@ -10,6 +10,8 @@ final class PieceCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
   }
 
   let session = AVCaptureSession()
+  /// Serializes startRunning/stopRunning so they cannot interleave.
+  private let sessionQueue = DispatchQueue(label: "dk.delectosoft.pussel.piece-camera")
   private let photoOutput = AVCapturePhotoOutput()
   private var isConfigured = false
   private var captureContinuation: CheckedContinuation<UIImage?, Never>?
@@ -20,19 +22,23 @@ final class PieceCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
     guard await AVCaptureDevice.requestAccess(for: .video) else { return false }
     configureIfNeeded()
     guard isConfigured else { return false }
-    guard !session.isRunning else { return true }
     let session = self.session
-    Task.detached {
-      // startRunning blocks, so keep it off the main thread.
+    // start/stop both block, so they run off the main thread — and both go
+    // through one serial queue so a stop that lands while a start is still
+    // queued runs after it. Checking `isRunning` on the caller's thread
+    // instead would let a quick open-then-close leave the camera running:
+    // the stop would see a session that had not flipped to running yet.
+    sessionQueue.async {
+      guard !session.isRunning else { return }
       session.startRunning()
     }
     return true
   }
 
   func stop() {
-    guard session.isRunning else { return }
     let session = self.session
-    Task.detached {
+    sessionQueue.async {
+      guard session.isRunning else { return }
       session.stopRunning()
     }
   }

--- a/ios/Pussel/Features/Solve/PieceCameraSession.swift
+++ b/ios/Pussel/Features/Solve/PieceCameraSession.swift
@@ -14,15 +14,19 @@ final class PieceCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
   private var isConfigured = false
   private var captureContinuation: CheckedContinuation<UIImage?, Never>?
 
-  func start() async {
-    guard await AVCaptureDevice.requestAccess(for: .video) else { return }
+  /// Returns false when the camera cannot run — access denied, or no usable
+  /// device — so the caller can report it rather than show a dead preview.
+  func start() async -> Bool {
+    guard await AVCaptureDevice.requestAccess(for: .video) else { return false }
     configureIfNeeded()
-    guard isConfigured, !session.isRunning else { return }
+    guard isConfigured else { return false }
+    guard !session.isRunning else { return true }
     let session = self.session
     Task.detached {
       // startRunning blocks, so keep it off the main thread.
       session.startRunning()
     }
+    return true
   }
 
   func stop() {

--- a/ios/Pussel/Features/Solve/PieceCameraSession.swift
+++ b/ios/Pussel/Features/Solve/PieceCameraSession.swift
@@ -15,19 +15,25 @@ final class PieceCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
   private let photoOutput = AVCapturePhotoOutput()
   private var isConfigured = false
   private var captureContinuation: CheckedContinuation<UIImage?, Never>?
+  /// Whether the view still wants the camera. `start()` awaits the permission
+  /// prompt, which can outlive the screen that asked, so the last caller's
+  /// intent decides — not how far along the awaits happen to be.
+  private var wantsRunning = false
 
   /// Returns false when the camera cannot run — access denied, or no usable
   /// device — so the caller can report it rather than show a dead preview.
   func start() async -> Bool {
+    wantsRunning = true
     guard await AVCaptureDevice.requestAccess(for: .video) else { return false }
     configureIfNeeded()
     guard isConfigured else { return false }
+    // The screen was dismissed while the permission prompt was up: stop() has
+    // already run, and starting now would strand the camera with no one left
+    // to stop it. Not a failure — nothing to report, nothing to run.
+    guard wantsRunning else { return true }
     let session = self.session
-    // start/stop both block, so they run off the main thread — and both go
-    // through one serial queue so a stop that lands while a start is still
-    // queued runs after it. Checking `isRunning` on the caller's thread
-    // instead would let a quick open-then-close leave the camera running:
-    // the stop would see a session that had not flipped to running yet.
+    // startRunning/stopRunning both block, so they run off the main thread —
+    // through one serial queue so a stop queued behind a start runs after it.
     sessionQueue.async {
       guard !session.isRunning else { return }
       session.startRunning()
@@ -36,6 +42,7 @@ final class PieceCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
   }
 
   func stop() {
+    wantsRunning = false
     let session = self.session
     sessionQueue.async {
       guard session.isRunning else { return }

--- a/ios/Pussel/Features/Solve/PieceCaptureView.swift
+++ b/ios/Pussel/Features/Solve/PieceCaptureView.swift
@@ -2,40 +2,45 @@ import AVFoundation
 import PhotosUI
 import SwiftUI
 
-/// Manual piece capture: a persistent live camera view with a shutter button
-/// on device, and a PhotosPicker path that also serves as the only option on
-/// the Simulator.
+/// Full-screen piece capture, presented when the "+" tile in the piece list is
+/// tapped. The camera only runs while this is on screen. Device-only — on the
+/// Simulator `PieceCameraSession.isCameraAvailable` is false and the "+" tile
+/// opens a PhotosPicker instead of this view.
 struct PieceCaptureView: View {
   @Environment(AppModel.self) private var model
+  @Environment(\.dismiss) private var dismiss
   @State private var camera = PieceCameraSession()
   @State private var photoItem: PhotosPickerItem?
 
   var body: some View {
-    VStack(spacing: 12) {
-      if PieceCameraSession.isCameraAvailable {
-        CameraPreview(session: camera.session)
-          .frame(height: 280)
-          .clipShape(RoundedRectangle(cornerRadius: 12))
-          .overlay(alignment: .bottom) {
-            shutterButton.padding(.bottom, 14)
-          }
-          .task {
-            await camera.start()
-          }
-          .onDisappear {
-            camera.stop()
-          }
-          .keepsScreenAwake()
-      }
-      PhotosPicker(selection: $photoItem, matching: .images) {
-        Label(
-          PieceCameraSession.isCameraAvailable ? "Add Piece from Library" : "Pick Piece Photo",
-          systemImage: "photo.on.rectangle"
-        )
-        .frame(maxWidth: .infinity)
-      }
-      .buttonStyle(.bordered)
+    ZStack {
+      Color.black.ignoresSafeArea()
+      CameraPreview(session: camera.session)
+        .ignoresSafeArea()
     }
+    .overlay(alignment: .top) {
+      Button("Cancel") { dismiss() }
+        .padding()
+        .foregroundStyle(.white)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .overlay(alignment: .bottom) {
+      HStack {
+        libraryButton.frame(maxWidth: .infinity, alignment: .leading)
+        shutterButton
+        // Balances the library button so the shutter stays centered.
+        Color.clear.frame(maxWidth: .infinity)
+      }
+      .padding(.horizontal, 32)
+      .padding(.bottom, 24)
+    }
+    .task {
+      await camera.start()
+    }
+    .onDisappear {
+      camera.stop()
+    }
+    .keepsScreenAwake()
     .onChange(of: photoItem) { _, item in
       guard let item else { return }
       Task {
@@ -43,10 +48,20 @@ struct PieceCaptureView: View {
           let image = UIImage(data: data)
         {
           model.addPiece(image: image)
+          dismiss()
         }
         photoItem = nil
       }
     }
+  }
+
+  private var libraryButton: some View {
+    PhotosPicker(selection: $photoItem, matching: .images) {
+      Image(systemName: "photo.on.rectangle")
+        .font(.title2)
+        .foregroundStyle(.white)
+    }
+    .accessibilityLabel("Add piece from library")
   }
 
   private var shutterButton: some View {
@@ -54,6 +69,7 @@ struct PieceCaptureView: View {
       Task {
         if let image = await camera.capturePhoto() {
           model.addPiece(image: image)
+          dismiss()
         }
       }
     } label: {

--- a/ios/Pussel/Features/Solve/PieceCaptureView.swift
+++ b/ios/Pussel/Features/Solve/PieceCaptureView.swift
@@ -11,6 +11,7 @@ struct PieceCaptureView: View {
   @Environment(\.dismiss) private var dismiss
   @State private var camera = PieceCameraSession()
   @State private var photoItem: PhotosPickerItem?
+  @State private var isCapturing = false
 
   var body: some View {
     ZStack {
@@ -24,18 +25,22 @@ struct PieceCaptureView: View {
         .foregroundStyle(.white)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
+    // Two overlays rather than one HStack: the shutter centers on the screen
+    // itself, so it stays put no matter how wide the library button is.
     .overlay(alignment: .bottom) {
-      HStack {
-        libraryButton.frame(maxWidth: .infinity, alignment: .leading)
-        shutterButton
-        // Balances the library button so the shutter stays centered.
-        Color.clear.frame(maxWidth: .infinity)
-      }
-      .padding(.horizontal, 32)
-      .padding(.bottom, 24)
+      shutterButton.padding(.bottom, 24)
+    }
+    .overlay(alignment: .bottomLeading) {
+      libraryButton
+        .padding(.leading, 32)
+        .padding(.bottom, 40)
     }
     .task {
-      await camera.start()
+      guard await camera.start() else {
+        model.reportPieceError("Pussel cannot use the camera. Check camera access in Settings.")
+        dismiss()
+        return
+      }
     }
     .onDisappear {
       camera.stop()
@@ -64,11 +69,20 @@ struct PieceCaptureView: View {
 
   private var shutterButton: some View {
     Button {
+      // Ignore taps while a shot is developing, so a nil result below means
+      // the capture itself failed rather than a double tap.
+      guard !isCapturing else { return }
+      isCapturing = true
       Task {
-        if let image = await camera.capturePhoto() {
-          model.addPiece(image: image)
+        let image = await camera.capturePhoto()
+        isCapturing = false
+        guard let image else {
+          model.reportPieceError("Could not take that photo. Try again.")
           dismiss()
+          return
         }
+        model.addPiece(image: image)
+        dismiss()
       }
     } label: {
       ZStack {

--- a/ios/Pussel/Features/Solve/PieceCaptureView.swift
+++ b/ios/Pussel/Features/Solve/PieceCaptureView.swift
@@ -36,7 +36,11 @@ struct PieceCaptureView: View {
         .padding(.bottom, 40)
     }
     .task {
-      guard await camera.start() else {
+      let started = await camera.start()
+      // Dismissed while the permission prompt was up — the user left on
+      // purpose, so there is nothing to complain about.
+      guard !Task.isCancelled else { return }
+      guard started else {
         model.reportPieceError("Pussel cannot use the camera. Check camera access in Settings.")
         dismiss()
         return

--- a/ios/Pussel/Features/Solve/PieceCaptureView.swift
+++ b/ios/Pussel/Features/Solve/PieceCaptureView.swift
@@ -44,13 +44,11 @@ struct PieceCaptureView: View {
     .onChange(of: photoItem) { _, item in
       guard let item else { return }
       Task {
-        if let data = try? await item.loadTransferable(type: Data.self),
-          let image = UIImage(data: data)
-        {
-          model.addPiece(image: image)
-          dismiss()
-        }
+        await model.addPiece(from: item)
         photoItem = nil
+        // Dismiss either way: a failure sets an error on the solve screen,
+        // which stays hidden behind this cover.
+        dismiss()
       }
     }
   }

--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -1,17 +1,25 @@
+import PhotosUI
 import SwiftUI
 
-/// Horizontal strip of captured pieces with their prediction status,
-/// mirroring frontend/src/components/puzzle/piece-queue.tsx.
+/// Horizontal strip of captured pieces with their prediction status, led by an
+/// "add piece" tile that opens the camera full screen. Mirrors
+/// frontend/src/components/puzzle/piece-queue.tsx.
 struct PieceQueueView: View {
   @Environment(AppModel.self) private var model
   let session: SolveSession
+  @State private var showCamera = false
+  @State private var showLibrary = false
+  @State private var photoItem: PhotosPickerItem?
 
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
       Text("Pieces (\(session.entries.count))")
         .font(.headline)
       ScrollView(.horizontal, showsIndicators: false) {
-        HStack(spacing: 12) {
+        // Top-aligned so the plus square lines up with the piece thumbnails
+        // rather than centering against their taller status labels.
+        HStack(alignment: .top, spacing: 12) {
+          AddPieceTile(action: addPiece)
           ForEach(session.entries) { entry in
             QueueTile(
               entry: entry,
@@ -23,6 +31,50 @@ struct PieceQueueView: View {
         .padding(.vertical, 2)
       }
     }
+    .fullScreenCover(isPresented: $showCamera) {
+      PieceCaptureView()
+    }
+    // Simulator path: no camera, so the tile picks from the library directly.
+    .photosPicker(isPresented: $showLibrary, selection: $photoItem, matching: .images)
+    .onChange(of: photoItem) { _, item in
+      guard let item else { return }
+      Task {
+        if let data = try? await item.loadTransferable(type: Data.self),
+          let image = UIImage(data: data)
+        {
+          model.addPiece(image: image)
+        }
+        photoItem = nil
+      }
+    }
+  }
+
+  private func addPiece() {
+    if PieceCameraSession.isCameraAvailable {
+      showCamera = true
+    } else {
+      showLibrary = true
+    }
+  }
+}
+
+/// Leading tile in the strip: a big plus that starts a new piece capture.
+private struct AddPieceTile: View {
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      RoundedRectangle(cornerRadius: 10)
+        .strokeBorder(.tint, style: StrokeStyle(lineWidth: 2, dash: [6, 4]))
+        .frame(width: 84, height: 84)
+        .overlay {
+          Image(systemName: "plus")
+            .font(.system(size: 34, weight: .light))
+            .foregroundStyle(.tint)
+        }
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel("Add piece")
   }
 }
 

--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -39,11 +39,7 @@ struct PieceQueueView: View {
     .onChange(of: photoItem) { _, item in
       guard let item else { return }
       Task {
-        if let data = try? await item.loadTransferable(type: Data.self),
-          let image = UIImage(data: data)
-        {
-          model.addPiece(image: image)
-        }
+        await model.addPiece(from: item)
         photoItem = nil
       }
     }

--- a/ios/Pussel/Features/Solve/SolvingView.swift
+++ b/ios/Pussel/Features/Solve/SolvingView.swift
@@ -12,10 +12,7 @@ struct SolvingView: View {
           expiredBanner
         }
         PuzzleOverlayView(session: session)
-        PieceCaptureView()
-        if !session.entries.isEmpty {
-          PieceQueueView(session: session)
-        }
+        PieceQueueView(session: session)
         if let error = session.errorMessage {
           Text(error)
             .font(.footnote)


### PR DESCRIPTION
## What

The solve screen no longer runs a live camera preview the whole time a puzzle is open. Instead, the piece list leads with a big dashed **+** tile; tapping it presents the camera full screen to shoot the next piece.

## Why

The `AVCaptureSession` previously ran for the entire solving session — a 280pt preview wedged between the puzzle image and the piece list, holding the screen awake throughout. The camera is only needed for the seconds you're actually photographing a piece.

## How

- **`PieceQueueView`** — the strip now starts with an `AddPieceTile` (84×84 dashed square with a plus, icon-only with an "Add piece" accessibility label). It presents `PieceCaptureView` as a `fullScreenCover` on device; on the Simulator, where `PieceCameraSession.isCameraAvailable` is false, it opens the photo library directly so that path still works. The `HStack` is top-aligned so the plus square lines up with the piece thumbnails rather than centering against their taller status labels.
- **`PieceCaptureView`** — reworked from an inline preview into a full-screen capture screen: edge-to-edge preview, centered shutter, Cancel top-left, and a photo-library button beside the shutter. It takes one photo, hands it to `model.addPiece`, and dismisses so the prediction lands back in the list. The session starts on appear and stops on disappear, so the camera isn't running while you look at the puzzle.
- **`SolvingView`** — dropped the standalone capture section; the piece list is now always shown (previously hidden when empty) so the **+** tile is there for the first piece.

## Verification

- `xcodebuild build` succeeds; `swift-format lint --strict` and `swiftlint --strict` pass; all unit tests pass.
- Drove the Simulator through trim → accept → add piece via the debug driver and confirmed the new layout by screenshot: puzzle image, then `Pieces (1)` with the **+** tile first and the captured piece beside it, no preview anywhere.
- ⚠️ The full-screen camera itself is **untested on device** — the Simulator has no camera, so the shutter, Cancel, and dismiss-after-capture paths have only been exercised as code, not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)