### PR TITLE
fix(ios): read the Google avatar from the Sign-In SDK, not the ID token

### DIFF
--- a/ios/Pussel/App/RootView.swift
+++ b/ios/Pussel/App/RootView.swift
@@ -46,7 +46,7 @@ struct AppFlowView: View {
               model.flow.reset()
             }
           } label: {
-            ProfileIconView(pictureURL: model.auth.user?.picture.flatMap(URL.init(string:)))
+            ProfileIconView(pictureURL: model.auth.avatarURL)
           }
           .accessibilityLabel("Account")
         }

--- a/ios/Pussel/Features/Auth/AuthService.swift
+++ b/ios/Pussel/Features/Auth/AuthService.swift
@@ -60,7 +60,7 @@ final class AuthService {
       guard let idToken = result.user.idToken?.tokenString else {
         throw APIError(message: "Google did not return an ID token.", status: nil)
       }
-      try await exchange(idToken: idToken)
+      try await exchange(idToken: idToken, googleUser: result.user)
     } catch let error as GIDSignInError where error.code == .canceled {
       // User dismissed the sheet.
     } catch {
@@ -72,12 +72,22 @@ final class AuthService {
     GIDSignIn.sharedInstance.signOut()
     authStore.user = nil
     authStore.backendToken = nil
+    authStore.avatarURL = nil
   }
 
-  private func exchange(idToken: String) async throws {
+  /// Avatar pixel size: the 28pt icon on a 3x screen, rounded up.
+  private static let avatarDimension: UInt = 96
+
+  private func exchange(idToken: String, googleUser: GIDGoogleUser) async throws {
     let response = try await apiClient.signInWithGoogle(idToken: idToken)
     authStore.backendToken = response.accessToken
     authStore.user = response.user
+    // Google omits the `picture` claim from ID tokens, so the backend's
+    // UserDTO.picture is null even for accounts that have an avatar. The
+    // Sign-In SDK resolves the profile separately and does have the URL.
+    authStore.avatarURL =
+      googleUser.profile?.imageURL(withDimension: Self.avatarDimension)
+      ?? response.user.picture.flatMap(URL.init(string:))
   }
 
   /// Silent re-auth used on launch and after 401s.
@@ -87,7 +97,7 @@ final class AuthService {
       let user = try await restorePreviousSignIn()
       let refreshed = try await refreshTokens(for: user)
       guard let idToken = refreshed.idToken?.tokenString else { return false }
-      try await exchange(idToken: idToken)
+      try await exchange(idToken: idToken, googleUser: refreshed)
       return true
     } catch {
       return false

--- a/ios/Pussel/Features/Auth/AuthService.swift
+++ b/ios/Pussel/Features/Auth/AuthService.swift
@@ -70,9 +70,7 @@ final class AuthService {
 
   func signOut() {
     GIDSignIn.sharedInstance.signOut()
-    authStore.user = nil
-    authStore.backendToken = nil
-    authStore.avatarURL = nil
+    authStore.clearSession()
   }
 
   /// Avatar pixel size: the 28pt icon on a 3x screen, rounded up.

--- a/ios/Pussel/Features/Auth/AuthStore.swift
+++ b/ios/Pussel/Features/Auth/AuthStore.swift
@@ -5,6 +5,9 @@ import Observation
 @MainActor
 final class AuthStore {
   var user: UserDTO?
+  /// The signed-in user's Google avatar, resolved by the Sign-In SDK rather
+  /// than from `user.picture` (ID tokens carry no `picture` claim).
+  var avatarURL: URL?
   /// Backend JWT, in memory only — reminted from the persisted Google
   /// session on launch and after 401s (60 min expiry, no refresh endpoint).
   var backendToken: String?

--- a/ios/Pussel/Features/Auth/AuthStore.swift
+++ b/ios/Pussel/Features/Auth/AuthStore.swift
@@ -15,4 +15,13 @@ final class AuthStore {
   var errorMessage: String?
 
   var isAuthenticated: Bool { backendToken != nil }
+
+  /// Drops every part of the signed-in session at once. Both the explicit
+  /// sign-out and the 401 session-drop go through here so neither can miss a
+  /// field as the session gains state.
+  func clearSession() {
+    user = nil
+    avatarURL = nil
+    backendToken = nil
+  }
 }

--- a/ios/Pussel/Networking/APIClient.swift
+++ b/ios/Pussel/Networking/APIClient.swift
@@ -116,8 +116,7 @@ final class APIClient {
         // Silent re-auth failed or the retry 401ed again — drop the
         // session so RootView falls back to SignInView instead of
         // leaving an "authenticated" UI whose every call fails.
-        authStore.backendToken = nil
-        authStore.user = nil
+        authStore.clearSession()
       }
       throw APIError.from(data: data, status: http.statusCode)
     }

--- a/ios/PusselTests/APIClientTests.swift
+++ b/ios/PusselTests/APIClientTests.swift
@@ -142,6 +142,9 @@ final class APIClientTests: XCTestCase {
 
   func test401WithoutReauthSurfacesError() async {
     authStore.backendToken = "stale"
+    authStore.user = UserDTO(
+      id: "u1", email: "u@example.com", name: "U", picture: nil, createdAt: nil)
+    authStore.avatarURL = URL(string: "https://lh3.googleusercontent.com/a/avatar=s96")
     StubURLProtocol.handler = { _ in
       (401, Data(#"{"detail": "Invalid or expired token"}"#.utf8))
     }
@@ -151,9 +154,11 @@ final class APIClientTests: XCTestCase {
     } catch let error as APIError {
       XCTAssertEqual(error.status, 401)
       XCTAssertEqual(error.message, "Authentication required. Please sign in.")
-      // The dead session must be dropped so the UI returns to sign-in.
+      // The dead session must be dropped in full so the UI returns to
+      // sign-in with nothing of the old session left behind.
       XCTAssertNil(authStore.backendToken)
       XCTAssertNil(authStore.user)
+      XCTAssertNil(authStore.avatarURL)
     } catch {
       XCTFail("Unexpected error type: \(error)")
     }


### PR DESCRIPTION
## Problem

The account menu avatar (added in #92) always showed the generic `person.crop.circle` fallback, even when signed in with a Google account that has a profile picture.

## Root cause

The icon sourced its URL from `UserDTO.picture`, which the backend fills from the **ID token's `picture` claim** — and **Google does not include a `picture` claim in ID tokens**.

Decoding the ID token from a real session confirms it:

```
CLAIMS SENT: [at_hash, aud, azp, email, email_verified, exp,
              family_name, given_name, iat, iss, name, nonce, sub]

  name     = Claus Thomasen
  picture  = <<< ABSENT >>>
```

`name` and `picture` come from the same `profile` scope, so the scope is granted correctly — the claim simply isn't there. The backend faithfully returned `"picture": null` and the view had nothing to render.

The backend can't fix this on its side: it only ever receives the ID token, never a Google access token, so it can't call the userinfo endpoint (which *does* return the picture).

## Fix

The Sign-In SDK resolves the profile separately and already has the URL client-side (`hasImage=true`), so the avatar now comes from `GIDGoogleUser.profile?.imageURL(withDimension:)`, with the backend's `picture` kept as a fallback in case Google ever sends the claim.

It's stored as `AuthStore.avatarURL` rather than backfilling the backend DTO, since the avatar genuinely doesn't originate from the backend. Sign-out clears it.

## Verification

- Reproduced the bug against a real restored Google session (default icon), then confirmed the fix renders the real avatar in the toolbar — same session, no debug token.
- Separately forced a known-good URL through the debug path first, which ruled out `AsyncImage` and the toolbar `Menu` label as suspects.
- `xcodebuild test`: 54 tests, 0 failures.

## Note (not addressed here)

`AsyncImage(url:content:placeholder:)` renders the placeholder on **failure** as well as while loading, so a broken avatar URL is visually indistinguishable from "no avatar" — that's what made this hard to spot. Worth a `phase`-based variant someday, but it isn't what caused this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)