### PR TITLE
Match model-input prep to training: black composite + pad-to-square

### DIFF
--- a/backend/app/services/image_processor.py
+++ b/backend/app/services/image_processor.py
@@ -89,6 +89,50 @@ def _pad_to_square(image: Image.Image) -> Image.Image:
     return canvas
 
 
+def _bound_longest_side(image: Image.Image, limit: int = PIECE_SIZE) -> Image.Image:
+    """Shrink an image so its longest side is at most ``limit``.
+
+    ``_pad_to_square`` allocates a canvas of ``max(width, height)`` per side, so
+    an elongated upload (8000x500) would expand into an 8000x8000 canvas — a
+    huge allocation driven by a small file, since MAX_UPLOAD_SIZE caps bytes and
+    not pixels. Inference resizes to ``PIECE_SIZE`` regardless, so bounding the
+    longest side first costs no fidelity: the scale factor and centering are the
+    same either way. Images already within the limit pass through untouched, so
+    upscaling stays with the inference resize.
+
+    Args:
+        image: The RGB image to bound.
+        limit: Maximum length of the longest side.
+
+    Returns:
+        The downscaled image, or the input unchanged when already within limit.
+    """
+    side = max(image.width, image.height)
+    if side <= limit:
+        return image
+    scale = limit / side
+    width = max(1, round(image.width * scale))
+    height = max(1, round(image.height * scale))
+    # BILINEAR matches the default used by the transforms.Resize below.
+    return image.resize((width, height), Image.Resampling.BILINEAR)
+
+
+def _prepare_model_input(image: Image.Image) -> Image.Image:
+    """Prepare a piece image for model inference.
+
+    Matches the exp20 training pieces and the exp25 north-star eval prep:
+    composite on black, then pad to a square so the fixed-size resize below
+    preserves the piece's aspect ratio instead of squashing it.
+
+    Args:
+        image: The piece image, RGBA from background removal or RGB otherwise.
+
+    Returns:
+        A square RGB image ready for the piece transform.
+    """
+    return _pad_to_square(_bound_longest_side(_composite_on_black(image)))
+
+
 def _extract_state_dict(checkpoint: Any) -> Any:
     """Return the model weights from a loaded checkpoint.
 
@@ -297,11 +341,9 @@ class ImageProcessor:
                 rgba_image.save(buffer, format="PNG")
                 cleaned_image_b64 = f"data:image/png;base64,{base64.b64encode(buffer.getvalue()).decode()}"
 
-                # Model input: composite on black and pad to square, matching
-                # the exp20 training pieces and the exp25 north-star eval prep
-                piece_img = _pad_to_square(_composite_on_black(rgba_image))
+                piece_img = _prepare_model_input(rgba_image)
             else:
-                piece_img = _pad_to_square(Image.open(io.BytesIO(contents)).convert("RGB"))
+                piece_img = _prepare_model_input(Image.open(io.BytesIO(contents)).convert("RGB"))
 
             # No model available (e.g. checkpoint not present): return a neutral
             # prediction but still hand back the cleaned cutout for display.

--- a/backend/app/services/image_processor.py
+++ b/backend/app/services/image_processor.py
@@ -47,6 +47,48 @@ PIECE_SIZE = 128
 PUZZLE_SIZE = 256
 
 
+def _composite_on_black(image: Image.Image) -> Image.Image:
+    """Composite an RGBA cutout onto a black background.
+
+    The exp20 training pieces (and the exp25 north-star eval that validated
+    this pipeline) put segmented pieces on black, so model inputs must match.
+
+    Args:
+        image: The piece image, typically RGBA from background removal.
+
+    Returns:
+        An RGB image with transparent regions rendered black.
+    """
+    rgb = Image.new("RGB", image.size, (0, 0, 0))
+    if image.mode == "RGBA":
+        rgb.paste(image, mask=image.split()[3])
+    else:
+        rgb.paste(image)
+    return rgb
+
+
+def _pad_to_square(image: Image.Image) -> Image.Image:
+    """Pad an RGB image to a centered square on black.
+
+    The model resizes inputs to a fixed square, so non-square crops must be
+    padded (as in training and the exp25 eval) rather than squashed, which
+    would distort the piece's aspect ratio.
+
+    Args:
+        image: The RGB image to pad.
+
+    Returns:
+        A square RGB image with the input centered on a black canvas, or the
+        input unchanged when it is already square.
+    """
+    side = max(image.width, image.height)
+    if image.width == side and image.height == side:
+        return image
+    canvas = Image.new("RGB", (side, side), (0, 0, 0))
+    canvas.paste(image, ((side - image.width) // 2, (side - image.height) // 2))
+    return canvas
+
+
 def _extract_state_dict(checkpoint: Any) -> Any:
     """Return the model weights from a loaded checkpoint.
 
@@ -255,14 +297,11 @@ class ImageProcessor:
                 rgba_image.save(buffer, format="PNG")
                 cleaned_image_b64 = f"data:image/png;base64,{base64.b64encode(buffer.getvalue()).decode()}"
 
-                # Convert to RGB with white background for model inference
-                piece_img = Image.new("RGB", rgba_image.size, (255, 255, 255))
-                if rgba_image.mode == "RGBA":
-                    piece_img.paste(rgba_image, mask=rgba_image.split()[3])
-                else:
-                    piece_img.paste(rgba_image)
+                # Model input: composite on black and pad to square, matching
+                # the exp20 training pieces and the exp25 north-star eval prep
+                piece_img = _pad_to_square(_composite_on_black(rgba_image))
             else:
-                piece_img = Image.open(io.BytesIO(contents)).convert("RGB")
+                piece_img = _pad_to_square(Image.open(io.BytesIO(contents)).convert("RGB"))
 
             # No model available (e.g. checkpoint not present): return a neutral
             # prediction but still hand back the cleaned cutout for display.

--- a/backend/tests/test_image_processor.py
+++ b/backend/tests/test_image_processor.py
@@ -1,17 +1,26 @@
 """Tests for the image processor's graceful degradation without a checkpoint."""
 
 import asyncio
+import base64
 import io
 from pathlib import Path
+from typing import Tuple, cast
 from unittest.mock import patch
 
 import pytest
 import torch
 from fastapi import UploadFile
 from PIL import Image
+from torch import Tensor
 
 from app.services import image_processor as ip_module
-from app.services.image_processor import ImageProcessor, _extract_state_dict, _load_checkpoint
+from app.services.image_processor import (
+    ImageProcessor,
+    _composite_on_black,
+    _extract_state_dict,
+    _load_checkpoint,
+    _pad_to_square,
+)
 
 
 def make_upload(content: bytes) -> UploadFile:
@@ -102,6 +111,135 @@ def test_corrupt_checkpoint_falls_back_to_no_model(tmp_path: Path) -> None:
         processor = ImageProcessor()
 
     assert processor.model is None
+
+
+def test_composite_on_black_renders_transparent_regions_black() -> None:
+    """Transparent pixels become black while opaque pixels keep their color."""
+    rgba = Image.new("RGBA", (4, 4), (0, 0, 0, 0))
+    rgba.putpixel((1, 1), (200, 50, 25, 255))
+
+    rgb = _composite_on_black(rgba)
+
+    assert rgb.mode == "RGB"
+    assert rgb.getpixel((0, 0)) == (0, 0, 0)
+    assert rgb.getpixel((1, 1)) == (200, 50, 25)
+
+
+def test_pad_to_square_centers_content_on_black() -> None:
+    """A non-square image is centered on a black square canvas of the longer side."""
+    img = Image.new("RGB", (10, 4), (255, 255, 255))
+
+    square = _pad_to_square(img)
+
+    assert square.size == (10, 10)
+    assert square.getpixel((5, 0)) == (0, 0, 0)  # padding row
+    assert square.getpixel((5, 5)) == (255, 255, 255)  # original content
+
+
+def test_pad_to_square_returns_square_input_unchanged() -> None:
+    """An already-square image is returned as-is."""
+    img = Image.new("RGB", (8, 8), (1, 2, 3))
+
+    assert _pad_to_square(img) is img
+
+
+class _FakeModel:
+    """Stand-in model returning fixed predictions for pipeline tests."""
+
+    def __call__(self, piece_tensor: Tensor, puzzle_tensor: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
+        """Return a fixed (position, rotation_logits, attention_map) triple."""
+        return (
+            torch.tensor([[0.25, 0.75]]),
+            torch.tensor([[5.0, 0.0, 0.0, 0.0]]),
+            torch.tensor([[0.9]]),
+        )
+
+
+def test_process_piece_model_input_is_black_composited_square() -> None:
+    """With background removal, the model sees the cutout on black, padded square.
+
+    This mirrors the exp20 training pieces and the exp25 north-star eval prep
+    (black composite + pad-to-square), not the previous white composite that
+    squashed non-square crops.
+    """
+    with patch.object(ip_module, "CHECKPOINT_PATH", "/nonexistent/checkpoint.pt"):
+        processor = ImageProcessor()
+
+    # Fake rembg output: a wide opaque red strip on a transparent canvas, so
+    # the alpha crop is wider than tall and square padding must add black rows.
+    rgba = Image.new("RGBA", (100, 60), (0, 0, 0, 0))
+    rgba.paste(Image.new("RGBA", (80, 20), (255, 0, 0, 255)), (10, 20))
+
+    class FakeRemover:
+        """Background remover stub returning the prebuilt RGBA cutout."""
+
+        def remove_background(self, contents: bytes) -> Image.Image:
+            """Return the fake rembg output regardless of input."""
+            return rgba
+
+    captured: list[Image.Image] = []
+    original_transform = processor.piece_transform
+
+    def spy_transform(img: Image.Image) -> Tensor:
+        captured.append(img)
+        return cast(Tensor, original_transform(img))
+
+    with (
+        patch.object(ip_module, "get_background_remover", return_value=FakeRemover()),
+        patch.object(ip_module.settings, "ENABLE_BACKGROUND_REMOVAL", True),
+        patch.object(processor, "model", _FakeModel()),
+        patch.object(processor, "piece_transform", spy_transform),
+        patch.object(processor, "_load_puzzle_tensor", return_value=torch.zeros(3, 256, 256)),
+    ):
+        result = asyncio.run(processor.process_piece(make_upload(make_jpeg()), "some-puzzle-id"))
+
+    assert len(captured) == 1
+    model_input = captured[0]
+    assert model_input.mode == "RGB"
+    assert model_input.width == model_input.height
+    # Padding rows and in-crop transparent regions are black; the piece keeps its color
+    assert model_input.getpixel((model_input.width // 2, 0)) == (0, 0, 0)
+    center = model_input.width // 2
+    assert model_input.getpixel((center, center)) == (255, 0, 0)
+
+    # The fake model's predictions flow through unchanged
+    assert result.position.x == pytest.approx(0.25)
+    assert result.position.y == pytest.approx(0.75)
+    assert result.rotation == 0
+
+    # The cleaned image for the frontend is still an RGBA PNG cutout
+    assert result.cleaned_image is not None
+    assert result.cleaned_image.startswith("data:image/png;base64,")
+    cleaned = Image.open(io.BytesIO(base64.b64decode(result.cleaned_image.split(",", 1)[1])))
+    assert cleaned.mode == "RGBA"
+
+
+def test_process_piece_without_background_removal_pads_to_square() -> None:
+    """Without background removal, a non-square upload is padded, not squashed."""
+    with patch.object(ip_module, "CHECKPOINT_PATH", "/nonexistent/checkpoint.pt"):
+        processor = ImageProcessor()
+
+    buffer = io.BytesIO()
+    Image.new("RGB", (90, 30), (0, 255, 0)).save(buffer, format="JPEG")
+
+    captured: list[Image.Image] = []
+    original_transform = processor.piece_transform
+
+    def spy_transform(img: Image.Image) -> Tensor:
+        captured.append(img)
+        return cast(Tensor, original_transform(img))
+
+    with (
+        patch.object(processor, "model", _FakeModel()),
+        patch.object(processor, "piece_transform", spy_transform),
+        patch.object(processor, "_load_puzzle_tensor", return_value=torch.zeros(3, 256, 256)),
+    ):
+        asyncio.run(processor.process_piece(make_upload(buffer.getvalue()), "some-puzzle-id", remove_background=False))
+
+    assert len(captured) == 1
+    model_input = captured[0]
+    assert model_input.size == (90, 90)
+    assert model_input.getpixel((45, 0)) == (0, 0, 0)  # black padding row
 
 
 def test_load_puzzle_tensor_rejects_non_uuid_puzzle_id() -> None:

--- a/backend/tests/test_image_processor.py
+++ b/backend/tests/test_image_processor.py
@@ -3,8 +3,10 @@
 import asyncio
 import base64
 import io
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Tuple, cast
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -15,7 +17,10 @@ from torch import Tensor
 
 from app.services import image_processor as ip_module
 from app.services.image_processor import (
+    PIECE_SIZE,
+    PUZZLE_SIZE,
     ImageProcessor,
+    _bound_longest_side,
     _composite_on_black,
     _extract_state_dict,
     _load_checkpoint,
@@ -143,16 +148,65 @@ def test_pad_to_square_returns_square_input_unchanged() -> None:
     assert _pad_to_square(img) is img
 
 
+def test_bound_longest_side_downscales_preserving_aspect() -> None:
+    """An oversized image is shrunk to the limit with its aspect ratio intact."""
+    img = Image.new("RGB", (8000, 500), (255, 255, 255))
+
+    bounded = _bound_longest_side(img, limit=PIECE_SIZE)
+
+    assert max(bounded.size) == PIECE_SIZE
+    assert bounded.size == (128, 8)  # 500 * 128/8000 = 8
+
+
+def test_bound_longest_side_leaves_small_image_unchanged() -> None:
+    """An image already within the limit passes through untouched.
+
+    Upscaling small crops stays with the inference resize, so this must not
+    enlarge anything.
+    """
+    img = Image.new("RGB", (40, 20), (9, 9, 9))
+
+    assert _bound_longest_side(img, limit=PIECE_SIZE) is img
+
+
 class _FakeModel:
     """Stand-in model returning fixed predictions for pipeline tests."""
 
-    def __call__(self, piece_tensor: Tensor, puzzle_tensor: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
+    def __call__(self, piece_tensor: Tensor, puzzle_tensor: Tensor) -> tuple[Tensor, Tensor, Tensor]:
         """Return a fixed (position, rotation_logits, attention_map) triple."""
         return (
             torch.tensor([[0.25, 0.75]]),
             torch.tensor([[5.0, 0.0, 0.0, 0.0]]),
             torch.tensor([[0.9]]),
         )
+
+
+@contextmanager
+def capture_model_input(processor: ImageProcessor) -> Iterator[list[Image.Image]]:
+    """Run process_piece against a fake model, capturing the image it is fed.
+
+    Yields a list that receives the image handed to ``piece_transform`` — the
+    prepared model input — for any process_piece call made inside the block.
+
+    Args:
+        processor: The processor whose model input should be captured.
+
+    Yields:
+        The list of captured model inputs.
+    """
+    captured: list[Image.Image] = []
+    original_transform = processor.piece_transform
+
+    def spy_transform(img: Image.Image) -> Tensor:
+        captured.append(img)
+        return cast(Tensor, original_transform(img))
+
+    with (
+        patch.object(processor, "model", _FakeModel()),
+        patch.object(processor, "piece_transform", spy_transform),
+        patch.object(processor, "_load_puzzle_tensor", return_value=torch.zeros(3, PUZZLE_SIZE, PUZZLE_SIZE)),
+    ):
+        yield captured
 
 
 def test_process_piece_model_input_is_black_composited_square() -> None:
@@ -177,19 +231,10 @@ def test_process_piece_model_input_is_black_composited_square() -> None:
             """Return the fake rembg output regardless of input."""
             return rgba
 
-    captured: list[Image.Image] = []
-    original_transform = processor.piece_transform
-
-    def spy_transform(img: Image.Image) -> Tensor:
-        captured.append(img)
-        return cast(Tensor, original_transform(img))
-
     with (
         patch.object(ip_module, "get_background_remover", return_value=FakeRemover()),
         patch.object(ip_module.settings, "ENABLE_BACKGROUND_REMOVAL", True),
-        patch.object(processor, "model", _FakeModel()),
-        patch.object(processor, "piece_transform", spy_transform),
-        patch.object(processor, "_load_puzzle_tensor", return_value=torch.zeros(3, 256, 256)),
+        capture_model_input(processor) as captured,
     ):
         result = asyncio.run(processor.process_piece(make_upload(make_jpeg()), "some-puzzle-id"))
 
@@ -222,24 +267,34 @@ def test_process_piece_without_background_removal_pads_to_square() -> None:
     buffer = io.BytesIO()
     Image.new("RGB", (90, 30), (0, 255, 0)).save(buffer, format="JPEG")
 
-    captured: list[Image.Image] = []
-    original_transform = processor.piece_transform
-
-    def spy_transform(img: Image.Image) -> Tensor:
-        captured.append(img)
-        return cast(Tensor, original_transform(img))
-
-    with (
-        patch.object(processor, "model", _FakeModel()),
-        patch.object(processor, "piece_transform", spy_transform),
-        patch.object(processor, "_load_puzzle_tensor", return_value=torch.zeros(3, 256, 256)),
-    ):
+    with capture_model_input(processor) as captured:
         asyncio.run(processor.process_piece(make_upload(buffer.getvalue()), "some-puzzle-id", remove_background=False))
 
     assert len(captured) == 1
     model_input = captured[0]
     assert model_input.size == (90, 90)
     assert model_input.getpixel((45, 0)) == (0, 0, 0)  # black padding row
+
+
+def test_process_piece_bounds_pad_canvas_for_elongated_upload() -> None:
+    """An elongated upload is downscaled before padding, bounding the canvas.
+
+    MAX_UPLOAD_SIZE caps bytes, not pixels, so a small file can decode to
+    extreme dimensions; padding those to square unbounded would allocate a
+    canvas of max(width, height) per side.
+    """
+    with patch.object(ip_module, "CHECKPOINT_PATH", "/nonexistent/checkpoint.pt"):
+        processor = ImageProcessor()
+
+    buffer = io.BytesIO()
+    Image.new("RGB", (4000, 200), (0, 0, 255)).save(buffer, format="JPEG")
+
+    with capture_model_input(processor) as captured:
+        asyncio.run(processor.process_piece(make_upload(buffer.getvalue()), "some-puzzle-id", remove_background=False))
+
+    assert len(captured) == 1
+    # Without the bound this canvas would be 4000x4000 (~48MB) instead of 128x128
+    assert captured[0].size == (PIECE_SIZE, PIECE_SIZE)
 
 
 def test_load_puzzle_tensor_rejects_non_uuid_puzzle_id() -> None:


### PR DESCRIPTION
## Summary
- `process_piece()` composited the rembg RGBA cutout onto **white** and let `Resize((128, 128))` squash the non-square bbox crop, but the exp20 CNN was trained on pieces composited on **black**, and the exp25 north-star eval validated the pipeline with black composite + pad-to-square.
- Add `_composite_on_black` and `_pad_to_square` helpers (mirroring what `piece_classifier.prepare_classifier_input` already does for the preview path) and use them to prepare the model input in both the background-removal and raw-upload branches.
- The `cleaned_image` RGBA PNG returned to the frontend is unchanged.

## Testing
- New unit tests for both helpers, plus pipeline tests that spy on `piece_transform` to assert the model input is a square RGB image with black padding/background and that `cleaned_image` is still an RGBA data-URL PNG.
- `make check-backend` (black, isort, flake8, pyright) clean; all 132 backend tests pass with coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)