### PR TITLE
Add swipe-to-delete with undo to the saved puzzles list

### DIFF
--- a/ios/Pussel/App/AppActions.swift
+++ b/ios/Pussel/App/AppActions.swift
@@ -122,12 +122,17 @@ extension AppModel {
     session.resume(api: api)
   }
 
-  /// Permanently deletes a stored puzzle. If it is the one being solved,
-  /// returns to the capture screen.
+  /// Deletes a stored puzzle, leaving a brief window to undo it. If it is the
+  /// one being solved, returns to the capture screen.
   func deletePuzzle(_ id: UUID) {
     if case .solving(let session) = flow.phase, session.id == id {
       flow.reset()
     }
-    store.delete(id)
+    store.deleteWithUndo(id)
+  }
+
+  /// Restores the most recently deleted puzzle, if its undo window is open.
+  func undoDelete() {
+    store.undoDelete()
   }
 }

--- a/ios/Pussel/Features/Capture/CapturePuzzleView.swift
+++ b/ios/Pussel/Features/Capture/CapturePuzzleView.swift
@@ -22,6 +22,8 @@ struct CapturePuzzleView: View {
       }
     }
     .scrollBounceBehavior(.basedOnSize)
+    .overlay(alignment: .bottom) { UndoDeleteSnackbar() }
+    .animation(.snappy, value: model.store.pendingDelete)
     .fullScreenCover(isPresented: $showCamera) {
       CameraPicker { image in
         Task { await handle(image: image, source: .camera) }

--- a/ios/Pussel/Features/Library/SavedPuzzlesSection.swift
+++ b/ios/Pussel/Features/Library/SavedPuzzlesSection.swift
@@ -1,10 +1,28 @@
 import SwiftUI
+import UIKit
+
+/// Shared metrics for the swipe row and the card it slides over. Kept outside
+/// `SwipeToDeleteRow` because generic types can't hold static stored properties.
+private enum SwipeMetrics {
+  static let cornerRadius: CGFloat = 12
+  /// Width of the revealed Delete button.
+  static let actionWidth: CGFloat = 80
+  /// How far the row must have travelled at the end of a drag to stay open.
+  static let openThreshold: CGFloat = 40
+  /// Extra red drawn to the left of the button so its rounded leading corners
+  /// stay tucked under the card instead of showing in the gap.
+  static let actionUnderlap: CGFloat = cornerRadius
+  /// Seconds of the release velocity to count toward the open/close decision,
+  /// so a fast flick opens the row even if it fell short of `openThreshold`.
+  static let flickProjection: CGFloat = 0.1
+}
 
 /// The list of locally stored puzzles shown beneath the capture buttons on the
-/// home screen. Tap a card to reopen it; long-press to delete.
+/// home screen. Tap a card to reopen it; swipe left (or long-press) to delete.
 struct SavedPuzzlesSection: View {
   @Environment(AppModel.self) private var model
-  @State private var pendingDelete: PuzzleSummary?
+  /// At most one row is swiped open at a time, mirroring `List`.
+  @State private var openRowID: UUID?
 
   var body: some View {
     // Lazy so rows (and their thumbnail decoding) are built only as they
@@ -15,37 +33,266 @@ struct SavedPuzzlesSection: View {
         .frame(maxWidth: .infinity, alignment: .leading)
 
       ForEach(model.store.puzzles) { puzzle in
-        Button {
-          model.openPuzzle(puzzle.id)
-        } label: {
-          SavedPuzzleRow(puzzle: puzzle)
-        }
-        .buttonStyle(.plain)
+        SwipeToDeleteRow(
+          isOpen: Binding(
+            get: { openRowID == puzzle.id },
+            set: { isOpen in
+              if isOpen {
+                openRowID = puzzle.id
+              } else if openRowID == puzzle.id {
+                openRowID = nil
+              }
+            }
+          ),
+          onOpen: { model.openPuzzle(puzzle.id) },
+          onDelete: { delete(puzzle) },
+          content: { SavedPuzzleRow(puzzle: puzzle) }
+        )
         .contextMenu {
           Button(role: .destructive) {
-            pendingDelete = puzzle
+            delete(puzzle)
           } label: {
             Label("Delete", systemImage: "trash")
           }
         }
       }
     }
-    .confirmationDialog(
-      "Delete this puzzle?",
-      isPresented: Binding(
-        get: { pendingDelete != nil },
-        set: { if !$0 { pendingDelete = nil } }
-      ),
-      titleVisibility: .visible,
-      presenting: pendingDelete
-    ) { puzzle in
-      Button("Delete", role: .destructive) {
-        model.deletePuzzle(puzzle.id)
-        pendingDelete = nil
+  }
+
+  /// Deletes straight away — the swipe is the deliberate act, so there's no
+  /// confirmation step. Animated so the surviving rows close the gap instead of
+  /// jumping up.
+  private func delete(_ puzzle: PuzzleSummary) {
+    openRowID = nil
+    withAnimation(.snappy) {
+      model.deletePuzzle(puzzle.id)
+    }
+  }
+}
+
+/// Floating "Deleted … / Undo" bar shown while a delete's undo window is open.
+/// Lives on the home screen rather than inside the list so it stays put at the
+/// bottom of the screen while the list scrolls underneath it.
+struct UndoDeleteSnackbar: View {
+  @Environment(AppModel.self) private var model
+
+  var body: some View {
+    if let pending = model.store.pendingDelete {
+      HStack(spacing: 12) {
+        // The picture says which puzzle went far better than its timestamp
+        // name did; "Deleted" alone then carries the meaning.
+        PuzzleThumbnail(data: pending.thumbnail, size: 32, cornerRadius: 6)
+        Text("Deleted")
+          .font(.subheadline)
+        Spacer(minLength: 0)
+        Button("Undo") {
+          withAnimation(.snappy) { model.undoDelete() }
+        }
+        .font(.subheadline.weight(.semibold))
       }
-      Button("Cancel", role: .cancel) { pendingDelete = nil }
-    } message: { puzzle in
-      Text("“\(puzzle.name)” and its pieces will be removed from this device.")
+      .padding(.leading, 10)
+      .padding(.trailing, 16)
+      .padding(.vertical, 8)
+      .background(.regularMaterial, in: Capsule())
+      .shadow(radius: 8, y: 2)
+      .padding(.horizontal, 24)
+      .padding(.bottom, 12)
+      .transition(.move(edge: .bottom).combined(with: .opacity))
+      // The thumbnail is meaningless to VoiceOver, so name the puzzle here.
+      .accessibilityElement(children: .contain)
+      .accessibilityLabel("Deleted “\(pending.name)”")
+    }
+  }
+}
+
+/// The stored puzzle picture, falling back to a placeholder symbol when a
+/// puzzle has no cached thumbnail.
+private struct PuzzleThumbnail: View {
+  let data: Data?
+  let size: CGFloat
+  let cornerRadius: CGFloat
+
+  var body: some View {
+    Group {
+      if let data, let image = UIImage(data: data) {
+        Image(uiImage: image)
+          .resizable()
+          .scaledToFill()
+      } else {
+        Image(systemName: "photo")
+          .foregroundStyle(.secondary)
+      }
+    }
+    .frame(width: size, height: size)
+    .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+  }
+}
+
+/// A row that slides left under a horizontal drag to reveal a red Delete
+/// button, the way `List`'s `swipeActions` does. Hand-rolled because this list
+/// is a `LazyVStack` in a `ScrollView`, not a `List`.
+private struct SwipeToDeleteRow<Content: View>: View {
+  @Binding var isOpen: Bool
+  let onOpen: () -> Void
+  let onDelete: () -> Void
+  /// Must be inert: the row owns the tap, because a `Button` here would win the
+  /// touch outright and every swipe would register as a tap on the card.
+  @ViewBuilder let content: Content
+
+  /// Live drag distance, folded into `offset` on top of the resting position.
+  @State private var translation: CGFloat = 0
+
+  /// Resting position plus the in-flight drag, clamped so the card can't be
+  /// pulled past the button or dragged right of its home position.
+  private var offset: CGFloat {
+    let resting: CGFloat = isOpen ? -SwipeMetrics.actionWidth : 0
+    return min(0, max(-SwipeMetrics.actionWidth, resting + translation))
+  }
+
+  var body: some View {
+    content
+      // The card is translucent, so it needs an opaque layer under it or the
+      // red button shows through the card as it slides.
+      .background(
+        Color(.systemBackground), in: RoundedRectangle(cornerRadius: SwipeMetrics.cornerRadius)
+      )
+      .contentShape(RoundedRectangle(cornerRadius: SwipeMetrics.cornerRadius))
+      // `offset` carries hit testing with it, so the card stays tappable where
+      // it's drawn and stops covering the button once it slides clear.
+      .offset(x: offset)
+      // A UIKit-backed pan, not a SwiftUI DragGesture — see HorizontalPanGesture
+      // for why the latter can't be used inside a ScrollView.
+      .gesture(swipe)
+      // While open, the card itself only closes the row — a stray tap must not
+      // open the puzzle the user is about to delete.
+      .onTapGesture {
+        if isOpen {
+          close()
+        } else {
+          onOpen()
+        }
+      }
+      .accessibilityElement(children: .combine)
+      .accessibilityAddTraits(.isButton)
+      // The button sits in the *card's* background rather than a ZStack sibling
+      // so the card alone sizes the row and the button can stretch to its
+      // height. A background is laid out in the unoffset frame, so it stays put
+      // while the card slides off it.
+      .background(alignment: .trailing) { deleteButton }
+      // VoiceOver can't swipe; give it the same action via the rotor.
+      .accessibilityAction(named: "Delete") { onDelete() }
+  }
+
+  private var deleteButton: some View {
+    Button(role: .destructive, action: onDelete) {
+      Label("Delete", systemImage: "trash")
+        .labelStyle(.iconOnly)
+        .font(.title3)
+        .foregroundStyle(.white)
+        .frame(maxHeight: .infinity)
+        .frame(width: SwipeMetrics.actionWidth)
+        // The underlap is drawn but never tapped — it stays under the card.
+        .padding(.leading, SwipeMetrics.actionUnderlap)
+        .background(.red, in: RoundedRectangle(cornerRadius: SwipeMetrics.cornerRadius))
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel("Delete puzzle")
+    // Hidden behind the card when closed, so keep it out of the tab/VoiceOver
+    // order until it's actually on screen.
+    .disabled(!isOpen)
+    .accessibilityHidden(!isOpen)
+  }
+
+  // Not `some Gesture`: a UIGestureRecognizerRepresentable isn't a Gesture, it
+  // just has its own `.gesture(_:)` overload.
+  private var swipe: HorizontalPanGesture {
+    HorizontalPanGesture(
+      onChanged: { translation = $0 },
+      onEnded: { velocity in
+        // Fold in the flick so a short, fast swipe opens the row rather than
+        // snapping back for falling short of the distance threshold.
+        let projected = offset + velocity * SwipeMetrics.flickProjection
+        withAnimation(.snappy(duration: 0.25)) {
+          isOpen = projected < -SwipeMetrics.openThreshold
+          translation = 0
+        }
+      }
+    )
+  }
+
+  private func close() {
+    withAnimation(.snappy(duration: 0.25)) {
+      isOpen = false
+      translation = 0
+    }
+  }
+}
+
+/// A pan recognizer that gives up the moment a drag looks vertical.
+///
+/// It marks itself `.failed` rather than declining via a delegate: SwiftUI
+/// installs its own delegate on a `UIGestureRecognizerRepresentable`, so a
+/// `gestureRecognizerShouldBegin` of ours is never consulted (verified — the
+/// list still refused to scroll). Failing from inside the recognizer is not
+/// overridable, and hands the touch back to the enclosing scroll view.
+private final class HorizontalPanRecognizer: UIPanGestureRecognizer {
+  /// How far a touch must travel before its direction is called. Below UIKit's
+  /// own ~10pt pan threshold, so the verdict lands before this recognizer would
+  /// otherwise begin and take the touch.
+  private static let decisionDistance: CGFloat = 8
+
+  private var origin: CGPoint?
+
+  override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+    super.touchesBegan(touches, with: event)
+    origin = touches.first?.location(in: view)
+  }
+
+  override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
+    // Judge before `super`, which is what would flip this to `.began`.
+    if state == .possible, let origin, let location = touches.first?.location(in: view) {
+      let dx = abs(location.x - origin.x)
+      let dy = abs(location.y - origin.y)
+      if max(dx, dy) >= Self.decisionDistance, dy > dx {
+        state = .failed
+        return
+      }
+    }
+    super.touchesMoved(touches, with: event)
+  }
+
+  override func reset() {
+    super.reset()
+    origin = nil
+  }
+}
+
+/// A pan gesture that reports sideways drags and ignores vertical ones.
+///
+/// SwiftUI's own `DragGesture` can't be used for this: attached anywhere inside
+/// a `ScrollView` it starves the scroll view's pan once it recognises, and
+/// neither `simultaneousGesture` nor a larger `minimumDistance` helps. Verified
+/// in the Simulator — with a `DragGesture` the list would not scroll from a
+/// card at all, while the same drag over the header scrolled fine.
+private struct HorizontalPanGesture: UIGestureRecognizerRepresentable {
+  /// Sideways distance from the start of the pan.
+  let onChanged: (CGFloat) -> Void
+  /// Release velocity, in points per second.
+  let onEnded: (CGFloat) -> Void
+
+  func makeUIGestureRecognizer(context: Context) -> HorizontalPanRecognizer {
+    HorizontalPanRecognizer()
+  }
+
+  func handleUIGestureRecognizerAction(_ recognizer: HorizontalPanRecognizer, context: Context) {
+    switch recognizer.state {
+    case .changed:
+      onChanged(recognizer.translation(in: recognizer.view).x)
+    case .ended, .cancelled:
+      onEnded(recognizer.velocity(in: recognizer.view).x)
+    default:
+      break
     }
   }
 }
@@ -55,7 +302,7 @@ private struct SavedPuzzleRow: View {
 
   var body: some View {
     HStack(spacing: 12) {
-      thumbnail
+      PuzzleThumbnail(data: puzzle.thumbnail, size: 56, cornerRadius: 8)
       VStack(alignment: .leading, spacing: 4) {
         Text(puzzle.name)
           .font(.subheadline.weight(.semibold))
@@ -71,23 +318,8 @@ private struct SavedPuzzleRow: View {
         .foregroundStyle(.tertiary)
     }
     .padding(10)
-    .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 12))
-  }
-
-  @ViewBuilder
-  private var thumbnail: some View {
-    Group {
-      if let data = puzzle.thumbnail, let image = UIImage(data: data) {
-        Image(uiImage: image)
-          .resizable()
-          .scaledToFill()
-      } else {
-        Image(systemName: "photo")
-          .foregroundStyle(.secondary)
-      }
-    }
-    .frame(width: 56, height: 56)
-    .clipShape(RoundedRectangle(cornerRadius: 8))
+    .background(
+      .quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: SwipeMetrics.cornerRadius))
   }
 
   private var subtitle: String {

--- a/ios/Pussel/Persistence/PuzzleStore.swift
+++ b/ios/Pussel/Persistence/PuzzleStore.swift
@@ -59,8 +59,18 @@ private struct StoredResult: Codable {
 @MainActor
 final class PuzzleStore {
   /// Home-screen rows, newest activity first. Refreshed after every mutation.
+  /// Excludes `pendingDelete` — a puzzle waiting out its undo window is gone
+  /// from the list even though its files are still on disk.
   private(set) var puzzles: [PuzzleSummary] = []
 
+  /// The puzzle hidden by the most recent `deleteWithUndo`, if its undo window
+  /// is still open. Drives the undo snackbar.
+  private(set) var pendingDelete: PuzzleSummary?
+
+  /// How long the user has to undo before the files actually go.
+  static let undoWindow: Duration = .seconds(5)
+
+  @ObservationIgnored private var purgeTask: Task<Void, Never>?
   @ObservationIgnored private let fileManager = FileManager.default
   @ObservationIgnored private let encoder: JSONEncoder
   @ObservationIgnored private let decoder: JSONDecoder
@@ -257,7 +267,46 @@ final class PuzzleStore {
     refresh()
   }
 
-  /// Rebuilds `puzzles` by scanning the store directory.
+  /// Hides a puzzle from the list and starts its undo window. Nothing is
+  /// touched on disk until the window closes, so quitting or crashing mid-undo
+  /// leaves the puzzle intact rather than half-deleted.
+  func deleteWithUndo(_ id: UUID) {
+    // Only one undo is offered at a time, so a second delete finishes the
+    // first — otherwise its files would linger with no way left to reach them.
+    commitPendingDelete()
+    guard let summary = puzzles.first(where: { $0.id == id }) else { return }
+    pendingDelete = summary
+    puzzles.removeAll { $0.id == id }
+    purgeTask = Task { [weak self] in
+      try? await Task.sleep(for: Self.undoWindow)
+      guard !Task.isCancelled else { return }
+      self?.commitPendingDelete()
+    }
+  }
+
+  /// Puts the pending puzzle back in the list and calls off the purge.
+  func undoDelete() {
+    purgeTask?.cancel()
+    purgeTask = nil
+    guard let summary = pendingDelete else { return }
+    pendingDelete = nil
+    upsert(summary)
+  }
+
+  /// Ends the undo window early and does the real delete. A no-op when nothing
+  /// is pending, so it's safe to call from anywhere that supersedes the undo.
+  func commitPendingDelete() {
+    purgeTask?.cancel()
+    purgeTask = nil
+    guard let pending = pendingDelete else { return }
+    // Cleared first: `delete` calls `refresh`, which would otherwise see the
+    // folder mid-removal and count it as still-pending.
+    pendingDelete = nil
+    delete(pending.id)
+  }
+
+  /// Rebuilds `puzzles` by scanning the store directory. A puzzle awaiting undo
+  /// is still on disk, so it has to be filtered back out or it reappears.
   func refresh() {
     let dirs =
       (try? fileManager.contentsOfDirectory(
@@ -265,6 +314,7 @@ final class PuzzleStore {
         includingPropertiesForKeys: [.isDirectoryKey]
       )) ?? []
     puzzles = dirs.compactMap { dir -> PuzzleSummary? in
+      guard dir.lastPathComponent != pendingDelete?.id.uuidString else { return nil }
       // The folder name is the canonical id (matching loadSession); use it
       // for the summary and all file lookups rather than manifest.id, which
       // could drift if a manifest was copied or moved.

--- a/ios/PusselTests/PuzzleStoreTests.swift
+++ b/ios/PusselTests/PuzzleStoreTests.swift
@@ -155,4 +155,80 @@ final class PuzzleStoreTests: XCTestCase {
     XCTAssertNil(store.loadSession(id: session.id))
     XCTAssertFalse(FileManager.default.fileExists(atPath: puzzleDir(session.id).path))
   }
+
+  func testDeleteWithUndoHidesPuzzleButKeepsFilesDuringWindow() throws {
+    let store = PuzzleStore()
+    let session = makeSession(store: store)
+    addTeardownBlock { @MainActor in store.delete(session.id) }
+    session.persist()
+
+    store.deleteWithUndo(session.id)
+
+    // Gone from the list, still whole on disk — the point of the undo window.
+    XCTAssertFalse(store.puzzles.contains { $0.id == session.id })
+    XCTAssertEqual(store.pendingDelete?.id, session.id)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: puzzleDir(session.id).path))
+
+    // A rescan must not resurrect the row just because the folder is there.
+    store.refresh()
+    XCTAssertFalse(store.puzzles.contains { $0.id == session.id })
+  }
+
+  func testUndoDeleteRestoresPuzzle() throws {
+    let store = PuzzleStore()
+    let session = makeSession(store: store)
+    addTeardownBlock { @MainActor in store.delete(session.id) }
+    session.persist()
+
+    store.deleteWithUndo(session.id)
+    store.undoDelete()
+
+    XCTAssertNil(store.pendingDelete)
+    XCTAssertTrue(store.puzzles.contains { $0.id == session.id })
+    XCTAssertNotNil(store.loadSession(id: session.id))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: puzzleDir(session.id).path))
+  }
+
+  func testCommitPendingDeleteRemovesFilesForGood() throws {
+    let store = PuzzleStore()
+    let session = makeSession(store: store)
+    addTeardownBlock { @MainActor in store.delete(session.id) }
+    session.persist()
+
+    store.deleteWithUndo(session.id)
+    store.commitPendingDelete()
+
+    XCTAssertNil(store.pendingDelete)
+    XCTAssertFalse(store.puzzles.contains { $0.id == session.id })
+    XCTAssertFalse(FileManager.default.fileExists(atPath: puzzleDir(session.id).path))
+
+    // Undoing after the window has closed must not resurrect a deleted row.
+    store.undoDelete()
+    XCTAssertFalse(store.puzzles.contains { $0.id == session.id })
+  }
+
+  func testSecondDeleteCommitsTheFirst() throws {
+    let store = PuzzleStore()
+    let first = makeSession(store: store, name: "First")
+    let second = makeSession(store: store, name: "Second")
+    addTeardownBlock { @MainActor in
+      store.delete(first.id)
+      store.delete(second.id)
+    }
+    first.persist()
+    second.persist()
+
+    store.deleteWithUndo(first.id)
+    store.deleteWithUndo(second.id)
+
+    // Only the newest delete is undoable; the first is already gone for good,
+    // otherwise its files would linger with no way left to reach them.
+    XCTAssertEqual(store.pendingDelete?.id, second.id)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: puzzleDir(first.id).path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: puzzleDir(second.id).path))
+
+    store.undoDelete()
+    XCTAssertTrue(store.puzzles.contains { $0.id == second.id })
+    XCTAssertFalse(store.puzzles.contains { $0.id == first.id })
+  }
 }


### PR DESCRIPTION
Swipe a puzzle card left on the home screen to reveal a red Delete button.

## Behaviour

- **Swipe left** on a saved puzzle card reveals a red trash button; tapping it deletes immediately, with no confirmation dialog.
- **Deletion is soft.** The row is hidden and the snackbar offers **Undo** for 5s; the files are only removed when that window closes. Quitting or crashing mid-window leaves the puzzle intact rather than half-deleted.
- The snackbar shows the puzzle's **thumbnail** (a timestamp name identifies it poorly) plus an Undo button. VoiceOver still gets the name via an accessibility label.
- Tapping an open row closes it rather than opening the puzzle; only one row is open at a time, mirroring `List`.
- The long-press context menu remains as a fallback and shares the same delete path.

## Why the swipe is hand-rolled

The list is a `LazyVStack` in a `ScrollView`, not a `List`, so `.swipeActions` isn't available. Two non-obvious traps, both caught by driving the Simulator rather than by the compiler:

- **The row content must be inert.** A `Button` there wins the touch outright, so every swipe registered as a tap and opened the puzzle. The swipe row owns the tap instead.
- **A SwiftUI `DragGesture` starves the enclosing ScrollView's pan** the moment it recognises — the list would not scroll from a card at all, while the same drag over the header scrolled fine. Neither `simultaneousGesture` nor a larger `minimumDistance` helps. The fix is a `UIPanGestureRecognizer` that marks *itself* `.failed` on a vertical drag, handing the touch back to the scroll view. It fails from inside rather than via a delegate because SwiftUI installs its own delegate on a `UIGestureRecognizerRepresentable`.

## Testing

- Four new `PuzzleStoreTests` cover the undo window (row hidden, files kept, rescan can't resurrect it), undo restoring the puzzle, commit removing files for good, and a second delete committing the first.
- `make check-ios` and the full test suite pass.
- Verified in the Simulator end to end: swipe reveals the button; delete removes the puzzle folder from disk; undo keeps it past the window and restores the row; tap-to-close, tap-to-open, and scrolling from a card all work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)