### PR TITLE
Add a pinch-zoom viewer for the puzzle on the solve screen

### DIFF
--- a/ios/Pussel/App/AppActions.swift
+++ b/ios/Pussel/App/AppActions.swift
@@ -21,9 +21,21 @@ extension AppModel {
     flow.errorMessage = nil
     flow.isBusy = true
     defer { flow.isBusy = false }
+    // Kept alongside the upload-size copy so the accepted trim can be re-warped
+    // sharply for the zoom viewer. Encoded off the main actor and in parallel
+    // with the detection round-trip, so a big photo neither freezes the screen
+    // nor delays the trim. Best-effort: a nil here costs zoom detail, not the
+    // capture.
+    async let zoomSourceJPEG = Task.detached(priority: .userInitiated) {
+      ImageUtilities.normalizedJPEG(
+        from: image, maxDimension: ImageUtilities.zoomSourceMaxDimension, quality: 0.85)
+    }.value
     do {
       let detection = try await api.detectFrame(jpegData: jpeg)
-      flow.phase = .confirmTrim(TrimCandidate(rawJPEG: jpeg, detection: detection, source: source))
+      flow.phase = .confirmTrim(
+        TrimCandidate(
+          rawJPEG: jpeg, zoomSourceJPEG: await zoomSourceJPEG, detection: detection, source: source)
+      )
     } catch {
       flow.errorMessage = error.localizedDescription
     }
@@ -56,12 +68,18 @@ extension AppModel {
     flow.errorMessage = nil
     flow.isBusy = true
     defer { flow.isBusy = false }
+    // Started alongside the upload rather than before it: the warp is pure
+    // local CPU and the upload is pure waiting, so overlapping them hides the
+    // zoom copy's cost behind the network entirely. Nothing downstream needs
+    // it until the session is built.
+    async let displayJPEG = zoomCopy(of: candidate, quarterTurns: quarterTurns)
     do {
       let response = try await api.uploadPuzzle(jpegData: trimmed, pieceCount: pieceCount)
       let session = SolveSession(
         name: Self.puzzleNameFormatter.string(from: Date()),
         puzzleId: response.puzzleId,
         trimmedJPEG: trimmed,
+        displayJPEG: await displayJPEG,
         targetPieceCount: pieceCount,
         rows: grid.rows,
         cols: grid.cols,
@@ -74,6 +92,39 @@ extension AppModel {
     } catch {
       flow.errorMessage = error.localizedDescription
     }
+  }
+
+  /// Re-warps the kept zoom-quality photo to the accepted trim, so the solve
+  /// screen can zoom into real detail instead of magnifying the
+  /// upload-resolution crop the backend returned.
+  ///
+  /// Uses the corners from the same detect-frame response the accepted
+  /// preview came from, so both copies frame the same region; `quarterTurns`
+  /// is the user's rotation, baked in here exactly as it is for the uploaded
+  /// image so the two stay in the same orientation.
+  ///
+  /// Best-effort throughout: every failure returns nil, leaving the session to
+  /// fall back to `trimmedJPEG` rather than blocking a working capture over a
+  /// display nicety.
+  ///
+  /// Runs off the main actor: decoding a multi-megapixel photo, warping it and
+  /// encoding the result takes long enough that doing it inline would freeze
+  /// the screen — including the very spinner meant to cover it.
+  private func zoomCopy(of candidate: TrimCandidate, quarterTurns: Int) async -> Data? {
+    guard let source = candidate.zoomSourceJPEG else { return nil }
+    let corners = candidate.detection.corners
+    return await Task.detached(priority: .userInitiated) {
+      guard let image = UIImage(data: source),
+        let corrected = ImageUtilities.perspectiveCorrected(from: image, corners: corners)
+      else {
+        return nil
+      }
+      // Rotate before encoding, so the copy is compressed once rather than
+      // decoded and re-encoded to turn it.
+      return ImageUtilities.normalizedJPEG(
+        from: ImageUtilities.rotated(corrected, quarterTurns: quarterTurns),
+        maxDimension: ImageUtilities.zoomMaxDimension, quality: 0.85)
+    }.value
   }
 
   /// Queues a captured piece photo for prediction in the current session.

--- a/ios/Pussel/App/AppActions.swift
+++ b/ios/Pussel/App/AppActions.swift
@@ -26,17 +26,27 @@ extension AppModel {
     // with the detection round-trip, so a big photo neither freezes the screen
     // nor delays the trim. Best-effort: a nil here costs zoom detail, not the
     // capture.
-    async let zoomSourceJPEG = Task.detached(priority: .userInitiated) {
+    //
+    // Unstructured on purpose. An `async let` is implicitly awaited when the
+    // scope exits, including the error path below — which would hold the
+    // spinner up through a whole encode before showing a detection failure.
+    let zoomSourceTask = Task.detached(priority: .userInitiated) {
       ImageUtilities.normalizedJPEG(
         from: image, maxDimension: ImageUtilities.zoomSourceMaxDimension, quality: 0.85)
-    }.value
+    }
     do {
       let detection = try await api.detectFrame(jpegData: jpeg)
       flow.phase = .confirmTrim(
         TrimCandidate(
-          rawJPEG: jpeg, zoomSourceJPEG: await zoomSourceJPEG, detection: detection, source: source)
+          rawJPEG: jpeg, zoomSourceJPEG: await zoomSourceTask.value, detection: detection,
+          source: source)
       )
     } catch {
+      // Marks the encode unwanted and drops it without waiting. It is plain
+      // synchronous pixel work, so it finishes on its own and the result is
+      // discarded — the point is that the failure surfaces now, not that the
+      // CPU stops.
+      zoomSourceTask.cancel()
       flow.errorMessage = error.localizedDescription
     }
   }
@@ -72,14 +82,18 @@ extension AppModel {
     // local CPU and the upload is pure waiting, so overlapping them hides the
     // zoom copy's cost behind the network entirely. Nothing downstream needs
     // it until the session is built.
-    async let displayJPEG = zoomCopy(of: candidate, quarterTurns: quarterTurns)
+    //
+    // Unstructured for the same reason as `startTrim`: an `async let` would be
+    // implicitly awaited on the way out of the error path too, leaving the
+    // spinner up for a whole warp before an upload failure could surface.
+    let zoomCopyTask = zoomCopyTask(for: candidate, quarterTurns: quarterTurns)
     do {
       let response = try await api.uploadPuzzle(jpegData: trimmed, pieceCount: pieceCount)
       let session = SolveSession(
         name: Self.puzzleNameFormatter.string(from: Date()),
         puzzleId: response.puzzleId,
         trimmedJPEG: trimmed,
-        displayJPEG: await displayJPEG,
+        displayJPEG: await zoomCopyTask.value,
         targetPieceCount: pieceCount,
         rows: grid.rows,
         cols: grid.cols,
@@ -90,6 +104,10 @@ extension AppModel {
       session.persist()
       flow.phase = .solving(session)
     } catch {
+      // See `startTrim`: dropped rather than waited on, so the upload failure
+      // is what the user sees next instead of a spinner over a warp whose
+      // result no session will ever hold.
+      zoomCopyTask.cancel()
       flow.errorMessage = error.localizedDescription
     }
   }
@@ -103,18 +121,21 @@ extension AppModel {
   /// is the user's rotation, baked in here exactly as it is for the uploaded
   /// image so the two stay in the same orientation.
   ///
-  /// Best-effort throughout: every failure returns nil, leaving the session to
+  /// Best-effort throughout: every failure yields nil, leaving the session to
   /// fall back to `trimmedJPEG` rather than blocking a working capture over a
   /// display nicety.
   ///
-  /// Runs off the main actor: decoding a multi-megapixel photo, warping it and
-  /// encoding the result takes long enough that doing it inline would freeze
-  /// the screen — including the very spinner meant to cover it.
-  private func zoomCopy(of candidate: TrimCandidate, quarterTurns: Int) async -> Data? {
-    guard let source = candidate.zoomSourceJPEG else { return nil }
+  /// Returns a running task rather than awaiting: the work is started so it can
+  /// overlap the upload, but the caller must stay free to abandon it if that
+  /// upload fails. It runs off the main actor because decoding a
+  /// multi-megapixel photo, warping it and encoding the result takes long
+  /// enough that doing it inline would freeze the screen — including the very
+  /// spinner meant to cover it.
+  private func zoomCopyTask(for candidate: TrimCandidate, quarterTurns: Int) -> Task<Data?, Never> {
+    let source = candidate.zoomSourceJPEG
     let corners = candidate.detection.corners
-    return await Task.detached(priority: .userInitiated) {
-      guard let image = UIImage(data: source),
+    return Task.detached(priority: .userInitiated) {
+      guard let source, let image = UIImage(data: source),
         let corrected = ImageUtilities.perspectiveCorrected(from: image, corners: corners)
       else {
         return nil
@@ -124,7 +145,7 @@ extension AppModel {
       return ImageUtilities.normalizedJPEG(
         from: ImageUtilities.rotated(corrected, quarterTurns: quarterTurns),
         maxDimension: ImageUtilities.zoomMaxDimension, quality: 0.85)
-    }.value
+    }
   }
 
   /// Queues a captured piece photo for prediction in the current session.

--- a/ios/Pussel/App/AppFlow.swift
+++ b/ios/Pussel/App/AppFlow.swift
@@ -18,7 +18,19 @@ enum CaptureSource {
 
 /// A detect-frame result awaiting user confirmation.
 struct TrimCandidate {
+  /// The photo as uploaded for detection — capped at the upload size, so the
+  /// detected `corners` are normalized to this image's frame.
   let rawJPEG: Data
+  /// The same photo kept at zoom quality, to re-warp into a sharp display
+  /// copy once the trim is accepted (see `AppModel.acceptTrim`). Nil when the
+  /// higher-resolution encode failed; the trim then falls back to the
+  /// server's upload-resolution crop.
+  ///
+  /// This is the *source photo*, not the crop taken from it — hence the
+  /// `zoomSource` naming it shares with `ImageUtilities.zoomSourceMaxDimension`,
+  /// which caps it. `SolveSession.zoomJPEG` is the other end of the pipeline:
+  /// the straightened crop that actually gets drawn.
+  let zoomSourceJPEG: Data?
   let detection: DetectFrameResponse
   let source: CaptureSource
 
@@ -61,6 +73,11 @@ final class SolveSession {
   let createdAt: Date
   var puzzleId: String
   let trimmedJPEG: Data
+  /// A higher-resolution copy of `trimmedJPEG` for the zoom viewer, or nil
+  /// for puzzles captured before it was kept (and when the local re-warp
+  /// failed). Never uploaded — `trimmedJPEG` remains the image the backend
+  /// predicted against. See `zoomJPEG`.
+  let displayJPEG: Data?
   /// Total piece count entered by the user when the puzzle was added —
   /// the puzzle's target size, not the number of captured pieces (which
   /// `PuzzleSummary.pieceCount` reports).
@@ -81,6 +98,7 @@ final class SolveSession {
     name: String,
     puzzleId: String,
     trimmedJPEG: Data,
+    displayJPEG: Data? = nil,
     targetPieceCount: Int,
     rows: Int,
     cols: Int,
@@ -91,6 +109,7 @@ final class SolveSession {
     self.name = name
     self.puzzleId = puzzleId
     self.trimmedJPEG = trimmedJPEG
+    self.displayJPEG = displayJPEG
     self.targetPieceCount = targetPieceCount
     self.rows = rows
     self.cols = cols
@@ -106,6 +125,12 @@ final class SolveSession {
   var placedEntries: [CaptureEntry] {
     entries.filter { $0.result != nil }
   }
+
+  /// Bytes the zoom viewer draws: the sharp copy when there is one, otherwise
+  /// the upload-resolution crop. The inline overlay deliberately stays on
+  /// `trimmedJPEG` — it is drawn a few hundred points wide, so decoding the
+  /// zoom copy for it would cost memory it can't show.
+  var zoomJPEG: Data { displayJPEG ?? trimmedJPEG }
 
   func enqueue(jpeg: Data, api: APIClient) {
     entries.append(CaptureEntry(jpeg: jpeg))

--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -8,6 +8,9 @@ import UIKit
 struct PieceQueueView: View {
   @Environment(AppModel.self) private var model
   let session: SolveSession
+  /// Invoked with a predicted piece's id when its tile is tapped, to open the
+  /// zoom viewer on where that piece was placed.
+  var onZoomToPiece: (UUID) -> Void = { _ in }
   @State private var isDeleteMode = false
   @State private var showCamera = false
   @State private var showLibrary = false
@@ -47,7 +50,8 @@ struct PieceQueueView: View {
             onRetry: { session.retry(id: entry.id, api: model.api) },
             onDelete: { withAnimation { session.remove(id: entry.id) } },
             onEnterDeleteMode: { withAnimation { isDeleteMode = true } },
-            onExitDeleteMode: { withAnimation { isDeleteMode = false } }
+            onExitDeleteMode: { withAnimation { isDeleteMode = false } },
+            onZoom: { onZoomToPiece(entry.id) }
           )
         }
       }
@@ -109,6 +113,7 @@ private struct QueueTile: View {
   let onDelete: () -> Void
   let onEnterDeleteMode: () -> Void
   let onExitDeleteMode: () -> Void
+  let onZoom: () -> Void
 
   /// Diameter of the visible badge circle.
   private static let badgeCircleSize: CGFloat = 22
@@ -190,8 +195,25 @@ private struct QueueTile: View {
     // reshuffle how its neighbours rock.
     .wiggle(isActive: isDeleteMode, seed: Int(entry.id.uuid.0))
     .contentShape(Rectangle())
+    // In delete mode a tap is the way out of it (the badges are the only
+    // thing meant to act there), so zooming waits until the grid is calm.
+    // A piece with no prediction yet has no place on the puzzle to zoom to.
     .onTapGesture {
-      if isDeleteMode { onExitDeleteMode() }
+      if isDeleteMode {
+        onExitDeleteMode()
+      } else if entry.result != nil {
+        onZoom()
+      }
+    }
+    // VoiceOver can't discover a tap gesture, so the zoom is published as an
+    // action on the tile rather than left implicit. Withheld exactly where the
+    // tap does something else (delete mode) or has nowhere to go (a piece with
+    // no prediction yet).
+    .accessibilityElement(children: .contain)
+    .accessibilityActions {
+      if !isDeleteMode, entry.result != nil {
+        Button("See placement on puzzle", action: onZoom)
+      }
     }
     // Simultaneous, because a plain `.onLongPressGesture` alongside
     // `.onTapGesture` loses the race and never fires.

--- a/ios/Pussel/Features/Solve/PuzzleFocusGeometry.swift
+++ b/ios/Pussel/Features/Solve/PuzzleFocusGeometry.swift
@@ -1,0 +1,46 @@
+import CoreGraphics
+
+/// Pure framing math for the zoom viewer (`PuzzleZoomView`), factored out so
+/// it's unit-testable without SwiftUI — the same treatment, and for the same
+/// reason, as `PieceMarkerGeometry`.
+enum PuzzleFocusGeometry {
+  /// How much of the puzzle to frame around a focused piece, in grid cells.
+  /// Wide enough to read the piece against its surroundings — which is the
+  /// point of looking — rather than filling the screen with the piece alone.
+  static let cellSpan: CGFloat = 3
+
+  /// Ceiling on the fraction of the puzzle a focused piece may frame, on
+  /// either axis.
+  ///
+  /// `cellSpan` alone measures nothing on a coarse grid: three cells of a
+  /// 12-piece puzzle is the whole board, so opening on a piece would land at
+  /// fit and the tap would look like it did nothing. Framing at most this much
+  /// keeps the jump visible (~2.5× in) whatever the grid, while on any puzzle
+  /// fine enough for three cells to be the smaller number, that span wins.
+  static let maxFraction: CGFloat = 0.4
+
+  /// Returns the region to open on, in the puzzle's normalized coordinates:
+  /// a `cellSpan`-cell box centred on `position`, never wider or taller than
+  /// `maxFraction` of the puzzle.
+  ///
+  /// Deliberately not clamped to the puzzle's bounds — a piece predicted near
+  /// an edge yields a rect that runs off it, and the scroll view pins the
+  /// resulting offset back to its content. Clamping here instead would shrink
+  /// the box and zoom edge pieces in further than middle ones.
+  ///
+  /// - Parameters:
+  ///   - position: the piece's centre, normalized to the puzzle.
+  ///   - rows: the puzzle's estimated grid rows.
+  ///   - cols: the puzzle's estimated grid columns.
+  static func focusRect(position: CGPoint, rows: Int, cols: Int) -> CGRect {
+    // A non-positive grid would divide by zero; fall back to the ceiling,
+    // which is a sane frame for any puzzle.
+    let width = cols > 0 ? min(cellSpan / CGFloat(cols), maxFraction) : maxFraction
+    let height = rows > 0 ? min(cellSpan / CGFloat(rows), maxFraction) : maxFraction
+    return CGRect(
+      x: position.x - width / 2,
+      y: position.y - height / 2,
+      width: width,
+      height: height)
+  }
+}

--- a/ios/Pussel/Features/Solve/PuzzleOverlayView.swift
+++ b/ios/Pussel/Features/Solve/PuzzleOverlayView.swift
@@ -5,8 +5,13 @@ import SwiftUI
 /// marker size is derived from the session's estimated grid (rows/cols)
 /// rather than a fixed ratio of the image, so pieces mismatched to the actual
 /// grid density scale correctly.
+///
+/// Tapping opens `PuzzleZoomView`, where the same markers are drawn over a
+/// sharper copy of the puzzle at whatever magnification the user pinches to.
 struct PuzzleOverlayView: View {
   let session: SolveSession
+  /// Invoked when the puzzle is tapped, to open the zoom viewer.
+  var onTap: () -> Void = {}
 
   var body: some View {
     if let image = UIImage(data: session.trimmedJPEG) {
@@ -15,44 +20,92 @@ struct PuzzleOverlayView: View {
         .scaledToFit()
         .overlay(Color.black.opacity(0.3))
         .overlay {
-          GeometryReader { geo in
-            ForEach(session.placedEntries) { entry in
-              if let piece = entry.result {
-                PieceMarker(entry: entry, piece: piece, canvas: geo.size, session: session)
-              }
-            }
-          }
+          PieceMarkerLayer(session: session)
         }
         .clipShape(RoundedRectangle(cornerRadius: 12))
+        .contentShape(RoundedRectangle(cornerRadius: 12))
+        .onTapGesture(perform: onTap)
+        .accessibilityElement()
+        .accessibilityLabel("Puzzle with \(session.placedEntries.count) placed pieces")
+        .accessibilityHint("Double tap to zoom in.")
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction(.default, onTap)
+    }
+  }
+}
+
+/// Every placed piece drawn over whatever space it's given, positioned in the
+/// puzzle's normalized coordinates. Shared by the inline overlay and the zoom
+/// viewer: it takes its canvas from the geometry it lands in, so the same
+/// markers serve a 350pt-wide thumbnail and a pinched-in close-up.
+struct PieceMarkerLayer: View {
+  let session: SolveSession
+  /// When set, every other marker is dimmed back so this one reads at a
+  /// glance — the reason the viewer was opened.
+  var focusedPieceID: UUID?
+
+  /// A placed piece with its image already decoded.
+  private struct Marker: Identifiable {
+    let id: UUID
+    let piece: PieceResponse
+    let image: UIImage?
+  }
+
+  private var decodedMarkers: [Marker] {
+    session.placedEntries.compactMap { entry in
+      guard let piece = entry.result else { return nil }
+      // The span (when present) describes the FULL displayed image frame,
+      // including the backend's transparent margin, so don't trim it there.
+      // In the null-span fallback, trim the margin from both display and
+      // aspect math so it doesn't inflate the marker.
+      let data = piece.pieceSpan == nil ? entry.trimmedDisplayImage : entry.displayImage
+      return Marker(id: entry.id, piece: piece, image: UIImage(data: data))
+    }
+  }
+
+  var body: some View {
+    // Bound here, outside the GeometryReader, on purpose: the closure below
+    // re-runs on every layout, and the zoom viewer relays this layer out on
+    // every pan and zoom frame. Decoding out here happens once per change to
+    // the pieces instead — the difference between a smooth pinch and a
+    // stuttering one.
+    let markers = decodedMarkers
+    GeometryReader { geo in
+      ForEach(markers) { marker in
+        PieceMarker(
+          piece: marker.piece,
+          image: marker.image,
+          canvas: geo.size,
+          session: session,
+          isDimmed: focusedPieceID != nil && marker.id != focusedPieceID
+        )
+      }
     }
   }
 }
 
 private struct PieceMarker: View {
-  let entry: CaptureEntry
   let piece: PieceResponse
+  /// Already decoded by `PieceMarkerLayer`, which knows which of the piece's
+  /// images to draw; nil when those bytes wouldn't decode.
+  let image: UIImage?
   let canvas: CGSize
   let session: SolveSession
+  var isDimmed = false
 
   var body: some View {
     let cellSize = CGSize(
       width: canvas.width / CGFloat(session.cols), height: canvas.height / CGFloat(session.rows))
-    // The span (when present) describes the FULL displayed image frame,
-    // including the backend's transparent margin, so don't trim it there.
-    // In the null-span fallback, trim the margin from both display and
-    // aspect math so it doesn't inflate the marker.
-    let displayData = piece.pieceSpan == nil ? entry.trimmedDisplayImage : entry.displayImage
-    let displayImage = UIImage(data: displayData)
     let markerSize = PieceMarkerGeometry.size(
       span: piece.pieceSpan,
-      imageSize: displayImage?.size ?? cellSize,
+      imageSize: image?.size ?? cellSize,
       canvas: canvas,
       cellSize: cellSize,
       rotation: piece.rotation
     )
     Group {
-      if let displayImage {
-        Image(uiImage: displayImage)
+      if let image {
+        Image(uiImage: image)
           .resizable()
           .scaledToFit()
           .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -60,6 +113,8 @@ private struct PieceMarker: View {
     }
     .frame(width: markerSize.width, height: markerSize.height)
     .background(.black.opacity(0.25))
+    // Chrome is sized in points, so it stays put as the canvas grows under
+    // zoom rather than swelling into a band across the piece it outlines.
     .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(.white, lineWidth: 1.5))
     .overlay(alignment: .bottom) {
       ConfidenceBar(value: piece.positionConfidence)
@@ -67,6 +122,7 @@ private struct PieceMarker: View {
     }
     .rotationEffect(.degrees(-Double(piece.rotation)))
     .position(x: canvas.width * piece.position.x, y: canvas.height * piece.position.y)
+    .opacity(isDimmed ? 0.25 : 1)
   }
 }
 

--- a/ios/Pussel/Features/Solve/PuzzleOverlayView.swift
+++ b/ios/Pussel/Features/Solve/PuzzleOverlayView.swift
@@ -27,7 +27,7 @@ struct PuzzleOverlayView: View {
         .onTapGesture(perform: onTap)
         .accessibilityElement()
         .accessibilityLabel("Puzzle with \(session.placedEntries.count) placed pieces")
-        .accessibilityHint("Double tap to zoom in.")
+        .accessibilityHint("Opens the puzzle in a zoomable full-screen view.")
         .accessibilityAddTraits(.isButton)
         .accessibilityAction(.default, onTap)
     }

--- a/ios/Pussel/Features/Solve/PuzzleZoomView.swift
+++ b/ios/Pussel/Features/Solve/PuzzleZoomView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+/// What the zoom viewer opens on: the whole puzzle, or one piece brought up
+/// close. Identifiable so it can drive a `fullScreenCover(item:)`.
+struct PuzzleZoomFocus: Identifiable, Equatable {
+  /// The piece to open centred on, or nil to open at fit.
+  let pieceID: UUID?
+
+  /// Stable stand-in for the whole-puzzle case, which has no piece to
+  /// identify it.
+  private static let wholePuzzleID = UUID()
+
+  var id: UUID { pieceID ?? Self.wholePuzzleID }
+}
+
+/// Full-screen, pinch-zoomable view of the puzzle with its predicted pieces
+/// drawn in place — the close look at where a piece landed that the inline
+/// overlay on the solve screen is too small to give.
+///
+/// A separate screen rather than zoom in place: the solve screen scrolls
+/// vertically, so panning a zoomed puzzle inside it would be a tug of war
+/// between the two for every drag.
+struct PuzzleZoomView: View {
+  let session: SolveSession
+  /// The piece to open on. Its marker is centred and the rest are dimmed;
+  /// nil opens the whole puzzle at fit with every marker at full strength.
+  let focus: PuzzleZoomFocus
+  @Environment(\.dismiss) private var dismiss
+
+  var body: some View {
+    ZStack(alignment: .topTrailing) {
+      Color.black.ignoresSafeArea()
+      if let image = UIImage(data: session.zoomJPEG) {
+        // No dimming scrim here, unlike the inline overlay: at zoom the
+        // artwork under the piece is exactly what you're comparing against.
+        ZoomableImageView(image: image, focusRect: focusRect) {
+          PieceMarkerLayer(session: session, focusedPieceID: focus.pieceID)
+        }
+        .ignoresSafeArea()
+      } else {
+        ContentUnavailableView("Could not load the puzzle image", systemImage: "photo")
+          .foregroundStyle(.white)
+      }
+      closeButton
+    }
+  }
+
+  private var closeButton: some View {
+    Button {
+      dismiss()
+    } label: {
+      Image(systemName: "xmark")
+        .font(.system(size: 15, weight: .bold))
+        .foregroundStyle(.white)
+        .frame(width: 36, height: 36)
+        .background(.black.opacity(0.55), in: Circle())
+    }
+    .buttonStyle(.plain)
+    .padding(16)
+    .accessibilityLabel("Close")
+  }
+
+  /// The region to open on, in the puzzle's normalized coordinates, or nil to
+  /// open the whole puzzle at fit. See `PuzzleFocusGeometry`.
+  private var focusRect: CGRect? {
+    guard let pieceID = focus.pieceID,
+      let piece = session.entries.first(where: { $0.id == pieceID })?.result
+    else {
+      return nil
+    }
+    return PuzzleFocusGeometry.focusRect(
+      position: CGPoint(x: piece.position.x, y: piece.position.y),
+      rows: session.rows,
+      cols: session.cols)
+  }
+}

--- a/ios/Pussel/Features/Solve/SolvingView.swift
+++ b/ios/Pussel/Features/Solve/SolvingView.swift
@@ -4,6 +4,8 @@ struct SolvingView: View {
   @Environment(AppModel.self) private var model
   let session: SolveSession
   @State private var isReuploading = false
+  /// Non-nil while the zoom viewer is up; carries what it opened on.
+  @State private var zoomFocus: PuzzleZoomFocus?
 
   var body: some View {
     ScrollView {
@@ -11,8 +13,12 @@ struct SolvingView: View {
         if session.puzzleExpired {
           expiredBanner
         }
-        PuzzleOverlayView(session: session)
-        PieceQueueView(session: session)
+        PuzzleOverlayView(session: session) {
+          zoomFocus = PuzzleZoomFocus(pieceID: nil)
+        }
+        PieceQueueView(session: session) { pieceID in
+          zoomFocus = PuzzleZoomFocus(pieceID: pieceID)
+        }
         if let error = session.errorMessage {
           Text(error)
             .font(.footnote)
@@ -20,6 +26,9 @@ struct SolvingView: View {
         }
       }
       .padding()
+    }
+    .fullScreenCover(item: $zoomFocus) { focus in
+      PuzzleZoomView(session: session, focus: focus)
     }
     .toolbar {
       // Work is saved locally, so leaving the session keeps it around on

--- a/ios/Pussel/Features/Solve/ZoomableImageView.swift
+++ b/ios/Pussel/Features/Solve/ZoomableImageView.swift
@@ -1,6 +1,14 @@
 import SwiftUI
 import UIKit
 
+/// How far the fit scale must move before it's treated as a real bounds change
+/// (rotation, a safe-area shift) rather than layout noise. Well below a scale
+/// change anyone could see, and far above float drift.
+///
+/// File scope because `ZoomableImageView` is generic, and a generic type can't
+/// hold a static stored property.
+private let fitEpsilon: CGFloat = 0.0001
+
 /// An image the user can pinch, pan and double-tap to zoom, with a SwiftUI
 /// `overlay` drawn on top that tracks the image as it moves.
 ///
@@ -135,11 +143,15 @@ struct ZoomableImageView<Overlay: View>: UIViewRepresentable {
       }
       let fit = min(
         scrollView.bounds.width / baseSize.width, scrollView.bounds.height / baseSize.height)
+      // Compared with a tolerance, not exactly: layoutSubviews runs throughout
+      // a pinch, and a sub-pixel drift in the bounds would otherwise re-seat
+      // zoomScale mid-gesture over a change too small to see.
+      //
       // `!hasSized` is not redundant with the scale check: an image that
       // happens to fit at exactly 1.0 matches UIScrollView's default minimum,
       // and would otherwise never be marked sized (leaving focus and
       // double-tap inert forever).
-      if !hasSized || scrollView.minimumZoomScale != fit {
+      if !hasSized || abs(scrollView.minimumZoomScale - fit) > fitEpsilon {
         // Hold the user's magnification across a bounds change (rotation)
         // rather than throwing them back to fit mid-inspection.
         let magnification = hasSized ? scrollView.zoomScale / scrollView.minimumZoomScale : 1

--- a/ios/Pussel/Features/Solve/ZoomableImageView.swift
+++ b/ios/Pussel/Features/Solve/ZoomableImageView.swift
@@ -129,20 +129,28 @@ struct ZoomableImageView<Overlay: View>: UIViewRepresentable {
 
     func viewForZooming(in scrollView: UIScrollView) -> UIView? { imageView }
 
-    /// Adopts a new image, keyed on its pixel size rather than on the instance.
+    /// Adopts a new image: always shows the given pixels, but only re-seats the
+    /// zoom when the picture's size changes.
     ///
-    /// SwiftUI hands a fresh `UIImage` down whenever the enclosing body
-    /// re-runs — a piece prediction landing while the viewer is open is enough,
-    /// since the image is built from the session each time. Those instances are
-    /// the same picture, so reacting to identity would re-seat the content and
-    /// throw the user's zoom away mid-inspection. A different size is what
-    /// actually means a different picture, and it's the only case that needs
-    /// the fit scale recomputed.
+    /// The two halves answer different questions and can't share a condition.
+    /// Whether to *display* it is about identity — the input must never be
+    /// silently dropped, or the view shows something other than what it was
+    /// handed. Whether to *re-seat* it is about size, because that alone
+    /// invalidates the fit scale and the content size.
+    ///
+    /// Keying both on identity would be the bug: SwiftUI hands a fresh
+    /// `UIImage` down whenever the enclosing body re-runs — a piece prediction
+    /// landing while the viewer is open is enough, since the image is rebuilt
+    /// from the session each time — and re-seating on those would throw the
+    /// user's zoom away mid-inspection. Keying both on size is the opposite
+    /// bug: a same-size replacement would never appear.
     func updateImage(_ image: UIImage, in scrollView: UIScrollView) {
       let size = CGSize(
         width: image.size.width * image.scale, height: image.size.height * image.scale)
-      guard size.width > 0, size.height > 0, size != baseSize else { return }
+      guard size.width > 0, size.height > 0 else { return }
+      guard imageView.image !== image else { return }
       imageView.image = image
+      guard size != baseSize else { return }
       imageView.frame = CGRect(origin: .zero, size: size)
       baseSize = size
       scrollView.contentSize = size

--- a/ios/Pussel/Features/Solve/ZoomableImageView.swift
+++ b/ios/Pussel/Features/Solve/ZoomableImageView.swift
@@ -1,0 +1,206 @@
+import SwiftUI
+import UIKit
+
+/// An image the user can pinch, pan and double-tap to zoom, with a SwiftUI
+/// `overlay` drawn on top that tracks the image as it moves.
+///
+/// Backed by `UIScrollView` rather than SwiftUI gestures, which buys the
+/// familiar feel — rubber-banding at the edges, momentum, zoom bounce — that a
+/// hand-rolled `MagnifyGesture`/`DragGesture` pair has to reimplement badly.
+///
+/// The overlay is a sibling of the zoomed image view, not a child, so the
+/// scroll view's zoom transform never touches it. Its frame is instead kept
+/// equal to the image's, which leaves it laying out its SwiftUI content afresh
+/// at every scale: content stays vector-crisp, and anything sized in points
+/// (a marker's border, its confidence bar) keeps a constant size on screen
+/// instead of growing into a slab over the artwork. As a side effect nothing
+/// here writes SwiftUI state from a scroll callback — the frame change alone
+/// drives the re-layout, so panning can't provoke a mid-update mutation.
+///
+/// The overlay is positioned in the image's own normalized space: it is handed
+/// exactly the image's rect, so a `GeometryReader` inside it can place a
+/// feature at (x, y) ∈ [0,1] as `geo.size * (x, y)`.
+struct ZoomableImageView<Overlay: View>: UIViewRepresentable {
+  /// The image to display. Its pixel size defines the zoom content size.
+  let image: UIImage
+  /// Region to zoom to, in normalized image coordinates. Applied when it
+  /// changes (and once the view has been laid out); nil opens at fit.
+  var focusRect: CGRect?
+  /// How far past fit the image may be magnified.
+  var maxMagnification: CGFloat = 6
+  /// Scale, relative to fit, that a double-tap zooms to.
+  var doubleTapMagnification: CGFloat = 3
+  @ViewBuilder let overlay: Overlay
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(maxMagnification: maxMagnification, doubleTapMagnification: doubleTapMagnification)
+  }
+
+  func makeUIView(context: Context) -> UIScrollView {
+    let coordinator = context.coordinator
+    let scrollView = LayoutReportingScrollView()
+    scrollView.delegate = coordinator
+    scrollView.showsVerticalScrollIndicator = false
+    scrollView.showsHorizontalScrollIndicator = false
+    scrollView.contentInsetAdjustmentBehavior = .never
+    scrollView.backgroundColor = .clear
+    scrollView.onLayout = { [weak coordinator, weak scrollView] in
+      guard let coordinator, let scrollView else { return }
+      coordinator.refreshLayout(scrollView)
+    }
+
+    // Sized in pixels so zoomScale 1 shows one image pixel per point, and the
+    // fit scale computed in `refreshLayout` is relative to the real image.
+    coordinator.baseSize = CGSize(
+      width: image.size.width * image.scale, height: image.size.height * image.scale)
+    coordinator.imageView.image = image
+    coordinator.imageView.frame = CGRect(origin: .zero, size: coordinator.baseSize)
+    scrollView.addSubview(coordinator.imageView)
+    scrollView.contentSize = coordinator.baseSize
+
+    let host = UIHostingController(rootView: overlay)
+    host.view.backgroundColor = .clear
+    // The overlay is decoration over the image: it must never intercept the
+    // pinch and pan that are the point of this view.
+    host.view.isUserInteractionEnabled = false
+    // Otherwise the host insets its content by the safe area, which would
+    // shift the overlay off the image it is meant to track.
+    host.safeAreaRegions = []
+    coordinator.host = host
+    scrollView.addSubview(host.view)
+
+    let doubleTap = UITapGestureRecognizer(
+      target: coordinator, action: #selector(Coordinator.handleDoubleTap(_:)))
+    doubleTap.numberOfTapsRequired = 2
+    scrollView.addGestureRecognizer(doubleTap)
+
+    return scrollView
+  }
+
+  func updateUIView(_ scrollView: UIScrollView, context: Context) {
+    let coordinator = context.coordinator
+    coordinator.host?.rootView = overlay
+    guard coordinator.requestedFocus != focusRect else { return }
+    coordinator.requestedFocus = focusRect
+    // Deferred when the view has no size yet (the first update lands before
+    // layout): refreshLayout applies it as soon as the bounds are real.
+    coordinator.pendingFocus = focusRect
+    coordinator.applyPendingFocus(scrollView, animated: true)
+  }
+
+  /// Reports every layout pass, which is where the fit scale can first be
+  /// computed and must be recomputed on rotation or a size change.
+  final class LayoutReportingScrollView: UIScrollView {
+    var onLayout: (() -> Void)?
+
+    override func layoutSubviews() {
+      super.layoutSubviews()
+      onLayout?()
+    }
+  }
+
+  final class Coordinator: NSObject, UIScrollViewDelegate {
+    let imageView = UIImageView()
+    var host: UIHostingController<Overlay>?
+    var baseSize: CGSize = .zero
+    /// The focus last handed to us, to detect a change (nil is a meaningful
+    /// value, so this can't just be the optional itself).
+    var requestedFocus: CGRect??
+    var pendingFocus: CGRect?
+
+    private let maxMagnification: CGFloat
+    private let doubleTapMagnification: CGFloat
+    private var hasSized = false
+
+    init(maxMagnification: CGFloat, doubleTapMagnification: CGFloat) {
+      self.maxMagnification = maxMagnification
+      self.doubleTapMagnification = doubleTapMagnification
+      imageView.contentMode = .scaleAspectFill
+      imageView.isUserInteractionEnabled = false
+    }
+
+    func viewForZooming(in scrollView: UIScrollView) -> UIView? { imageView }
+
+    func scrollViewDidZoom(_ scrollView: UIScrollView) {
+      syncOverlay(scrollView)
+    }
+
+    /// Establishes (and re-establishes) the fit scale, then keeps the content
+    /// centred and the overlay aligned.
+    func refreshLayout(_ scrollView: UIScrollView) {
+      guard scrollView.bounds.width > 0, scrollView.bounds.height > 0,
+        baseSize.width > 0, baseSize.height > 0
+      else {
+        return
+      }
+      let fit = min(
+        scrollView.bounds.width / baseSize.width, scrollView.bounds.height / baseSize.height)
+      // `!hasSized` is not redundant with the scale check: an image that
+      // happens to fit at exactly 1.0 matches UIScrollView's default minimum,
+      // and would otherwise never be marked sized (leaving focus and
+      // double-tap inert forever).
+      if !hasSized || scrollView.minimumZoomScale != fit {
+        // Hold the user's magnification across a bounds change (rotation)
+        // rather than throwing them back to fit mid-inspection.
+        let magnification = hasSized ? scrollView.zoomScale / scrollView.minimumZoomScale : 1
+        scrollView.minimumZoomScale = fit
+        scrollView.maximumZoomScale = fit * maxMagnification
+        scrollView.zoomScale = min(fit * magnification, fit * maxMagnification)
+        hasSized = true
+      }
+      syncOverlay(scrollView)
+      applyPendingFocus(scrollView, animated: false)
+    }
+
+    /// Zooms to the pending normalized rect, once there is a fit scale to
+    /// measure it against. Consumed on success so it fires only once.
+    func applyPendingFocus(_ scrollView: UIScrollView, animated: Bool) {
+      guard hasSized, let focus = pendingFocus, baseSize.width > 0, baseSize.height > 0 else {
+        return
+      }
+      pendingFocus = nil
+      // `zoom(to:)` takes the zoomed view's own coordinate space — the image
+      // at scale 1 — and clamps to maximumZoomScale, so a rect smaller than
+      // the detail we have simply stops at the sharpest scale on offer.
+      let rect = CGRect(
+        x: focus.minX * baseSize.width,
+        y: focus.minY * baseSize.height,
+        width: focus.width * baseSize.width,
+        height: focus.height * baseSize.height)
+      scrollView.zoom(to: rect, animated: animated)
+    }
+
+    @objc func handleDoubleTap(_ recognizer: UITapGestureRecognizer) {
+      guard let scrollView = recognizer.view as? UIScrollView, hasSized else { return }
+      let fit = scrollView.minimumZoomScale
+      if scrollView.zoomScale > fit * 1.01 {
+        scrollView.setZoomScale(fit, animated: true)
+        return
+      }
+      // Zoom in around the tapped point, so a double-tap on a piece brings up
+      // that piece rather than the middle of the puzzle.
+      let target = min(fit * doubleTapMagnification, scrollView.maximumZoomScale)
+      let point = recognizer.location(in: imageView)
+      let size = CGSize(
+        width: scrollView.bounds.width / target, height: scrollView.bounds.height / target)
+      scrollView.zoom(
+        to: CGRect(
+          x: point.x - size.width / 2, y: point.y - size.height / 2,
+          width: size.width, height: size.height),
+        animated: true)
+    }
+
+    /// Centres the content while it's smaller than the viewport and pins the
+    /// overlay to the image. Insets do the centring so the zoomed view's
+    /// transform is left alone.
+    private func syncOverlay(_ scrollView: UIScrollView) {
+      let insetX = max(0, (scrollView.bounds.width - scrollView.contentSize.width) / 2)
+      let insetY = max(0, (scrollView.bounds.height - scrollView.contentSize.height) / 2)
+      let inset = UIEdgeInsets(top: insetY, left: insetX, bottom: insetY, right: insetX)
+      if scrollView.contentInset != inset {
+        scrollView.contentInset = inset
+      }
+      host?.view.frame = imageView.frame
+    }
+  }
+}

--- a/ios/Pussel/Features/Solve/ZoomableImageView.swift
+++ b/ios/Pussel/Features/Solve/ZoomableImageView.swift
@@ -57,14 +57,10 @@ struct ZoomableImageView<Overlay: View>: UIViewRepresentable {
       coordinator.refreshLayout(scrollView)
     }
 
-    // Sized in pixels so zoomScale 1 shows one image pixel per point, and the
-    // fit scale computed in `refreshLayout` is relative to the real image.
-    coordinator.baseSize = CGSize(
-      width: image.size.width * image.scale, height: image.size.height * image.scale)
-    coordinator.imageView.image = image
-    coordinator.imageView.frame = CGRect(origin: .zero, size: coordinator.baseSize)
+    // The image itself is installed by `updateImage`, which SwiftUI calls
+    // immediately after this via `updateUIView` — so sizing lives in one place
+    // and handles both the first picture and any later one.
     scrollView.addSubview(coordinator.imageView)
-    scrollView.contentSize = coordinator.baseSize
 
     let host = UIHostingController(rootView: overlay)
     host.view.backgroundColor = .clear
@@ -88,6 +84,7 @@ struct ZoomableImageView<Overlay: View>: UIViewRepresentable {
   func updateUIView(_ scrollView: UIScrollView, context: Context) {
     let coordinator = context.coordinator
     coordinator.host?.rootView = overlay
+    coordinator.updateImage(image, in: scrollView)
     guard coordinator.requestedFocus != focusRect else { return }
     coordinator.requestedFocus = focusRect
     // Deferred when the view has no size yet (the first update lands before
@@ -110,7 +107,10 @@ struct ZoomableImageView<Overlay: View>: UIViewRepresentable {
   final class Coordinator: NSObject, UIScrollViewDelegate {
     let imageView = UIImageView()
     var host: UIHostingController<Overlay>?
-    var baseSize: CGSize = .zero
+    /// The current image's pixel size, which is the zoom content size: at
+    /// zoomScale 1 one image pixel covers one point, so the fit scale computed
+    /// in `refreshLayout` is relative to the real picture.
+    private(set) var baseSize: CGSize = .zero
     /// The focus last handed to us, to detect a change (nil is a meaningful
     /// value, so this can't just be the optional itself).
     var requestedFocus: CGRect??
@@ -128,6 +128,29 @@ struct ZoomableImageView<Overlay: View>: UIViewRepresentable {
     }
 
     func viewForZooming(in scrollView: UIScrollView) -> UIView? { imageView }
+
+    /// Adopts a new image, keyed on its pixel size rather than on the instance.
+    ///
+    /// SwiftUI hands a fresh `UIImage` down whenever the enclosing body
+    /// re-runs — a piece prediction landing while the viewer is open is enough,
+    /// since the image is built from the session each time. Those instances are
+    /// the same picture, so reacting to identity would re-seat the content and
+    /// throw the user's zoom away mid-inspection. A different size is what
+    /// actually means a different picture, and it's the only case that needs
+    /// the fit scale recomputed.
+    func updateImage(_ image: UIImage, in scrollView: UIScrollView) {
+      let size = CGSize(
+        width: image.size.width * image.scale, height: image.size.height * image.scale)
+      guard size.width > 0, size.height > 0, size != baseSize else { return }
+      imageView.image = image
+      imageView.frame = CGRect(origin: .zero, size: size)
+      baseSize = size
+      scrollView.contentSize = size
+      // A new picture gets a fresh fit rather than inheriting the old one's
+      // magnification.
+      hasSized = false
+      refreshLayout(scrollView)
+    }
 
     func scrollViewDidZoom(_ scrollView: UIScrollView) {
       syncOverlay(scrollView)

--- a/ios/Pussel/Persistence/PuzzleStore.swift
+++ b/ios/Pussel/Persistence/PuzzleStore.swift
@@ -52,7 +52,8 @@ private struct StoredResult: Codable {
 
 /// Local, on-device persistence for solved/in-progress puzzles. Everything is
 /// kept under `Documents/Puzzles/<uuid>/` — one folder per puzzle with a
-/// `manifest.json`, the `trimmed.jpg` picture, and a `pieces/` directory of
+/// `manifest.json`, the `trimmed.jpg` picture, an optional zoom-quality
+/// `display.jpg` of the same crop, and a `pieces/` directory of
 /// `<pieceId>-upload.jpg` (and optional `<pieceId>-display.jpg`) files. No
 /// server storage: reopening a puzzle rehydrates purely from disk.
 @Observable
@@ -101,6 +102,13 @@ final class PuzzleStore {
     let trimmed = trimmedURL(session.id)
     if !fileManager.fileExists(atPath: trimmed.path) {
       try? session.trimmedJPEG.write(to: trimmed, options: .atomic)
+    }
+    // The zoom copy is optional and immutable, so it's written once and its
+    // absence is a valid state (puzzles from before it was kept, and captures
+    // whose re-warp failed) — loadSession falls back to the trimmed image.
+    let display = puzzleDisplayURL(session.id)
+    if let displayJPEG = session.displayJPEG, !fileManager.fileExists(atPath: display.path) {
+      try? displayJPEG.write(to: display, options: .atomic)
     }
     // The trimmed image is immutable, so its downsampled thumbnail is
     // generated once and reused for the home-screen list.
@@ -231,6 +239,7 @@ final class PuzzleStore {
       name: manifest.name,
       puzzleId: manifest.serverPuzzleId,
       trimmedJPEG: trimmed,
+      displayJPEG: try? Data(contentsOf: puzzleDisplayURL(id)),
       targetPieceCount: manifest.pieceCount,
       rows: manifest.rows,
       cols: manifest.cols,
@@ -365,6 +374,12 @@ final class PuzzleStore {
 
   private func trimmedURL(_ id: UUID) -> URL {
     puzzleDir(id).appendingPathComponent("trimmed.jpg")
+  }
+
+  /// The puzzle's optional zoom-quality overview (`SolveSession.displayJPEG`),
+  /// distinct from a piece's `<pieceId>-display.jpg` under `pieces/`.
+  private func puzzleDisplayURL(_ id: UUID) -> URL {
+    puzzleDir(id).appendingPathComponent("display.jpg")
   }
 
   private func thumbnailURL(_ id: UUID) -> URL {

--- a/ios/Pussel/Support/ImageUtilities.swift
+++ b/ios/Pussel/Support/ImageUtilities.swift
@@ -1,9 +1,38 @@
+import CoreImage
+import CoreImage.CIFilterBuiltins
 import ImageIO
 import UIKit
 
 enum ImageUtilities {
   /// Backend rejects uploads above 10 MB (413).
   static let maxUploadBytes = 10 * 1024 * 1024
+
+  /// Long-side cap for the puzzle's zoom copy — the straightened crop itself,
+  /// not the photo it came from (see `perspectiveCorrectedJPEG`).
+  ///
+  /// The uploaded image is capped at 1920 by `normalizedJPEG`, and the crop
+  /// taken from it is smaller again, so on a 3× phone the server's copy is
+  /// already at one image pixel per device pixel when it merely *fits* the
+  /// screen: pinching it magnifies JPEG artefacts from the first gesture.
+  ///
+  /// True magnification costs pixels fast — the crop needs `n` × the screen's
+  /// 1206px width to stay sharp at `n`×, and its area (and decoded memory)
+  /// grows with the square. 3600 buys roughly 2× before softness at ~35 MB
+  /// decoded; 3× would want ~76 MB for one image, which is not a trade worth
+  /// making for the top of a zoom range. Above 2× the viewer is upscaling —
+  /// still a far better look at a piece than the 350pt inline overlay, but
+  /// not new detail.
+  static let zoomMaxDimension: CGFloat = 3600
+
+  /// Long-side cap for the *photo* kept to re-warp into the zoom copy.
+  ///
+  /// Sized off `zoomMaxDimension`, not chosen independently: the crop is a
+  /// quadrilateral inside the photo, so the photo must be the larger of the
+  /// two for the crop to reach its own cap. A puzzle shot at an angle can run
+  /// close to the frame's diagonal, so the margin here is what keeps the crop
+  /// from landing short of `zoomMaxDimension` on exactly the tilted shots
+  /// that need straightening most.
+  static let zoomSourceMaxDimension: CGFloat = 4400
 
   /// Downsamples JPEG data to a small thumbnail (long side ~`maxPixel`) using
   /// ImageIO, which decodes only what the thumbnail needs. Used for the
@@ -65,6 +94,101 @@ enum ImageUtilities {
     return encoded
   }
 
+  // MARK: Perspective correction
+
+  /// Perspective-corrects `image` to the quadrilateral `corners`, with the
+  /// result's long side at most `maxDimension`.
+  ///
+  /// Returns an image rather than JPEG bytes so a caller that still has to
+  /// rotate it (see `AppModel.acceptTrim`) can do so before encoding, and pay
+  /// one lossy pass instead of two.
+  ///
+  /// This reproduces locally the crop the backend's detect-frame endpoint
+  /// already returned, but from a higher-resolution source: `corners` are
+  /// normalized, so they describe the same region of the photo at any
+  /// resolution, and re-running the warp here avoids uploading a second,
+  /// much larger copy of the photo just to get a sharper picture back.
+  ///
+  /// The output frames the same region as the server's `trimmed_image` and
+  /// carries its aspect ratio (the target size below mirrors the dst_w/dst_h
+  /// formula in backend/app/services/puzzle_detector.py's `warp`), which is
+  /// what makes the two interchangeable for display: piece positions are
+  /// normalized to the trimmed puzzle's frame, so they land in the same place
+  /// on either copy. It is deliberately not pixel-identical — Core Image and
+  /// OpenCV resample differently — and is only ever shown, never uploaded or
+  /// measured against.
+  ///
+  /// - Parameters:
+  ///   - image: the full-resolution photo the corners were detected in.
+  ///   - corners: the quad to straighten, normalized to `image`'s frame with
+  ///     a top-left origin, as returned by `DetectFrameResponse`.
+  ///   - maxDimension: long-side cap for the result.
+  /// - Returns: the straightened image, or nil when it can't be decoded, the
+  ///   quad is degenerate, or rendering fails.
+  static func perspectiveCorrected(
+    from image: UIImage,
+    corners: QuadCorners,
+    maxDimension: CGFloat = zoomMaxDimension
+  ) -> UIImage? {
+    // Bake any EXIF orientation into the pixels first: the corners are
+    // normalized to the upright photo the user saw and the backend detected
+    // in (it applies exif_transpose), not to the raw sensor buffer.
+    let upright =
+      (image.imageOrientation == .up && image.cgImage != nil) ? image : redrawnUpright(image)
+    guard let cgImage = upright.cgImage else { return nil }
+    let width = CGFloat(cgImage.width)
+    let height = CGFloat(cgImage.height)
+    guard width > 0, height > 0 else { return nil }
+
+    // Core Image's coordinate space has its origin at the bottom left, so the
+    // top-left-origin normalized corners flip in y.
+    func point(_ corner: NormalizedPoint) -> CGPoint {
+      CGPoint(x: CGFloat(corner.x) * width, y: (1 - CGFloat(corner.y)) * height)
+    }
+    let topLeft = point(corners.topLeft)
+    let topRight = point(corners.topRight)
+    let bottomRight = point(corners.bottomRight)
+    let bottomLeft = point(corners.bottomLeft)
+
+    // Each output side takes the longer of the two source edges it could come
+    // from, so a quad seen at an angle straightens to the larger, undistorted
+    // rectangle rather than the foreshortened one.
+    let targetWidth = max(distance(topLeft, topRight), distance(bottomLeft, bottomRight))
+    let targetHeight = max(distance(topLeft, bottomLeft), distance(topRight, bottomRight))
+    guard targetWidth >= 1, targetHeight >= 1 else { return nil }
+
+    let filter = CIFilter.perspectiveCorrection()
+    filter.inputImage = CIImage(cgImage: cgImage)
+    filter.topLeft = topLeft
+    filter.topRight = topRight
+    filter.bottomRight = bottomRight
+    filter.bottomLeft = bottomLeft
+    filter.crop = true
+    guard let corrected = filter.outputImage, corrected.extent.width > 0,
+      corrected.extent.height > 0
+    else {
+      return nil
+    }
+
+    // Never upscale: a photo smaller than the cap has no more detail to give.
+    let scale = min(1, maxDimension / max(targetWidth, targetHeight))
+    // Scale from Core Image's own rectified extent onto the target size,
+    // rather than by a single factor, so the result carries the aspect ratio
+    // computed above even where the two rectifications disagree slightly.
+    let transform = CGAffineTransform(
+      scaleX: targetWidth * scale / corrected.extent.width,
+      y: targetHeight * scale / corrected.extent.height)
+    let scaled = corrected.transformed(by: transform)
+
+    let context = CIContext()
+    guard let output = context.createCGImage(scaled, from: scaled.extent) else { return nil }
+    return UIImage(cgImage: output)
+  }
+
+  private static func distance(_ from: CGPoint, _ to: CGPoint) -> CGFloat {
+    CGFloat(hypot(to.x - from.x, to.y - from.y))
+  }
+
   /// Returns `image` rotated clockwise by `quarterTurns` × 90°. When
   /// `quarterTurns` normalizes to 0 the image is returned unchanged. For a
   /// non-zero turn, any existing EXIF orientation is baked into the pixels
@@ -105,6 +229,7 @@ enum ImageUtilities {
   /// unchanged when no rotation is requested, or `nil` when a requested
   /// rotation cannot be applied — so a caller never uploads an unrotated image
   /// believing it was rotated.
+  ///
   static func rotatedJPEG(from data: Data, quarterTurns: Int) -> Data? {
     guard ((quarterTurns % 4) + 4) % 4 != 0 else { return data }
     guard let image = UIImage(data: data) else { return nil }

--- a/ios/Pussel/Support/ImageUtilities.swift
+++ b/ios/Pussel/Support/ImageUtilities.swift
@@ -8,7 +8,8 @@ enum ImageUtilities {
   static let maxUploadBytes = 10 * 1024 * 1024
 
   /// Long-side cap for the puzzle's zoom copy — the straightened crop itself,
-  /// not the photo it came from (see `perspectiveCorrectedJPEG`).
+  /// not the photo it came from (see
+  /// `perspectiveCorrected(from:corners:maxDimension:)`).
   ///
   /// The uploaded image is capped at 1920 by `normalizedJPEG`, and the crop
   /// taken from it is smaller again, so on a 3× phone the server's copy is

--- a/ios/PusselTests/ImageUtilitiesTests.swift
+++ b/ios/PusselTests/ImageUtilitiesTests.swift
@@ -44,6 +44,96 @@ final class ImageUtilitiesTests: XCTestCase {
     XCTAssertEqual(turned.size, CGSize(width: 4, height: 8))
   }
 
+  // MARK: perspectiveCorrected(from:corners:maxDimension:)
+
+  /// A quad covering the whole image, so the correction is a no-op crop and
+  /// only the sizing behaviour is under test.
+  private func fullFrameCorners() -> QuadCorners {
+    QuadCorners(
+      topLeft: NormalizedPoint(x: 0, y: 0),
+      topRight: NormalizedPoint(x: 1, y: 0),
+      bottomRight: NormalizedPoint(x: 1, y: 1),
+      bottomLeft: NormalizedPoint(x: 0, y: 1))
+  }
+
+  private func correctedSize(
+    _ image: UIImage, corners: QuadCorners, maxDimension: CGFloat
+  ) throws -> CGSize {
+    let corrected = try XCTUnwrap(
+      ImageUtilities.perspectiveCorrected(
+        from: image, corners: corners, maxDimension: maxDimension))
+    return CGSize(
+      width: corrected.size.width * corrected.scale,
+      height: corrected.size.height * corrected.scale)
+  }
+
+  func testPerspectiveCorrectedFullFrameKeepsSizeUnderCap() throws {
+    let size = try correctedSize(
+      makeImage(width: 800, height: 400), corners: fullFrameCorners(), maxDimension: 3000)
+    // Comfortably under the cap, so the whole frame survives at 1:1 rather
+    // than being upscaled to meet it.
+    XCTAssertEqual(size, CGSize(width: 800, height: 400))
+  }
+
+  func testPerspectiveCorrectedDownscalesLongSideToCap() throws {
+    let size = try correctedSize(
+      makeImage(width: 800, height: 400), corners: fullFrameCorners(), maxDimension: 200)
+    XCTAssertEqual(size.width, 200, accuracy: 1)
+    XCTAssertEqual(size.height, 100, accuracy: 1)
+  }
+
+  func testPerspectiveCorrectedCropsToQuad() throws {
+    // The left half of an 800×400 image: a 400×400 square, so the result must
+    // carry the quad's aspect ratio, not the source photo's.
+    let corners = QuadCorners(
+      topLeft: NormalizedPoint(x: 0, y: 0),
+      topRight: NormalizedPoint(x: 0.5, y: 0),
+      bottomRight: NormalizedPoint(x: 0.5, y: 1),
+      bottomLeft: NormalizedPoint(x: 0, y: 1))
+    let size = try correctedSize(
+      makeImage(width: 800, height: 400), corners: corners, maxDimension: 3000)
+    XCTAssertEqual(size.width, 400, accuracy: 1)
+    XCTAssertEqual(size.height, 400, accuracy: 1)
+  }
+
+  func testPerspectiveCorrectedStraightensSkewedQuadToLongestEdges() throws {
+    // A quad whose top edge spans half the width and whose bottom edge spans
+    // all of it — a picture shot at an angle. Each output side takes the
+    // longer of its two source edges, so this straightens to the full 800
+    // wide rather than the foreshortened 400.
+    let corners = QuadCorners(
+      topLeft: NormalizedPoint(x: 0.25, y: 0),
+      topRight: NormalizedPoint(x: 0.75, y: 0),
+      bottomRight: NormalizedPoint(x: 1, y: 1),
+      bottomLeft: NormalizedPoint(x: 0, y: 1))
+    let size = try correctedSize(
+      makeImage(width: 800, height: 400), corners: corners, maxDimension: 3000)
+    XCTAssertEqual(size.width, 800, accuracy: 1)
+  }
+
+  func testPerspectiveCorrectedDegenerateQuadReturnsNil() {
+    // Every corner in the same place: no region to straighten.
+    let point = NormalizedPoint(x: 0.5, y: 0.5)
+    let corners = QuadCorners(
+      topLeft: point, topRight: point, bottomRight: point, bottomLeft: point)
+    XCTAssertNil(
+      ImageUtilities.perspectiveCorrected(
+        from: makeImage(width: 800, height: 400), corners: corners))
+  }
+
+  func testPerspectiveCorrectedFeedsRotationWithoutAReEncode() throws {
+    // The zoom copy's pipeline (AppModel.acceptTrim): warp, rotate, encode
+    // once. `perspectiveCorrected` returning an image is what lets the
+    // rotation happen before the single lossy pass.
+    let corrected = try XCTUnwrap(
+      ImageUtilities.perspectiveCorrected(
+        from: makeImage(width: 800, height: 400), corners: fullFrameCorners(),
+        maxDimension: 3000))
+    let turned = ImageUtilities.rotated(corrected, quarterTurns: 1)
+    XCTAssertEqual(turned.size.width * turned.scale, 400, accuracy: 1)
+    XCTAssertEqual(turned.size.height * turned.scale, 800, accuracy: 1)
+  }
+
   // MARK: rotatedJPEG(from:quarterTurns:)
 
   func testRotatedJPEGZeroTurnsReturnsInputUnchanged() throws {

--- a/ios/PusselTests/PuzzleFocusGeometryTests.swift
+++ b/ios/PusselTests/PuzzleFocusGeometryTests.swift
@@ -1,0 +1,60 @@
+import CoreGraphics
+import XCTest
+
+@testable import Pussel
+
+final class PuzzleFocusGeometryTests: XCTestCase {
+  private let centre = CGPoint(x: 0.5, y: 0.5)
+
+  func testFocusRectIsCentredOnThePiece() {
+    let rect = PuzzleFocusGeometry.focusRect(
+      position: CGPoint(x: 0.25, y: 0.8), rows: 20, cols: 20)
+    XCTAssertEqual(rect.midX, 0.25, accuracy: 0.0001)
+    XCTAssertEqual(rect.midY, 0.8, accuracy: 0.0001)
+  }
+
+  func testFineGridFramesThreeCells() {
+    // 3 of 30 columns is a tenth of the puzzle — well under the ceiling, so
+    // the cell span is what decides the frame.
+    let rect = PuzzleFocusGeometry.focusRect(position: centre, rows: 40, cols: 30)
+    XCTAssertEqual(rect.width, 0.1, accuracy: 0.0001)
+    XCTAssertEqual(rect.height, 0.075, accuracy: 0.0001)
+  }
+
+  func testCoarseGridIsCappedSoTheZoomStaysVisible() {
+    // The regression this cap exists for: on a 4×3 puzzle, three cells is the
+    // entire width, which resolves to fit — opening on a piece would look like
+    // the tap did nothing.
+    let rect = PuzzleFocusGeometry.focusRect(position: centre, rows: 4, cols: 3)
+    XCTAssertEqual(rect.width, PuzzleFocusGeometry.maxFraction, accuracy: 0.0001)
+    XCTAssertEqual(rect.height, PuzzleFocusGeometry.maxFraction, accuracy: 0.0001)
+  }
+
+  func testFocusRectNeverFramesMoreThanTheCeiling() {
+    // Whatever the grid, both axes stay within the ceiling.
+    for rows in 1...12 {
+      for cols in 1...12 {
+        let rect = PuzzleFocusGeometry.focusRect(position: centre, rows: rows, cols: cols)
+        XCTAssertLessThanOrEqual(rect.width, PuzzleFocusGeometry.maxFraction + 0.0001)
+        XCTAssertLessThanOrEqual(rect.height, PuzzleFocusGeometry.maxFraction + 0.0001)
+      }
+    }
+  }
+
+  func testEdgePieceKeepsFullSizeRectRatherThanBeingClamped() {
+    // A rect running off the puzzle is intended: the scroll view pins the
+    // offset back. Clamping here would zoom edge pieces further in than
+    // middle ones.
+    let rect = PuzzleFocusGeometry.focusRect(position: CGPoint(x: 0, y: 1), rows: 40, cols: 30)
+    XCTAssertEqual(rect.width, 0.1, accuracy: 0.0001)
+    XCTAssertLessThan(rect.minX, 0)
+    XCTAssertGreaterThan(rect.maxY, 1)
+  }
+
+  func testDegenerateGridFallsBackToTheCeiling() {
+    // A zero grid must not divide by zero into an infinite/NaN rect.
+    let rect = PuzzleFocusGeometry.focusRect(position: centre, rows: 0, cols: 0)
+    XCTAssertEqual(rect.width, PuzzleFocusGeometry.maxFraction, accuracy: 0.0001)
+    XCTAssertEqual(rect.height, PuzzleFocusGeometry.maxFraction, accuracy: 0.0001)
+  }
+}

--- a/ios/PusselTests/PuzzleStoreTests.swift
+++ b/ios/PusselTests/PuzzleStoreTests.swift
@@ -9,10 +9,12 @@ import XCTest
 @MainActor
 final class PuzzleStoreTests: XCTestCase {
   /// A real (decodable) JPEG so thumbnail generation exercises ImageIO.
-  private func tinyJPEG() -> Data {
+  /// `color` distinguishes one image's bytes from another's, so a test can tell
+  /// which file it got back.
+  private func tinyJPEG(_ color: UIColor = .systemBlue) -> Data {
     let renderer = UIGraphicsImageRenderer(size: CGSize(width: 8, height: 8))
     return renderer.image { context in
-      UIColor.systemBlue.setFill()
+      color.setFill()
       context.fill(CGRect(x: 0, y: 0, width: 8, height: 8))
     }.jpegData(compressionQuality: 0.9)!
   }
@@ -56,15 +58,22 @@ final class PuzzleStoreTests: XCTestCase {
 
   func testZoomCopyIsPersistedAndReloaded() throws {
     let store = PuzzleStore()
-    let displayJPEG = Data("zoom-quality-copy".utf8)
+    // Real JPEG bytes, as the zoom viewer decodes these for display — and a
+    // different colour from the trimmed image the session is built with, so
+    // the assertions below can tell the two files apart rather than passing on
+    // a fallback.
+    let displayJPEG = tinyJPEG(.systemRed)
     let session = makeSession(store: store, displayJPEG: displayJPEG)
+    XCTAssertNotEqual(displayJPEG, session.trimmedJPEG)
     addTeardownBlock { @MainActor in store.delete(session.id) }
 
     session.persist()
     XCTAssertTrue(FileManager.default.fileExists(atPath: displayFile(session.id).path))
 
     let reloaded = try XCTUnwrap(store.loadSession(id: session.id))
+    // Byte-for-byte: the copy is stored as given, never re-encoded.
     XCTAssertEqual(reloaded.displayJPEG, displayJPEG)
+    XCTAssertNotNil(UIImage(data: try XCTUnwrap(reloaded.displayJPEG)))
     // The viewer draws the sharp copy when there is one.
     XCTAssertEqual(reloaded.zoomJPEG, displayJPEG)
   }

--- a/ios/PusselTests/PuzzleStoreTests.swift
+++ b/ios/PusselTests/PuzzleStoreTests.swift
@@ -32,17 +32,58 @@ final class PuzzleStoreTests: XCTestCase {
     puzzleDir(puzzle).appendingPathComponent("pieces/\(piece.uuidString)-upload.jpg")
   }
 
-  private func makeSession(store: PuzzleStore, name: String = "Test") -> SolveSession {
+  private func displayFile(_ puzzle: UUID) -> URL {
+    puzzleDir(puzzle).appendingPathComponent("display.jpg")
+  }
+
+  private func makeSession(
+    store: PuzzleStore, name: String = "Test", displayJPEG: Data? = nil
+  ) -> SolveSession {
     SolveSession(
       id: UUID(),
       name: name,
       puzzleId: "server-123",
       trimmedJPEG: tinyJPEG(),
+      displayJPEG: displayJPEG,
       targetPieceCount: 48,
       rows: 6,
       cols: 8,
       store: store
     )
+  }
+
+  // MARK: Zoom copy (display.jpg)
+
+  func testZoomCopyIsPersistedAndReloaded() throws {
+    let store = PuzzleStore()
+    let displayJPEG = Data("zoom-quality-copy".utf8)
+    let session = makeSession(store: store, displayJPEG: displayJPEG)
+    addTeardownBlock { @MainActor in store.delete(session.id) }
+
+    session.persist()
+    XCTAssertTrue(FileManager.default.fileExists(atPath: displayFile(session.id).path))
+
+    let reloaded = try XCTUnwrap(store.loadSession(id: session.id))
+    XCTAssertEqual(reloaded.displayJPEG, displayJPEG)
+    // The viewer draws the sharp copy when there is one.
+    XCTAssertEqual(reloaded.zoomJPEG, displayJPEG)
+  }
+
+  func testPuzzleWithoutZoomCopyReloadsAndFallsBackToTrimmed() throws {
+    // The compatibility path for every puzzle saved before the zoom copy
+    // existed, and for a capture whose re-warp failed: no display.jpg on disk,
+    // and the viewer falls back to the trimmed image rather than showing
+    // nothing.
+    let store = PuzzleStore()
+    let session = makeSession(store: store, displayJPEG: nil)
+    addTeardownBlock { @MainActor in store.delete(session.id) }
+
+    session.persist()
+    XCTAssertFalse(FileManager.default.fileExists(atPath: displayFile(session.id).path))
+
+    let reloaded = try XCTUnwrap(store.loadSession(id: session.id))
+    XCTAssertNil(reloaded.displayJPEG)
+    XCTAssertEqual(reloaded.zoomJPEG, reloaded.trimmedJPEG)
   }
 
   func testSavePersistsSummaryAndSurvivesReload() throws {


### PR DESCRIPTION
Tapping the puzzle on the solve screen — or a predicted piece's tile — opens a full-screen, pinch-zoomable viewer, so you can see exactly where a piece was placed. A piece tile opens centred on its marker with the others dimmed.

## Why a separate screen

The solve screen scrolls vertically, so panning a zoomed puzzle inside it would be a tug of war for every drag. The viewer is backed by `UIScrollView`, which brings rubber-banding, momentum, zoom bounce and double-tap for free — all things a hand-rolled `MagnifyGesture`/`DragGesture` pair reimplements badly.

## Why a second copy of the image, and how it's made

Zooming the image the backend returns is pointless on its own: it's capped at 1920 by the upload and the crop taken from it is smaller again, so on a 3× phone it's already at one image pixel per device pixel when it merely *fits* the screen. Pinching it magnifies JPEG artefacts from the first gesture.

`detect-frame` already returns the trim's four corners as **normalized** coordinates, which describe the same region of the photo at any resolution. So the warp is re-run locally with Core Image from a higher-resolution copy of the photo, rather than uploading a second, much larger one. The local crop carries the server crop's aspect ratio, so piece markers — positioned in normalized coordinates — land in the same place on either. Verified on a 24MP photo: aspect matches to **0.05%**.

`trimmed.jpg` remains the image the backend predicted against and the one the inline overlay draws; `display.jpg` is display-only and never uploaded.

## On the resolution ceiling

The cap applies to the **crop**, not the photo it came from — only part of a photo is puzzle, so capping the photo leaves the crop short and the cap never binds (this was a real bug caught by measuring the output on disk: 2784px against a 3000px cap).

True magnification costs pixels fast — the crop needs *n* × the screen's 1206px width to stay sharp at *n*×, and area grows with the square:

| Puzzle crop | True detail until | Decoded |
|---|---|---|
| `trimmed.jpg` (1221×1782) | 1.01× — gone at fit | 8 MB |
| `display.jpg` (2468×3600) | **2.04×** | ~35 MB |
| 3× | 3618px wide | ~76 MB |

So this buys roughly 1× → 2× of true detail, not the 4–6× that might be expected. Above 2× the viewer upscales — still a far better look at a piece than the 350pt inline overlay, but not new detail. 3× isn't a trade worth making for the top of a zoom range.

## Notable implementation points

- **The marker overlay is a sibling of the zoomed image, not a child**, so the scroll view's zoom transform never rasterises it. Markers stay vector-crisp and their chrome keeps a constant size on screen instead of swelling into a band across the piece it outlines. It also means nothing writes SwiftUI state from a scroll callback — the frame change alone drives re-layout.
- **The warp runs off the main actor, overlapped with the upload**, so its cost hides behind the network rather than freezing the screen before the spinner can draw.
- **`display.jpg` is optional throughout** — puzzles saved before this, and captures whose re-warp fails, fall back to the trimmed image.
- Focus framing is capped at 40% of the puzzle per axis: three cells of a 12-piece puzzle is the whole board, so without it, opening on a piece landed at fit and the tap looked inert.

## Tests

72 pass, up from 63. New coverage for the warp's sizing/cropping/degenerate cases, the extracted focus-rect math (including the coarse-grid regression above), and the `display.jpg` round-trip plus the legacy-puzzle fallback. `make check-ios` clean.

## Verification

Driven in the Simulator against a real 24MP photo of a 12-piece puzzle: the viewer renders the sharp copy, markers align with the inline overlay, focus-zoom centres correctly, letterboxing centres correctly, and the refactored pipeline produces byte-identical output.

**The pinch gesture itself is unexercised** — the booted Simulator had no window, so `screencapture` failed and synthetic taps had nothing to hit. The viewer was verified by temporarily forcing it open in code (reverted). Pinch, double-tap, pan and the tap-to-open path have only UIScrollView's own behaviour behind them; worth a minute on a real device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)