### PR TITLE
Add make ios-screenshot for connected devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,9 +197,10 @@ ios-deploy: ios-generate
 #   make ios-screenshot TARGET=device
 #   make ios-screenshot TARGET=simulator
 #   make ios-screenshot SIM="iPhone 17 Pro"   # name or udid; implies simulator
+#   make ios-screenshot DEV=<udid>            # implies device
 # Override the destination with OUT=<path>; defaults to a timestamped /tmp file.
-# SIM is quoted here rather than passed through a bare $(ARGS), so simulator
-# names containing spaces survive as a single argument.
+# SIM/DEV are quoted here rather than passed through a bare $(ARGS), so names
+# containing spaces survive as a single argument.
 ios-screenshot:
 	@./scripts/ios_screenshot.sh $(if $(TARGET),--$(TARGET)) \
-		$(if $(SIM),--simulator="$(SIM)") "$(OUT)"
+		$(if $(SIM),--simulator="$(SIM)") $(if $(DEV),--device="$(DEV)") "$(OUT)"

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,15 @@ ios-deploy: ios-generate
 		"$(IOS_DERIVED)/Build/Products/Debug-iphoneos/$(IOS_APP_NAME).app" && \
 	xcrun devicectl device process launch --device "$$DEVICE" "$(IOS_BUNDLE_ID)"
 
-# Screenshot the connected (physical) device. The device must be unlocked.
+# Screenshot a connected device or a booted Simulator, whichever is available
+# (a connected device must be unlocked). When several targets are available the
+# script lists them and exits rather than guessing; pick one with:
+#   make ios-screenshot TARGET=device
+#   make ios-screenshot TARGET=simulator
+#   make ios-screenshot SIM="iPhone 17 Pro"   # name or udid; implies simulator
 # Override the destination with OUT=<path>; defaults to a timestamped /tmp file.
+# SIM is quoted here rather than passed through a bare $(ARGS), so simulator
+# names containing spaces survive as a single argument.
 ios-screenshot:
-	@./scripts/ios_screenshot.sh "$(OUT)"
+	@./scripts/ios_screenshot.sh $(if $(TARGET),--$(TARGET)) \
+		$(if $(SIM),--simulator="$(SIM)") "$(OUT)"

--- a/Makefile
+++ b/Makefile
@@ -194,4 +194,4 @@ ios-deploy: ios-generate
 # Screenshot the connected (physical) device. The device must be unlocked.
 # Override the destination with OUT=<path>; defaults to a timestamped /tmp file.
 ios-screenshot:
-	@./scripts/ios_screenshot.sh $(OUT)
+	@./scripts/ios_screenshot.sh "$(OUT)"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
         format format-backend format-network format-shared format-frontend format-ios \
         test-backend install-dev-backend install-dev-network \
         start-backend start-frontend stop-backend stop-frontend \
-        ios-generate ios-run ios-deploy ios-test
+        ios-generate ios-run ios-deploy ios-test ios-screenshot
 
 # Run all checks (Python + Next.js + iOS)
 # check-ios self-skips where swift-format is unavailable (non-macOS), so this
@@ -190,3 +190,8 @@ ios-deploy: ios-generate
 	xcrun devicectl device install app --device "$$DEVICE" \
 		"$(IOS_DERIVED)/Build/Products/Debug-iphoneos/$(IOS_APP_NAME).app" && \
 	xcrun devicectl device process launch --device "$$DEVICE" "$(IOS_BUNDLE_ID)"
+
+# Screenshot the connected (physical) device. The device must be unlocked.
+# Override the destination with OUT=<path>; defaults to a timestamped /tmp file.
+ios-screenshot:
+	@./scripts/ios_screenshot.sh $(OUT)

--- a/ios/README.md
+++ b/ios/README.md
@@ -103,8 +103,8 @@ screenshot service from `lockdownd` to RemoteXPC:
 - The iPhone's AVFoundation entries are Continuity Camera, not the device screen.
 
 `scripts/ios_screenshot.sh` therefore uses `pymobiledevice3 developer dvt
-screenshot --userspace`. The `--userspace` flag opens the required iOS 17+ RSD
-tunnel without root; without it the command demands
+screenshot <out.png> --userspace`. The `--userspace` flag opens the required
+iOS 17+ RSD tunnel without root; without it the command demands
 `sudo pymobiledevice3 remote tunneld`.
 
 <details>

--- a/ios/README.md
+++ b/ios/README.md
@@ -78,23 +78,39 @@ make ios-deploy IOS_DEVICE=<name-or-udid>   # device is auto-detected otherwise
 `ios-deploy` needs `DEVELOPMENT_TEAM` set in `Config/Secrets.xcconfig` (device
 signing) and a device that's connected and trusts this Mac.
 
-## Screenshotting a connected device
+## Screenshots
 
-The Simulator has no camera, so the capture UI can only be exercised on real
-hardware. `make ios-screenshot` grabs the device screen at native resolution
-(~2-3s per shot):
+`make ios-screenshot` captures a booted Simulator or a connected device at
+native resolution (a device shot takes ~2-3s):
 
 ```bash
-make ios-screenshot                     # → /tmp/iphone-<timestamp>.png
+make ios-screenshot                          # → /tmp/iphone-<timestamp>.png
 make ios-screenshot OUT=/path/shot.png
 ```
 
-The device must be connected via USB, paired/trusted, and **unlocked**. Install
-the one required dependency with `uv tool install pymobiledevice3`. ffmpeg is
-used if present (see below) but is not required.
+With no target given it uses whichever one is available. When several are —
+a connected device *and* a Simulator, or two booted Simulators — it lists them
+and exits instead of guessing, since a screenshot of the wrong target looks
+like a successful capture of a broken app. (`simctl io booted` has exactly that
+failure mode: with two Simulators booted it silently picks one.) Pick a target
+with:
 
-Note that the obvious alternatives do not work on iOS 17+, which moved the
-screenshot service from `lockdownd` to RemoteXPC:
+```bash
+make ios-screenshot TARGET=device
+make ios-screenshot TARGET=simulator
+make ios-screenshot SIM="iPhone 17 Pro"      # name or udid; implies simulator
+```
+
+A connected device must be paired/trusted and **unlocked**, and needs
+`uv tool install pymobiledevice3`. Simulator capture needs only Xcode. ffmpeg
+is used if present (see below) but is not required.
+
+Reach for a device rather than the Simulator whenever the camera is involved —
+the Simulator has none, so the piece-capture UI can only be exercised on real
+hardware.
+
+Note that the obvious alternatives for *device* capture do not work on iOS 17+,
+which moved the screenshot service from `lockdownd` to RemoteXPC:
 
 - `idevicescreenshot` fails with "Could not start screenshotr service: Invalid
   service". Its suggestion to mount the Developer disk image is a red herring —
@@ -103,8 +119,9 @@ screenshot service from `lockdownd` to RemoteXPC:
 - The iPhone's AVFoundation entries are Continuity Camera, not the device screen.
 
 `scripts/ios_screenshot.sh` therefore uses `pymobiledevice3 developer dvt
-screenshot <out.png> --userspace`. The `--userspace` flag opens the required
-iOS 17+ RSD tunnel without root; without it the command demands
+screenshot <out.png> --userspace` for devices (and `xcrun simctl io <udid>
+screenshot` for Simulators). The `--userspace` flag opens the required iOS 17+
+RSD tunnel without root; without it the command demands
 `sudo pymobiledevice3 remote tunneld`.
 
 <details>

--- a/ios/README.md
+++ b/ios/README.md
@@ -78,6 +78,34 @@ make ios-deploy IOS_DEVICE=<name-or-udid>   # device is auto-detected otherwise
 `ios-deploy` needs `DEVELOPMENT_TEAM` set in `Config/Secrets.xcconfig` (device
 signing) and a device that's connected and trusts this Mac.
 
+## Screenshotting a connected device
+
+The Simulator has no camera, so the capture UI can only be exercised on real
+hardware. `make ios-screenshot` grabs the device screen at native resolution
+(~2-3s per shot):
+
+```bash
+make ios-screenshot                     # → /tmp/iphone-<timestamp>.png
+make ios-screenshot OUT=/path/shot.png
+```
+
+The device must be connected via USB, paired/trusted, and **unlocked**. Install
+the one dependency with `uv tool install pymobiledevice3`.
+
+Note that the obvious alternatives do not work on iOS 17+, which moved the
+screenshot service from `lockdownd` to RemoteXPC:
+
+- `idevicescreenshot` fails with "Could not start screenshotr service: Invalid
+  service". Its suggestion to mount the Developer disk image is a red herring —
+  the DDI is already mounted (`ideviceimagemounter list` → `Status: Complete`).
+- `xcrun devicectl` has no screenshot subcommand.
+- The iPhone's AVFoundation entries are Continuity Camera, not the device screen.
+
+`scripts/ios_screenshot.sh` therefore uses `pymobiledevice3 developer dvt
+screenshot --userspace`. The `--userspace` flag opens the required iOS 17+ RSD
+tunnel without root; without it the command demands
+`sudo pymobiledevice3 remote tunneld`.
+
 <details>
 <summary>Equivalent raw <code>xcodebuild</code> / <code>simctl</code> commands</summary>
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -88,17 +88,18 @@ make ios-screenshot                          # → /tmp/iphone-<timestamp>.png
 make ios-screenshot OUT=/path/shot.png
 ```
 
-With no target given it uses whichever one is available. When several are —
-a connected device *and* a Simulator, or two booted Simulators — it lists them
-and exits instead of guessing, since a screenshot of the wrong target looks
-like a successful capture of a broken app. (`simctl io booted` has exactly that
-failure mode: with two Simulators booted it silently picks one.) Pick a target
-with:
+With no target given it uses whichever one is available. When several are — a
+connected device *and* a Simulator, two booted Simulators, or two connected
+devices — it lists them and exits instead of guessing, since a screenshot of
+the wrong target looks like a successful capture of a broken app. (`simctl io
+booted` has exactly that failure mode: with two Simulators booted it silently
+picks one.) Pick a target with:
 
 ```bash
 make ios-screenshot TARGET=device
 make ios-screenshot TARGET=simulator
 make ios-screenshot SIM="iPhone 17 Pro"      # name or udid; implies simulator
+make ios-screenshot DEV=<udid>               # implies device
 ```
 
 A connected device must be paired/trusted and **unlocked**, and needs

--- a/ios/README.md
+++ b/ios/README.md
@@ -90,7 +90,8 @@ make ios-screenshot OUT=/path/shot.png
 ```
 
 The device must be connected via USB, paired/trusted, and **unlocked**. Install
-the one dependency with `uv tool install pymobiledevice3`.
+the one required dependency with `uv tool install pymobiledevice3`. ffmpeg is
+used if present (see below) but is not required.
 
 Note that the obvious alternatives do not work on iOS 17+, which moved the
 screenshot service from `lockdownd` to RemoteXPC:

--- a/scripts/ios_screenshot.sh
+++ b/scripts/ios_screenshot.sh
@@ -19,7 +19,15 @@ if ! command -v pymobiledevice3 &> /dev/null; then
     exit 1
 fi
 
-if ! pymobiledevice3 usbmux list 2>/dev/null | grep -q '"Identifier"'; then
+# Keep the two failure modes distinct: a broken usbmuxd is not the same problem
+# as an absent device, and reporting it as one sends you looking at the cable.
+if ! DEVICES="$(pymobiledevice3 usbmux list 2>&1)"; then
+    echo "Error: could not query usbmuxd for connected devices."
+    echo "$DEVICES"
+    exit 1
+fi
+
+if ! grep -q '"Identifier"' <<< "$DEVICES"; then
     echo "Error: no paired iOS device found."
     echo "Connect the device via USB, unlock it, and tap Trust."
     exit 1

--- a/scripts/ios_screenshot.sh
+++ b/scripts/ios_screenshot.sh
@@ -1,42 +1,267 @@
 #!/bin/bash
 
-# Capture a screenshot of a connected (physical) iPhone/iPad.
-# Usage: ios_screenshot.sh [output.png]
-# Defaults to a timestamped file under /tmp.
+# Capture a screenshot from a connected iPhone/iPad or a booted Simulator.
 #
-# The device must be connected via USB, unlocked, and paired/trusted.
+# Usage: ios_screenshot.sh [--device | --simulator[=<name-or-udid>]] [OUT]
+#
+# With no target flag the script uses whichever target is available. When more
+# than one is available it stops and prints how to choose rather than guessing:
+# `simctl io booted` silently picks one of several booted simulators, and a
+# screenshot of the wrong target is worse than an error, because it looks like
+# a successful capture of a broken app.
+#
+# Physical devices must be connected via USB, paired/trusted, and unlocked.
 # iOS 17+ serves the screenshot over RemoteXPC rather than lockdownd, so the
 # older idevicescreenshot cannot reach it; pymobiledevice3 --userspace opens
 # the required tunnel without needing root.
 
-set -e
+set -euo pipefail
 
-OUT="${1:-/tmp/iphone-$(date +%Y%m%d-%H%M%S).png}"
+TARGET="auto"
+SIM_SPEC=""
+OUT=""
 
-if ! command -v pymobiledevice3 &> /dev/null; then
-    echo "Error: pymobiledevice3 is not installed."
-    echo "Install it with: uv tool install pymobiledevice3"
-    exit 1
+usage() {
+    cat <<'USAGE'
+Usage: ios_screenshot.sh [--device | --simulator[=<name-or-udid>]] [OUT]
+
+  --device                     Capture the connected physical device.
+  --simulator                  Capture the booted Simulator.
+  --simulator=<name-or-udid>   Capture a specific booted Simulator.
+  -h, --help                   Show this message.
+
+OUT defaults to a timestamped file under /tmp. With no target flag, the only
+available target is used; if several are available the script lists them and
+exits rather than picking one.
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --device) TARGET="device" ;;
+        --simulator|--sim) TARGET="simulator" ;;
+        --simulator=*|--sim=*) TARGET="simulator"; SIM_SPEC="${1#*=}" ;;
+        -h|--help) usage; exit 0 ;;
+        -*) echo "Error: unknown option '$1'." >&2; echo >&2; usage >&2; exit 2 ;;
+        # An empty positional is what `make ios-screenshot` passes when OUT is
+        # unset, so it must mean "use the default", not an empty filename.
+        *) [ -n "$1" ] && OUT="$1" ;;
+    esac
+    shift
+done
+
+# ---------------------------------------------------------------------------
+# Discover targets
+# ---------------------------------------------------------------------------
+
+DEVICE_LABEL=""
+USBMUX_ERROR=""
+
+# First value for a JSON string key, reading stdin. Tolerates both `"k": "v"`
+# and `"k" : "v"` spacing so a formatting change upstream degrades to an empty
+# label rather than a wrong one.
+json_string() {
+    sed -n "s/.*\"$1\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -1
+}
+
+# Indent a block of text; awk rather than sed so a multi-line value stays intact.
+indent() { awk -v p="$1" '{print p $0}'; }
+
+if command -v pymobiledevice3 &> /dev/null; then
+    # Keep the two failure modes distinct: a broken usbmuxd is not the same
+    # problem as an absent device, and conflating them sends you to the cable.
+    if DEVICE_JSON="$(pymobiledevice3 usbmux list 2>&1)"; then
+        if grep -q '"Identifier"' <<< "$DEVICE_JSON"; then
+            # ProductType/ProductVersion rather than DeviceName: the name comes
+            # back with \uXXXX escapes that bash cannot readably decode.
+            PRODUCT="$(json_string ProductType <<< "$DEVICE_JSON")"
+            VERSION="$(json_string ProductVersion <<< "$DEVICE_JSON")"
+            DEVICE_LABEL="${PRODUCT:-device} (iOS ${VERSION:-unknown})"
+        fi
+    else
+        USBMUX_ERROR="$DEVICE_JSON"
+    fi
 fi
 
-# Keep the two failure modes distinct: a broken usbmuxd is not the same problem
-# as an absent device, and reporting it as one sends you looking at the cable.
-if ! DEVICES="$(pymobiledevice3 usbmux list 2>&1)"; then
-    echo "Error: could not query usbmuxd for connected devices."
-    echo "$DEVICES"
-    exit 1
+# Lines of "<udid><TAB><name>" for each booted simulator.
+SIMS=""
+if command -v xcrun &> /dev/null; then
+    SIMS="$(xcrun simctl list devices booted 2>/dev/null \
+        | sed -n 's/^ *\(.*\) (\([0-9A-Fa-f-]\{36\}\)) (Booted).*/\2	\1/p' || true)"
 fi
 
-if ! grep -q '"Identifier"' <<< "$DEVICES"; then
-    echo "Error: no paired iOS device found."
-    echo "Connect the device via USB, unlock it, and tap Trust."
-    exit 1
+sim_count() {
+    if [ -z "$SIMS" ]; then echo 0; else wc -l <<< "$SIMS" | tr -d ' '; fi
+}
+
+SIM_COUNT="$(sim_count)"
+DEVICE_COUNT=0
+[ -n "$DEVICE_LABEL" ] && DEVICE_COUNT=1
+
+list_sims() {
+    if [ -n "$SIMS" ]; then
+        while IFS="	" read -r udid name; do
+            echo "  simulator  $name ($udid)"
+        done <<< "$SIMS"
+    fi
+}
+
+list_targets() {
+    if [ -n "$DEVICE_LABEL" ]; then
+        echo "  device     $DEVICE_LABEL"
+    fi
+    list_sims
+}
+
+# The runnable command for each target, so the message can be pasted as-is.
+suggest_sims() {
+    if [ -n "$SIMS" ]; then
+        while IFS="	" read -r udid name; do
+            echo "  make ios-screenshot SIM=$udid   # $name"
+        done <<< "$SIMS"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Resolve the target
+# ---------------------------------------------------------------------------
+
+if [ "$TARGET" = "auto" ]; then
+    TOTAL=$((DEVICE_COUNT + SIM_COUNT))
+    if [ "$TOTAL" -eq 0 ]; then
+        {
+            echo "Error: no screenshot target found."
+            echo
+            echo "Checked:"
+            if [ -n "$USBMUX_ERROR" ]; then
+                echo "  connected device   could not query usbmuxd:"
+                indent "                       " <<< "$USBMUX_ERROR"
+            elif command -v pymobiledevice3 &> /dev/null; then
+                echo "  connected device   none (pymobiledevice3 usbmux list)"
+            else
+                echo "  connected device   pymobiledevice3 is not installed"
+            fi
+            echo "  booted simulator   none (xcrun simctl list devices booted)"
+            echo
+            echo "Fix by doing one of:"
+            echo "  - Connect an iPhone via USB, unlock it, and tap Trust."
+            if ! command -v pymobiledevice3 &> /dev/null; then
+                echo "    Physical devices also need: uv tool install pymobiledevice3"
+            fi
+            echo "  - Boot a simulator and launch the app: make ios-run"
+        } >&2
+        exit 1
+    fi
+    if [ "$TOTAL" -gt 1 ]; then
+        {
+            echo "Error: $TOTAL screenshot targets are available; pick one explicitly."
+            echo
+            echo "Available:"
+            list_targets
+            echo
+            echo "Re-run with one of:"
+            if [ -n "$DEVICE_LABEL" ]; then
+                echo "  make ios-screenshot TARGET=device"
+            fi
+            suggest_sims
+        } >&2
+        exit 1
+    fi
+    if [ "$DEVICE_COUNT" -eq 1 ]; then TARGET="device"; else TARGET="simulator"; fi
 fi
 
-pymobiledevice3 developer dvt screenshot "$OUT" --userspace
+SIM_UDID=""
+if [ "$TARGET" = "simulator" ]; then
+    if [ -z "$SIMS" ]; then
+        {
+            echo "Error: no booted simulator found."
+            echo
+            echo "Boot one with: make ios-run"
+            echo "Or list what exists: xcrun simctl list devices"
+        } >&2
+        exit 1
+    fi
+    if [ -n "$SIM_SPEC" ]; then
+        SIM_UDID="$(awk -F'\t' -v s="$SIM_SPEC" '$1==s || $2==s {print $1; exit}' <<< "$SIMS")"
+        if [ -z "$SIM_UDID" ]; then
+            {
+                echo "Error: no booted simulator matches '$SIM_SPEC'."
+                echo
+                echo "Booted simulators:"
+                list_sims
+                echo
+                echo "Match is exact, on either the name or the udid."
+            } >&2
+            exit 1
+        fi
+    elif [ "$SIM_COUNT" -gt 1 ]; then
+        {
+            echo "Error: $SIM_COUNT simulators are booted; pick one explicitly."
+            echo
+            echo "Booted simulators:"
+            list_sims
+            echo
+            echo "Re-run with one of:"
+            suggest_sims
+        } >&2
+        exit 1
+    else
+        SIM_UDID="$(cut -f1 <<< "$SIMS")"
+    fi
+fi
 
-# The capture is 16-bit RGB (~9 MB); flattening to 8-bit cuts that to ~3 MB
-# with no visible loss. Optional -- skipped when ffmpeg is unavailable.
+if [ "$TARGET" = "device" ]; then
+    if ! command -v pymobiledevice3 &> /dev/null; then
+        {
+            echo "Error: pymobiledevice3 is not installed, so no device can be captured."
+            echo
+            echo "Install it with: uv tool install pymobiledevice3"
+        } >&2
+        exit 1
+    fi
+    if [ -n "$USBMUX_ERROR" ]; then
+        {
+            echo "Error: could not query usbmuxd for connected devices."
+            echo
+            indent "  " <<< "$USBMUX_ERROR"
+        } >&2
+        exit 1
+    fi
+    if [ -z "$DEVICE_LABEL" ]; then
+        {
+            echo "Error: no paired iOS device found."
+            echo
+            echo "Connect the device via USB, unlock it, and tap Trust."
+            echo "Then confirm it is visible with: pymobiledevice3 usbmux list"
+        } >&2
+        exit 1
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Capture
+# ---------------------------------------------------------------------------
+
+OUT="${OUT:-/tmp/iphone-$(date +%Y%m%d-%H%M%S).png}"
+
+if [ "$TARGET" = "device" ]; then
+    pymobiledevice3 developer dvt screenshot "$OUT" --userspace
+else
+    # simctl narrates to stderr on success ("Detected file type...", "Note: No
+    # display specified..."), so hold its output and surface it only on failure.
+    if ! SIM_ERR="$(xcrun simctl io "$SIM_UDID" screenshot "$OUT" 2>&1 > /dev/null)"; then
+        {
+            echo "Error: simctl could not screenshot simulator $SIM_UDID."
+            echo
+            indent "  " <<< "$SIM_ERR"
+        } >&2
+        exit 1
+    fi
+fi
+
+# Device captures are 16-bit RGB (~9 MB); flattening to 8-bit cuts that to ~3 MB
+# with no visible loss, and drops the simulator's unused alpha channel.
+# Optional -- skipped when ffmpeg is unavailable.
 # The scratch file sits next to $OUT so the .png suffix lets ffmpeg infer the
 # format and the final mv stays within one filesystem.
 if command -v ffmpeg &> /dev/null; then
@@ -47,4 +272,8 @@ if command -v ffmpeg &> /dev/null; then
     fi
 fi
 
-echo "Saved: $OUT"
+if [ "$TARGET" = "device" ]; then
+    echo "Saved: $OUT  (device: $DEVICE_LABEL)"
+else
+    echo "Saved: $OUT  (simulator: $(awk -F'\t' -v u="$SIM_UDID" '$1==u {print $2}' <<< "$SIMS"))"
+fi

--- a/scripts/ios_screenshot.sh
+++ b/scripts/ios_screenshot.sh
@@ -19,13 +19,16 @@ set -euo pipefail
 
 TARGET="auto"
 SIM_SPEC=""
+DEV_SPEC=""
+DEV_UDID=""
 OUT=""
 
 usage() {
     cat <<'USAGE'
-Usage: ios_screenshot.sh [--device | --simulator[=<name-or-udid>]] [OUT]
+Usage: ios_screenshot.sh [--device[=<udid>] | --simulator[=<name-or-udid>]] [OUT]
 
   --device                     Capture the connected physical device.
+  --device=<udid>              Capture a specific connected device.
   --simulator                  Capture the booted Simulator.
   --simulator=<name-or-udid>   Capture a specific booted Simulator.
   -h, --help                   Show this message.
@@ -39,6 +42,7 @@ USAGE
 while [ $# -gt 0 ]; do
     case "$1" in
         --device) TARGET="device" ;;
+        --device=*) TARGET="device"; DEV_SPEC="${1#*=}" ;;
         --simulator|--sim) TARGET="simulator" ;;
         --simulator=*|--sim=*) TARGET="simulator"; SIM_SPEC="${1#*=}" ;;
         -h|--help) usage; exit 0 ;;
@@ -54,14 +58,34 @@ done
 # Discover targets
 # ---------------------------------------------------------------------------
 
-DEVICE_LABEL=""
+# Lines of "<udid><TAB><label>" for each connected device.
+DEVICES=""
 USBMUX_ERROR=""
 
-# First value for a JSON string key, reading stdin. Tolerates both `"k": "v"`
-# and `"k" : "v"` spacing so a formatting change upstream degrades to an empty
-# label rather than a wrong one.
-json_string() {
-    sed -n "s/.*\"$1\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -1
+# Read `pymobiledevice3 usbmux list` JSON on stdin, emit "<udid><TAB><label>"
+# per device. A real JSON parser rather than line-oriented matching: fields are
+# read per object, so a device missing one cannot borrow another's value, and
+# whitespace/formatting carries no meaning. python3 ships with the Xcode command
+# line tools this repo already needs, and pymobiledevice3 is itself Python.
+# ProductType rather than DeviceName: the name arrives with \uXXXX escapes.
+parse_devices() {
+    python3 -c '
+import json, sys
+try:
+    devices = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+if not isinstance(devices, list):
+    sys.exit(0)
+for d in devices:
+    if not isinstance(d, dict):
+        continue
+    udid = d.get("UniqueDeviceID") or d.get("Identifier")
+    if not udid:
+        continue
+    label = "%s (iOS %s)" % (d.get("ProductType", "device"), d.get("ProductVersion", "unknown"))
+    print("%s\t%s" % (udid, label))
+'
 }
 
 # Indent a block of text; awk rather than sed so a multi-line value stays intact.
@@ -71,12 +95,11 @@ if command -v pymobiledevice3 &> /dev/null; then
     # Keep the two failure modes distinct: a broken usbmuxd is not the same
     # problem as an absent device, and conflating them sends you to the cable.
     if DEVICE_JSON="$(pymobiledevice3 usbmux list 2>&1)"; then
-        if grep -q '"Identifier"' <<< "$DEVICE_JSON"; then
-            # ProductType/ProductVersion rather than DeviceName: the name comes
-            # back with \uXXXX escapes that bash cannot readably decode.
-            PRODUCT="$(json_string ProductType <<< "$DEVICE_JSON")"
-            VERSION="$(json_string ProductVersion <<< "$DEVICE_JSON")"
-            DEVICE_LABEL="${PRODUCT:-device} (iOS ${VERSION:-unknown})"
+        if command -v python3 &> /dev/null; then
+            DEVICES="$(parse_devices <<< "$DEVICE_JSON")"
+        else
+            # Say so rather than let an empty list read as "nothing plugged in".
+            USBMUX_ERROR="python3 is needed to read the device list, but is not installed."
         fi
     else
         USBMUX_ERROR="$DEVICE_JSON"
@@ -90,13 +113,21 @@ if command -v xcrun &> /dev/null; then
         | sed -n 's/^ *\(.*\) (\([0-9A-Fa-f-]\{36\}\)) (Booted).*/\2	\1/p' || true)"
 fi
 
-sim_count() {
-    if [ -z "$SIMS" ]; then echo 0; else wc -l <<< "$SIMS" | tr -d ' '; fi
+# wc -l miscounts a single unterminated line, and an empty list is not one line.
+count_lines() {
+    if [ -z "$1" ]; then echo 0; else grep -c '' <<< "$1"; fi
 }
 
-SIM_COUNT="$(sim_count)"
-DEVICE_COUNT=0
-[ -n "$DEVICE_LABEL" ] && DEVICE_COUNT=1
+SIM_COUNT="$(count_lines "$SIMS")"
+DEVICE_COUNT="$(count_lines "$DEVICES")"
+
+list_devices() {
+    if [ -n "$DEVICES" ]; then
+        while IFS="	" read -r udid label; do
+            echo "  device     $label ($udid)"
+        done <<< "$DEVICES"
+    fi
+}
 
 list_sims() {
     if [ -n "$SIMS" ]; then
@@ -107,13 +138,22 @@ list_sims() {
 }
 
 list_targets() {
-    if [ -n "$DEVICE_LABEL" ]; then
-        echo "  device     $DEVICE_LABEL"
-    fi
+    list_devices
     list_sims
 }
 
 # The runnable command for each target, so the message can be pasted as-is.
+# A single device needs no udid, so keep the common suggestion short.
+suggest_devices() {
+    if [ "$DEVICE_COUNT" -eq 1 ]; then
+        echo "  make ios-screenshot TARGET=device"
+    elif [ -n "$DEVICES" ]; then
+        while IFS="	" read -r udid label; do
+            echo "  make ios-screenshot DEV=$udid   # $label"
+        done <<< "$DEVICES"
+    fi
+}
+
 suggest_sims() {
     if [ -n "$SIMS" ]; then
         while IFS="	" read -r udid name; do
@@ -160,9 +200,7 @@ if [ "$TARGET" = "auto" ]; then
             list_targets
             echo
             echo "Re-run with one of:"
-            if [ -n "$DEVICE_LABEL" ]; then
-                echo "  make ios-screenshot TARGET=device"
-            fi
+            suggest_devices
             suggest_sims
         } >&2
         exit 1
@@ -227,7 +265,7 @@ if [ "$TARGET" = "device" ]; then
         } >&2
         exit 1
     fi
-    if [ -z "$DEVICE_LABEL" ]; then
+    if [ -z "$DEVICES" ]; then
         {
             echo "Error: no paired iOS device found."
             echo
@@ -236,16 +274,47 @@ if [ "$TARGET" = "device" ]; then
         } >&2
         exit 1
     fi
+    if [ -n "$DEV_SPEC" ]; then
+        DEV_UDID="$(awk -F'\t' -v s="$DEV_SPEC" '$1==s {print $1; exit}' <<< "$DEVICES")"
+        if [ -z "$DEV_UDID" ]; then
+            {
+                echo "Error: no connected device matches udid '$DEV_SPEC'."
+                echo
+                echo "Connected devices:"
+                list_devices
+            } >&2
+            exit 1
+        fi
+    elif [ "$DEVICE_COUNT" -gt 1 ]; then
+        # Without a udid pymobiledevice3 picks one of several devices on its
+        # own, so stop here for the same reason as the simulator case.
+        {
+            echo "Error: $DEVICE_COUNT devices are connected; pick one explicitly."
+            echo
+            echo "Connected devices:"
+            list_devices
+            echo
+            echo "Re-run with one of:"
+            suggest_devices
+        } >&2
+        exit 1
+    else
+        DEV_UDID="$(cut -f1 <<< "$DEVICES")"
+    fi
 fi
 
 # ---------------------------------------------------------------------------
 # Capture
 # ---------------------------------------------------------------------------
 
-OUT="${OUT:-/tmp/iphone-$(date +%Y%m%d-%H%M%S).png}"
+# $$ as well as the timestamp: two runs within the same second would otherwise
+# land on the same default path and the first shot would be lost.
+OUT="${OUT:-/tmp/iphone-$(date +%Y%m%d-%H%M%S)-$$.png}"
 
 if [ "$TARGET" = "device" ]; then
-    pymobiledevice3 developer dvt screenshot "$OUT" --userspace
+    # --udid rather than letting pymobiledevice3 choose: the choice is already
+    # made above, and leaving it implicit is what allows a silent wrong target.
+    pymobiledevice3 developer dvt screenshot "$OUT" --userspace --udid "$DEV_UDID"
 else
     # simctl narrates to stderr on success ("Detected file type...", "Note: No
     # display specified..."), so hold its output and surface it only on failure.
@@ -273,7 +342,7 @@ if command -v ffmpeg &> /dev/null; then
 fi
 
 if [ "$TARGET" = "device" ]; then
-    echo "Saved: $OUT  (device: $DEVICE_LABEL)"
+    echo "Saved: $OUT  (device: $(awk -F'\t' -v u="$DEV_UDID" '$1==u {print $2}' <<< "$DEVICES"))"
 else
     echo "Saved: $OUT  (simulator: $(awk -F'\t' -v u="$SIM_UDID" '$1==u {print $2}' <<< "$SIMS"))"
 fi

--- a/scripts/ios_screenshot.sh
+++ b/scripts/ios_screenshot.sh
@@ -39,12 +39,29 @@ exits rather than picking one.
 USAGE
 }
 
+# Refuse a device+simulator combination rather than letting the last flag win:
+# `make ios-screenshot TARGET=simulator DEV=<udid>` expands to both, and
+# silently honouring one would capture the target the caller did not ask for.
+select_target() {
+    if [ "$TARGET" != "auto" ] && [ "$TARGET" != "$1" ]; then
+        {
+            echo "Error: --device and --simulator cannot be combined."
+            echo
+            echo "Pass one target, or none to use whichever is available."
+            echo "Via make, TARGET=device|simulator, SIM=<name-or-udid> and DEV=<udid>"
+            echo "each select a target -- use only one of them."
+        } >&2
+        exit 2
+    fi
+    TARGET="$1"
+}
+
 while [ $# -gt 0 ]; do
     case "$1" in
-        --device) TARGET="device" ;;
-        --device=*) TARGET="device"; DEV_SPEC="${1#*=}" ;;
-        --simulator|--sim) TARGET="simulator" ;;
-        --simulator=*|--sim=*) TARGET="simulator"; SIM_SPEC="${1#*=}" ;;
+        --device) select_target "device" ;;
+        --device=*) select_target "device"; DEV_SPEC="${1#*=}" ;;
+        --simulator|--sim) select_target "simulator" ;;
+        --simulator=*|--sim=*) select_target "simulator"; SIM_SPEC="${1#*=}" ;;
         -h|--help) usage; exit 0 ;;
         -*) echo "Error: unknown option '$1'." >&2; echo >&2; usage >&2; exit 2 ;;
         # An empty positional is what `make ios-screenshot` passes when OUT is

--- a/scripts/ios_screenshot.sh
+++ b/scripts/ios_screenshot.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Capture a screenshot of a connected (physical) iPhone/iPad.
+# Usage: ios_screenshot.sh [output.png]
+# Defaults to a timestamped file under /tmp.
+#
+# The device must be connected via USB, unlocked, and paired/trusted.
+# iOS 17+ serves the screenshot over RemoteXPC rather than lockdownd, so the
+# older idevicescreenshot cannot reach it; pymobiledevice3 --userspace opens
+# the required tunnel without needing root.
+
+set -e
+
+OUT="${1:-/tmp/iphone-$(date +%Y%m%d-%H%M%S).png}"
+
+if ! command -v pymobiledevice3 &> /dev/null; then
+    echo "Error: pymobiledevice3 is not installed."
+    echo "Install it with: uv tool install pymobiledevice3"
+    exit 1
+fi
+
+if ! idevice_id -l 2>/dev/null | grep -q .; then
+    echo "Error: no paired iOS device found."
+    echo "Connect the device via USB, unlock it, and tap Trust."
+    exit 1
+fi
+
+pymobiledevice3 developer dvt screenshot "$OUT" --userspace
+
+# The capture is 16-bit RGB (~9 MB); flattening to 8-bit cuts that to ~3 MB
+# with no visible loss. Optional -- skipped when ffmpeg is unavailable.
+if command -v ffmpeg &> /dev/null; then
+    TMP="$(mktemp -t ios_screenshot).png"
+    if ffmpeg -y -loglevel error -i "$OUT" -pix_fmt rgb24 "$TMP" 2>/dev/null; then
+        mv "$TMP" "$OUT"
+    else
+        rm -f "$TMP"
+    fi
+fi
+
+echo "Saved: $OUT"

--- a/scripts/ios_screenshot.sh
+++ b/scripts/ios_screenshot.sh
@@ -19,7 +19,7 @@ if ! command -v pymobiledevice3 &> /dev/null; then
     exit 1
 fi
 
-if ! idevice_id -l 2>/dev/null | grep -q .; then
+if ! pymobiledevice3 usbmux list 2>/dev/null | grep -q '"Identifier"'; then
     echo "Error: no paired iOS device found."
     echo "Connect the device via USB, unlock it, and tap Trust."
     exit 1
@@ -29,12 +29,13 @@ pymobiledevice3 developer dvt screenshot "$OUT" --userspace
 
 # The capture is 16-bit RGB (~9 MB); flattening to 8-bit cuts that to ~3 MB
 # with no visible loss. Optional -- skipped when ffmpeg is unavailable.
+# The scratch file sits next to $OUT so the .png suffix lets ffmpeg infer the
+# format and the final mv stays within one filesystem.
 if command -v ffmpeg &> /dev/null; then
-    TMP="$(mktemp -t ios_screenshot).png"
+    TMP="$OUT.tmp.$$.png"
+    trap 'rm -f "$TMP"' EXIT
     if ffmpeg -y -loglevel error -i "$OUT" -pix_fmt rgb24 "$TMP" 2>/dev/null; then
         mv "$TMP" "$OUT"
-    else
-        rm -f "$TMP"
     fi
 fi
 


### PR DESCRIPTION
## Why

The Simulator has no camera, so the piece-capture UI can only be exercised on real hardware — but there was no way to see the device screen from the CLI. This adds one.

## What

```bash
make ios-screenshot                     # → /tmp/iphone-<timestamp>.png
make ios-screenshot OUT=/path/shot.png
```

~2-3s per capture at native resolution (1179x2556 on an iPhone 15). The device must be connected via USB, paired/trusted, and unlocked. One new dependency, installed by the developer: `uv tool install pymobiledevice3`.

## Why pymobiledevice3 and not the obvious tools

iOS 17+ moved the screenshot service from `lockdownd` to RemoteXPC, which breaks the usual suspects:

- `idevicescreenshot` fails with `Could not start screenshotr service: Invalid service`. Its hint to mount the Developer disk image is a red herring — the DDI is already mounted (`ideviceimagemounter list` → `Status: Complete`).
- `xcrun devicectl` has no screenshot subcommand.
- The iPhone's AVFoundation entries are Continuity Camera, not the device screen.

`pymobiledevice3 developer dvt screenshot --userspace` works. The `--userspace` flag matters: without it the command demands `sudo pymobiledevice3 remote tunneld` for the RSD tunnel, which would make this unusable for automation. With it, no root is needed.

Captures come back as 16-bit RGB (~9 MB); the script flattens them to 8-bit (~3 MB) with no visible loss via ffmpeg. `sips` can't do this — it has no bit-depth property and silently no-ops. The conversion is skipped when ffmpeg is absent.

## Testing

No automated tests — this is a dev-tooling shell script whose only real behavior is talking to physical hardware.

Verified by hand end to end against a connected iPhone 15 (iOS 27): `make ios-screenshot` and `make ios-screenshot OUT=<path>` both produced correct 1179x2556 8-bit PNGs of the Pussel app's live capture view. `bash -n`, `shellcheck`, and `pre-commit run --files` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)