### PR TITLE
Piece geometry scanning: exp28 research (M1-M7), backend geometry API (M8), iOS live outline + scan-and-lock (M9-M10)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -51,7 +51,13 @@ class Settings(BaseSettings):
     # z-score (exp28 M7, frozen on north_star): accept as a match below
     # PIECE_GEOMETRY_T_ACCEPT, declare a new piece above PIECE_GEOMETRY_T_NEW, and
     # treat anything in between as a gray zone (ask the user to rescan).
-    PIECE_GEOMETRY_T_ACCEPT: float = -4.78
+    # t_accept sits at M7's FMR=1% ROC point (-3.98) rather than the strictest
+    # frozen setting (-4.78): the M10 device runs showed the strict point sends
+    # ~26-30% of genuine re-scans to the gray zone, and with the scanner
+    # auto-enrolling gray-zone pieces those re-scans would duplicate. At -3.98
+    # gray-zone re-scans drop to ~8% for a 1% wrong-lock risk (see exp28
+    # HANDOFF M7/M10).
+    PIECE_GEOMETRY_T_ACCEPT: float = -3.98
     PIECE_GEOMETRY_T_NEW: float = -0.80
 
     # Environment setting (used for validation)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -47,6 +47,13 @@ class Settings(BaseSettings):
     CLASSICAL_GRID_ROWS: int = Field(default=4, ge=1)
     CLASSICAL_GRID_COLS: int = Field(default=4, ge=1)
 
+    # Piece geometry (M8) scan-lock thresholds on the combined shape+spatial-color
+    # z-score (exp28 M7, frozen on north_star): accept as a match below
+    # PIECE_GEOMETRY_T_ACCEPT, declare a new piece above PIECE_GEOMETRY_T_NEW, and
+    # treat anything in between as a gray zone (ask the user to rescan).
+    PIECE_GEOMETRY_T_ACCEPT: float = -4.78
+    PIECE_GEOMETRY_T_NEW: float = -0.80
+
     # Environment setting (used for validation)
     ENVIRONMENT: str = "development"  # development, test, or production
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -294,8 +294,9 @@ async def preview_piece(
         bool,
         Query(
             description=(
-                "Also run a quick corner-detection pass on the detected region and add "
-                "lockable/corner_disagreement flags. Default response shape is unchanged when omitted."
+                "Also run a quick corner-detection pass on the detected region and populate the "
+                "lockable/corner_disagreement flags. Those fields are always present in the response "
+                "model; when this is omitted/false they are returned as null."
             )
         ),
     ] = False,
@@ -309,12 +310,12 @@ async def preview_piece(
     Args:
         current_user: The authenticated user.
         file: A downscaled camera frame.
-        include_quality: When true, adds best-effort `lockable` and
+        include_quality: When true, populates the best-effort `lockable` and
             `corner_disagreement` piece-geometry flags computed from the
             detected region's polygon (see
             `app.services.piece_geometry.service.quick_quality_from_polygon`).
-            Omitted/false leaves the response unchanged from before this flag
-            existed.
+            Both fields are always present in `PiecePreviewResponse`; when
+            omitted/false they are returned as null.
 
     Returns:
         PiecePreviewResponse with the detected region outline and a confidence

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,8 +4,9 @@ import base64
 import io
 import os
 import uuid
-from typing import Annotated, Dict, Optional, Tuple
+from typing import Annotated, Dict, List, Literal, Optional, Tuple
 
+import numpy as np
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from PIL import Image, ImageOps, UnidentifiedImageError
@@ -14,6 +15,15 @@ from pydantic import ValidationError
 from app.auth.dependencies import get_current_user
 from app.auth.service import AuthService, get_auth_service
 from app.config import settings
+from app.models.piece_geometry_model import (
+    GeometryEdge,
+    GeometryPoint,
+    GeometryQuality,
+    PieceGeometryListResponse,
+    PieceGeometryRecordResponse,
+    PieceGeometrySummary,
+    PieceGeometryUploadResponse,
+)
 from app.models.puzzle_model import (
     BoundingBox,
     Corner,
@@ -31,6 +41,12 @@ from app.models.user_model import GoogleAuthRequest, TokenResponse, User
 from app.services.classical_matcher import get_classical_matcher
 from app.services.image_processor import get_image_processor
 from app.services.piece_detector import get_piece_detector
+from app.services.piece_geometry.service import (
+    PieceGeometryRecord,
+    get_piece_geometry_service,
+    quick_quality_from_polygon,
+)
+from app.services.piece_geometry.store import get_piece_geometry_store
 from app.services.piece_shape import PieceShapeGenerator, calculate_grid_dimensions
 from app.services.puzzle_cutter import get_puzzle_cutter
 from app.services.puzzle_detector import get_puzzle_detector
@@ -274,6 +290,15 @@ async def detect_frame(
 async def preview_piece(
     current_user: Annotated[User, Depends(get_current_user)],
     file: Optional[UploadFile] = None,
+    include_quality: Annotated[
+        bool,
+        Query(
+            description=(
+                "Also run a quick corner-detection pass on the detected region and add "
+                "lockable/corner_disagreement flags. Default response shape is unchanged when omitted."
+            )
+        ),
+    ] = False,
 ) -> PiecePreviewResponse:
     """Detect the puzzle piece region in a live camera frame.
 
@@ -284,6 +309,12 @@ async def preview_piece(
     Args:
         current_user: The authenticated user.
         file: A downscaled camera frame.
+        include_quality: When true, adds best-effort `lockable` and
+            `corner_disagreement` piece-geometry flags computed from the
+            detected region's polygon (see
+            `app.services.piece_geometry.service.quick_quality_from_polygon`).
+            Omitted/false leaves the response unchanged from before this flag
+            existed.
 
     Returns:
         PiecePreviewResponse with the detected region outline and a confidence
@@ -315,12 +346,19 @@ async def preview_piece(
     if region is None:
         return PiecePreviewResponse(found=False)
 
+    lockable: Optional[bool] = None
+    corner_disagreement: Optional[bool] = None
+    if include_quality:
+        lockable, corner_disagreement = quick_quality_from_polygon(region.polygon)
+
     x, y, w, h = region.bbox
     return PiecePreviewResponse(
         found=True,
         polygon=[Corner(x=px, y=py) for px, py in region.polygon],
         bbox=BoundingBox(x=x, y=y, width=w, height=h),
         confidence=region.confidence,
+        lockable=lockable,
+        corner_disagreement=corner_disagreement,
     )
 
 
@@ -360,6 +398,206 @@ async def process_piece(
     grid_hint = puzzle_grids.get(puzzle_id)
     return await get_classical_matcher().process_piece(
         file, puzzle_id, remove_background=remove_bg, grid_hint=grid_hint
+    )
+
+
+def _normalize_points(points: np.ndarray, width: int, height: int) -> List[GeometryPoint]:
+    """Normalize Nx2 pixel points to a list of [0, 1] GeometryPoint.
+
+    Args:
+        points: Nx2 array of pixel coordinates.
+        width: The source image's width in pixels.
+        height: The source image's height in pixels.
+
+    Returns:
+        The normalized, clamped points.
+    """
+    return [
+        GeometryPoint(x=float(np.clip(x / width, 0.0, 1.0)), y=float(np.clip(y / height, 0.0, 1.0))) for x, y in points
+    ]
+
+
+def _geometry_quality_response(record: PieceGeometryRecord) -> GeometryQuality:
+    """Build the GeometryQuality response model from a PieceGeometryRecord.
+
+    Args:
+        record: The pipeline's output record.
+
+    Returns:
+        The corresponding `GeometryQuality` response model.
+    """
+    quality = record.quality
+    return GeometryQuality(
+        is_clean=quality.is_clean,
+        corner_disagreement=record.corner_disagreement,
+        n_large_components=quality.n_large_components,
+        border_touching=quality.border_touching,
+        area_ratio=quality.area_ratio,
+        solidity=quality.solidity,
+    )
+
+
+def _geometry_record_response(
+    record: PieceGeometryRecord, width: int, height: int, include_contour: bool
+) -> PieceGeometryRecordResponse:
+    """Build the PieceGeometryRecordResponse from a PieceGeometryRecord.
+
+    Args:
+        record: The pipeline's output record.
+        width: The uploaded photo's width in pixels (for normalization).
+        height: The uploaded photo's height in pixels (for normalization).
+        include_contour: Whether to include the (large) full contour polyline.
+
+    Returns:
+        The corresponding `PieceGeometryRecordResponse` response model.
+    """
+    corners = _normalize_points(record.corners, width, height) if record.corners is not None else []
+    edges = (
+        [
+            GeometryEdge(
+                type=edge.edge_type,  # type: ignore[arg-type]
+                dominant_dev=edge.dominant_dev,
+                polyline=_normalize_points(edge.polyline, width, height),
+            )
+            for edge in record.edges
+        ]
+        if record.edges is not None
+        else []
+    )
+    contour = (
+        _normalize_points(record.contour, width, height) if include_contour and record.contour is not None else None
+    )
+    return PieceGeometryRecordResponse(
+        corners=corners,
+        corner_confidences=record.corner_confidences or [],
+        edges=edges,
+        contour=contour,
+    )
+
+
+@app.post("/api/v1/puzzle/{puzzle_id}/piece/geometry", response_model=PieceGeometryUploadResponse)
+async def upload_piece_geometry(
+    puzzle_id: str,
+    current_user: Annotated[User, Depends(get_current_user)],
+    file: Optional[UploadFile] = None,
+    include_contour: Annotated[
+        bool, Query(description="Include the full contour polyline in the response (large)")
+    ] = False,
+    on_uncertain: Annotated[
+        Literal["report", "enroll"],
+        Query(
+            description=(
+                "How to resolve a gray-zone (uncertain) verdict: 'report' returns status=uncertain without "
+                "enrolling (default); 'enroll' enrolls the photo as a NEW piece and returns status=new. Use "
+                "'enroll' after the client's own confirmation UX — most genuinely-new pieces land in the "
+                "gray zone (M7), so a session needs this to enroll beyond its first piece."
+            )
+        ),
+    ] = "report",
+) -> PieceGeometryUploadResponse:
+    """Extract piece geometry from a photo and dedupe it against this puzzle's piece store.
+
+    Runs the exp28 pipeline (background removal -> contour -> corners ->
+    edges -> fingerprint) on the uploaded photo, then compares the resulting
+    fingerprint against every piece already enrolled for this puzzle to
+    decide whether the photo is a piece seen before, a new piece, or an
+    uncertain (gray-zone) match.
+
+    Args:
+        puzzle_id: ID of the puzzle this piece photo belongs to.
+        current_user: The authenticated user.
+        file: The puzzle piece photo.
+        include_contour: Whether to include the full (large) contour polyline.
+        on_uncertain: Gray-zone resolution: "report" (default) keeps the
+            current conservative behavior; "enroll" enrolls a gray-zone
+            photo as a new piece. Matched/new verdicts are unaffected.
+
+    Returns:
+        PieceGeometryUploadResponse with the dedupe verdict, quality flags,
+        and the extracted geometric record.
+
+    Raises:
+        HTTPException: If no/invalid file is provided, the file is too
+            large, or the puzzle does not exist.
+    """
+    _ = current_user  # Acknowledge the parameter is intentionally unused for now
+    if file is None:
+        raise HTTPException(status_code=400, detail="No file provided")
+
+    if puzzle_id not in puzzle_images:
+        raise HTTPException(status_code=404, detail="Puzzle not found")
+
+    if file.size and file.size > settings.MAX_UPLOAD_SIZE:
+        raise HTTPException(status_code=413, detail="File too large")
+
+    contents = await file.read()
+    if len(contents) > settings.MAX_UPLOAD_SIZE:
+        raise HTTPException(status_code=413, detail="File too large")
+
+    try:
+        probe = Image.open(io.BytesIO(contents))
+        width, height = probe.size
+        probe.load()
+    except (UnidentifiedImageError, OSError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="Invalid image file") from exc
+
+    record = get_piece_geometry_service().process(contents)
+    # A record with a fingerprint always has a measured (non-None) disagreement
+    # flag; without a fingerprint the store ignores the flag entirely, so
+    # coercing None to False here is safe.
+    match = get_piece_geometry_store().add_or_match(
+        puzzle_id,
+        record.fingerprint,
+        record.quality.is_clean,
+        bool(record.corner_disagreement),
+        enroll_uncertain=on_uncertain == "enroll",
+    )
+
+    return PieceGeometryUploadResponse(
+        piece_id=match.piece_id,
+        status=match.verdict.value,
+        match_piece_id=match.match_piece_id,
+        z_score=match.z_score,
+        lockable=record.lockable,
+        quality=_geometry_quality_response(record),
+        record=_geometry_record_response(record, width, height, include_contour),
+    )
+
+
+@app.get("/api/v1/puzzle/{puzzle_id}/piece/geometry", response_model=PieceGeometryListResponse)
+async def list_piece_geometry(
+    puzzle_id: str,
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> PieceGeometryListResponse:
+    """List the pieces enrolled in a puzzle's piece-geometry store.
+
+    Args:
+        puzzle_id: ID of the puzzle to list.
+        current_user: The authenticated user.
+
+    Returns:
+        PieceGeometryListResponse with one summary (id, edge types, quality
+        flags — no polylines) per enrolled piece.
+
+    Raises:
+        HTTPException: If the puzzle does not exist.
+    """
+    _ = current_user  # Acknowledge the parameter is intentionally unused for now
+    if puzzle_id not in puzzle_images:
+        raise HTTPException(status_code=404, detail="Puzzle not found")
+
+    enrolled = get_piece_geometry_store().list_pieces(puzzle_id)
+    return PieceGeometryListResponse(
+        puzzle_id=puzzle_id,
+        pieces=[
+            PieceGeometrySummary(
+                piece_id=piece.piece_id,
+                edge_types=list(piece.fingerprint.edge_types),  # type: ignore[arg-type]
+                is_clean=piece.is_clean,
+                corner_disagreement=piece.corner_disagreement,
+            )
+            for piece in enrolled
+        ],
     )
 
 

--- a/backend/app/models/piece_geometry_model.py
+++ b/backend/app/models/piece_geometry_model.py
@@ -1,0 +1,85 @@
+"""Data models for the piece-geometry API (contour/corner/edge/fingerprint dedupe)."""
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+EdgeType = Literal["tab", "blank", "flat"]
+MatchStatus = Literal["matched", "new", "uncertain"]
+
+
+class GeometryPoint(BaseModel):
+    """A single point, normalized to [0, 1] relative to the piece image's width/height."""
+
+    x: float
+    y: float
+
+
+class GeometryEdge(BaseModel):
+    """One classified edge, in contour traversal order (orientation is unknown, so not N/E/S/W)."""
+
+    type: EdgeType
+    dominant_dev: float = Field(
+        ..., description="Signed dominant deviation from the corner-to-corner chord, normalized by chord length"
+    )
+    polyline: List[GeometryPoint] = Field(default_factory=list, description="100-point edge polyline, normalized 0-1")
+
+
+class GeometryQuality(BaseModel):
+    """Quality gates and metrics for an extracted piece contour (measured within the piece crop)."""
+
+    is_clean: bool = Field(..., description="Contour passed the quality gate (component count, area, solidity)")
+    corner_disagreement: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Whether the polydp and curvature corner detectors disagreed by more than the tolerance; "
+            "null when corner detection never ran (the flag only asserts what was actually measured)"
+        ),
+    )
+    n_large_components: int
+    border_touching: bool
+    area_ratio: float
+    solidity: float
+
+
+class PieceGeometryRecordResponse(BaseModel):
+    """The geometric record extracted from one piece photo."""
+
+    corners: List[GeometryPoint] = Field(default_factory=list, description="4 corners, normalized 0-1")
+    corner_confidences: List[float] = Field(default_factory=list)
+    edges: List[GeometryEdge] = Field(default_factory=list, description="4 edges, in contour traversal order")
+    contour: Optional[List[GeometryPoint]] = Field(
+        default=None, description="Full contour, normalized 0-1; present only when include_contour=true"
+    )
+
+
+class PieceGeometryUploadResponse(BaseModel):
+    """Response for POST .../piece/geometry: the extracted record plus the dedupe verdict."""
+
+    piece_id: Optional[str] = Field(
+        default=None, description="This photo's piece id (matched/new), or null when uncertain (not enrolled)"
+    )
+    status: MatchStatus
+    match_piece_id: Optional[str] = Field(
+        default=None, description="Closest existing piece id, when a comparison was made"
+    )
+    z_score: Optional[float] = Field(default=None, description="Closest match's combined shape+color z-score")
+    lockable: bool = Field(..., description="Clean contour, corner detectors agree, geometry fully computed")
+    quality: GeometryQuality
+    record: PieceGeometryRecordResponse
+
+
+class PieceGeometrySummary(BaseModel):
+    """One enrolled piece, without polylines (used by the list endpoint)."""
+
+    piece_id: str
+    edge_types: List[EdgeType]
+    is_clean: bool
+    corner_disagreement: bool
+
+
+class PieceGeometryListResponse(BaseModel):
+    """Response for GET .../piece/geometry: all pieces enrolled for a puzzle."""
+
+    puzzle_id: str
+    pieces: List[PieceGeometrySummary]

--- a/backend/app/models/piece_geometry_model.py
+++ b/backend/app/models/piece_geometry_model.py
@@ -9,7 +9,12 @@ MatchStatus = Literal["matched", "new", "uncertain"]
 
 
 class GeometryPoint(BaseModel):
-    """A single point, normalized to [0, 1] relative to the piece image's width/height."""
+    """A single point, normalized to [0, 1] against the uploaded piece photo's width/height.
+
+    The service extracts geometry within a crop but maps every coordinate back to the full
+    uploaded image before normalizing (see `_normalize_points`), so these are full-photo fractions,
+    not fractions of a cropped piece image.
+    """
 
     x: float
     y: float

--- a/backend/app/models/puzzle_model.py
+++ b/backend/app/models/puzzle_model.py
@@ -113,6 +113,17 @@ class PiecePreviewResponse(BaseModel):
     confidence: float = Field(
         default=0.0, ge=0.0, le=1.0, description="How piece-like the detected region is; 0.0 when found is False"
     )
+    lockable: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Best-effort piece-geometry quality flag from a quick corner-detection pass on the preview "
+            "region; only populated when the request opts in with include_quality=true"
+        ),
+    )
+    corner_disagreement: Optional[bool] = Field(
+        default=None,
+        description="Whether the quick corner cross-check disagreed; only populated with include_quality=true",
+    )
 
 
 class DetectFrameResponse(BaseModel):

--- a/backend/app/services/piece_geometry/__init__.py
+++ b/backend/app/services/piece_geometry/__init__.py
@@ -1,0 +1,9 @@
+"""Piece-geometry pipeline: photo -> contour -> corners -> edges -> fingerprint.
+
+Ported from ``network/experiments/exp28_piece_geometry/`` (see that
+experiment's ``HANDOFF.md`` for the algorithm decisions and thresholds this
+package productionizes). Each submodule carries a provenance note pointing
+at the exp28 source file it was ported from; keep algorithm changes in sync
+with that source unless a deviation is required for production (e.g. no
+scipy, unknown photo orientation) and documented locally.
+"""

--- a/backend/app/services/piece_geometry/contour.py
+++ b/backend/app/services/piece_geometry/contour.py
@@ -1,0 +1,315 @@
+"""Contour extraction, smoothing, resampling, and quality metrics.
+
+Ported from ``network/experiments/exp28_piece_geometry/common.py`` — keep
+algorithm changes in sync. Adapted for production: operates on a single
+in-memory alpha mask (from rembg) rather than a north_star dataset crop, and
+replaces ``scipy.ndimage.gaussian_filter1d`` (the backend has no scipy) with
+a small numpy circular-Gaussian helper that is numerically equivalent to
+scipy's ``mode="wrap"`` filtering (same truncated kernel, same wraparound).
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import cv2
+import numpy as np
+
+# Alpha value above which a rembg pixel counts as opaque (matches
+# app/services/piece_detector.py's harden_alpha/largest_alpha_component).
+ALPHA_THRESHOLD = 128
+
+# Morphological open+close kernel used to clean up masks before contour extraction.
+MORPH_KERNEL = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (5, 5))
+
+# A connected component must be at least this fraction of the largest component's
+# area to count as a distinct "large" component for quality scoring.
+LARGE_COMPONENT_AREA_FRAC = 0.02
+
+# A contour point within this many pixels of the crop edge counts as border-touching.
+BORDER_TOUCH_MARGIN_PX = 2.0
+
+# Kernel half-width in standard deviations, matching scipy.ndimage.gaussian_filter1d's default.
+GAUSSIAN_TRUNCATE = 4.0
+
+
+def alpha_to_mask(alpha: np.ndarray, alpha_threshold: int = ALPHA_THRESHOLD) -> np.ndarray:
+    """Harden a soft alpha matte into a binary mask.
+
+    Args:
+        alpha: Single-channel alpha array (H, W), values in [0, 255].
+        alpha_threshold: Alpha value above which a pixel counts as opaque.
+
+    Returns:
+        Binary mask (H, W) with values in {0, 255}.
+    """
+    return np.where(alpha > alpha_threshold, np.uint8(255), np.uint8(0))
+
+
+def largest_component_bbox(mask: np.ndarray) -> Optional[Tuple[int, int, int, int]]:
+    """Bounding box of the largest connected component in a binary mask.
+
+    Mirrors the intent of `app.services.piece_detector.largest_alpha_component`
+    (pick the biggest opaque blob as the piece candidate), but returns the
+    component's bbox directly: the piece-geometry pipeline needs the crop
+    window, not the contour, at this stage.
+
+    Args:
+        mask: Binary mask (H, W) with values in {0, 255}.
+
+    Returns:
+        Inclusive pixel bbox (x1, y1, x2, y2) of the largest component, or
+        None when the mask has no foreground pixels.
+    """
+    n_components, _, stats, _ = cv2.connectedComponentsWithStats(mask, connectivity=8)
+    if n_components <= 1:
+        return None
+    areas = stats[1:n_components, cv2.CC_STAT_AREA]
+    largest = 1 + int(np.argmax(areas))
+    x = int(stats[largest, cv2.CC_STAT_LEFT])
+    y = int(stats[largest, cv2.CC_STAT_TOP])
+    w = int(stats[largest, cv2.CC_STAT_WIDTH])
+    h = int(stats[largest, cv2.CC_STAT_HEIGHT])
+    return x, y, x + w - 1, y + h - 1
+
+
+def crop_with_margin(
+    image: np.ndarray, bbox: Tuple[int, int, int, int], margin_frac: float = 0.15
+) -> Tuple[np.ndarray, Tuple[int, int]]:
+    """Crop an image to a bounding box expanded by a margin, clamped to image bounds.
+
+    This reproduces exp28's frame of reference: the calibrated pipeline
+    (quality gates, corner windows, spatial color grid) was tuned on
+    piece-bbox crops with a 15% margin, not on full camera frames.
+
+    Args:
+        image: Source image as a numpy array (H, W, C) or (H, W).
+        bbox: Bounding box (x1, y1, x2, y2), inclusive pixel coordinates.
+        margin_frac: Extra margin added on each side, as a fraction of the
+            bbox width/height.
+
+    Returns:
+        Tuple of (crop, (offset_x, offset_y)) where offset is the crop's
+        top-left corner in the original image's pixel coordinates.
+    """
+    height, width = image.shape[:2]
+    x1, y1, x2, y2 = bbox
+    box_w = max(1, x2 - x1)
+    box_h = max(1, y2 - y1)
+    pad_x = round(box_w * margin_frac)
+    pad_y = round(box_h * margin_frac)
+
+    left = max(0, x1 - pad_x)
+    top = max(0, y1 - pad_y)
+    right = min(width, x2 + pad_x + 1)
+    bottom = min(height, y2 + pad_y + 1)
+
+    crop = image[top:bottom, left:right]
+    return crop, (left, top)
+
+
+def mask_to_contour(mask: np.ndarray) -> Optional[np.ndarray]:
+    """Clean up a binary mask and extract its largest external contour.
+
+    Applies a morphological open then close (5px ellipse) to remove speckle
+    noise and close small gaps, then returns the largest external contour at
+    full point density.
+
+    Args:
+        mask: Binary mask (H, W) with values in {0, 255}.
+
+    Returns:
+        Nx2 float array of contour points in the mask's own pixel coordinates,
+        or None when no contour is found.
+    """
+    cleaned = cv2.morphologyEx(mask, cv2.MORPH_OPEN, MORPH_KERNEL)
+    cleaned = cv2.morphologyEx(cleaned, cv2.MORPH_CLOSE, MORPH_KERNEL)
+    contours, _ = cv2.findContours(cleaned, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)
+    if not contours:
+        return None
+    largest = max(contours, key=cv2.contourArea)
+    if cv2.contourArea(largest) <= 0:
+        return None
+    return largest.reshape(-1, 2).astype(np.float64)
+
+
+def _gaussian_kernel1d(sigma: float, truncate: float = GAUSSIAN_TRUNCATE) -> np.ndarray:
+    """Build a normalized 1D Gaussian kernel, matching scipy's gaussian_filter1d.
+
+    Args:
+        sigma: Gaussian standard deviation in samples.
+        truncate: Kernel half-width in standard deviations.
+
+    Returns:
+        1D array of length ``2 * radius + 1`` (``radius = int(truncate * sigma + 0.5)``),
+        summing to 1.
+    """
+    radius = int(truncate * sigma + 0.5)
+    x = np.arange(-radius, radius + 1, dtype=np.float64)
+    kernel = np.exp(-0.5 * (x / sigma) ** 2)
+    return kernel / kernel.sum()
+
+
+def gaussian_filter1d_wrap(values: np.ndarray, sigma: float) -> np.ndarray:
+    """Circularly filter a 1D signal with a Gaussian kernel, numpy-only.
+
+    Numerically equivalent to
+    ``scipy.ndimage.gaussian_filter1d(values, sigma=sigma, mode="wrap")``:
+    same truncated kernel (see `_gaussian_kernel1d`) and the same circular
+    (wrap) boundary handling. Because the kernel is symmetric, convolution
+    and correlation coincide, so a plain `numpy.convolve` on a
+    wrap-padded signal reproduces scipy's `correlate1d`-based result exactly.
+
+    Args:
+        values: 1D signal, treated as one period of a periodic (closed-loop) signal.
+        sigma: Gaussian standard deviation in samples.
+
+    Returns:
+        The filtered signal, same length as `values`.
+    """
+    kernel = _gaussian_kernel1d(sigma)
+    radius = (len(kernel) - 1) // 2
+    padded = np.concatenate([values[-radius:], values, values[:radius]])
+    return np.convolve(padded, kernel, mode="valid")
+
+
+def smooth_contour(contour: np.ndarray, sigma: float = 2.0) -> np.ndarray:
+    """Smooth a closed contour with circular Gaussian filtering.
+
+    Args:
+        contour: Nx2 array of contour points, implicitly closed (first point
+            follows the last).
+        sigma: Gaussian standard deviation in samples.
+
+    Returns:
+        Nx2 smoothed contour, same length as the input.
+    """
+    x = gaussian_filter1d_wrap(contour[:, 0], sigma=sigma)
+    y = gaussian_filter1d_wrap(contour[:, 1], sigma=sigma)
+    return np.column_stack([x, y])
+
+
+def resample_contour(contour: np.ndarray, n: int) -> np.ndarray:
+    """Resample a closed contour to `n` arc-length-equidistant points.
+
+    Args:
+        contour: Nx2 array of contour points, implicitly closed.
+        n: Number of output points.
+
+    Returns:
+        Nx2 resampled contour.
+    """
+    closed = np.vstack([contour, contour[:1]])
+    diffs = np.diff(closed, axis=0)
+    segment_lengths = np.sqrt((diffs**2).sum(axis=1))
+    cumulative_length = np.concatenate([[0.0], np.cumsum(segment_lengths)])
+    total_length = cumulative_length[-1]
+
+    if total_length == 0:
+        idx = np.linspace(0, len(contour) - 1, n).astype(int)
+        return contour[idx]
+
+    target_lengths = np.linspace(0, total_length, n, endpoint=False)
+    resampled_x = np.interp(target_lengths, cumulative_length, closed[:, 0])
+    resampled_y = np.interp(target_lengths, cumulative_length, closed[:, 1])
+    return np.column_stack([resampled_x, resampled_y])
+
+
+def resample_polyline(points: np.ndarray, n: int) -> np.ndarray:
+    """Resample an OPEN polyline to `n` arc-length-equidistant points.
+
+    Unlike `resample_contour`, the polyline is not closed: the first and last
+    output points coincide with the input endpoints.
+
+    Args:
+        points: Mx2 array of polyline points.
+        n: Number of output points (>= 2).
+
+    Returns:
+        Nx2 resampled polyline.
+    """
+    diffs = np.diff(points, axis=0)
+    segment_lengths = np.sqrt((diffs**2).sum(axis=1))
+    cumulative_length = np.concatenate([[0.0], np.cumsum(segment_lengths)])
+    total_length = cumulative_length[-1]
+
+    if total_length == 0:
+        return np.repeat(points[:1], n, axis=0)
+
+    target_lengths = np.linspace(0, total_length, n)
+    resampled_x = np.interp(target_lengths, cumulative_length, points[:, 0])
+    resampled_y = np.interp(target_lengths, cumulative_length, points[:, 1])
+    return np.column_stack([resampled_x, resampled_y])
+
+
+@dataclass(frozen=True)
+class QualityMetrics:
+    """Quality signals for a contour extracted from a piece photo.
+
+    Attributes:
+        n_large_components: Number of connected components in the source mask
+            with area at least `LARGE_COMPONENT_AREA_FRAC` of the largest one.
+        border_touching: Whether any contour point lies within
+            `BORDER_TOUCH_MARGIN_PX` of the crop edge (segmentation likely
+            clipped the piece).
+        area_ratio: Contour area divided by the crop's pixel area.
+        solidity: Contour area divided by its convex hull area (low solidity
+            indicates a ragged or multi-lobed contour).
+        is_clean: Overall pass/fail: exactly one large component, not
+            border-touching, plausible area ratio, and plausible solidity.
+    """
+
+    n_large_components: int
+    border_touching: bool
+    area_ratio: float
+    solidity: float
+    is_clean: bool
+
+
+def contour_quality(contour: np.ndarray, mask: np.ndarray, crop_shape: Tuple[int, int]) -> QualityMetrics:
+    """Score how trustworthy an extracted contour is.
+
+    Args:
+        contour: Nx2 contour points in the mask's own pixel coordinates.
+        mask: The (uncleaned) binary mask the contour was derived from,
+            used to count connected components.
+        crop_shape: (height, width) of the crop the mask was computed on.
+
+    Returns:
+        The computed `QualityMetrics`.
+    """
+    height, width = crop_shape
+    crop_area = float(height * width)
+
+    n_components, _, stats, _ = cv2.connectedComponentsWithStats(mask, connectivity=8)
+    component_areas = stats[1:n_components, cv2.CC_STAT_AREA] if n_components > 1 else np.array([])
+    if len(component_areas) == 0:
+        n_large_components = 0
+    else:
+        largest_area = float(component_areas.max())
+        n_large_components = int(np.sum(component_areas >= LARGE_COMPONENT_AREA_FRAC * largest_area))
+
+    border_touching = bool(
+        np.any(contour[:, 0] <= BORDER_TOUCH_MARGIN_PX)
+        or np.any(contour[:, 1] <= BORDER_TOUCH_MARGIN_PX)
+        or np.any(contour[:, 0] >= width - 1 - BORDER_TOUCH_MARGIN_PX)
+        or np.any(contour[:, 1] >= height - 1 - BORDER_TOUCH_MARGIN_PX)
+    )
+
+    contour_area = float(cv2.contourArea(contour.astype(np.float32)))
+    area_ratio = contour_area / crop_area if crop_area > 0 else 0.0
+
+    hull = cv2.convexHull(contour.astype(np.float32))
+    hull_area = float(cv2.contourArea(hull))
+    solidity = contour_area / hull_area if hull_area > 0 else 0.0
+
+    is_clean = (
+        n_large_components == 1 and not border_touching and 0.05 <= area_ratio <= 0.9 and 0.6 <= solidity <= 0.995
+    )
+
+    return QualityMetrics(
+        n_large_components=n_large_components,
+        border_touching=border_touching,
+        area_ratio=area_ratio,
+        solidity=solidity,
+        is_clean=is_clean,
+    )

--- a/backend/app/services/piece_geometry/corners.py
+++ b/backend/app/services/piece_geometry/corners.py
@@ -1,0 +1,606 @@
+"""Corner detection: polydp (primary) + curvature (cross-check).
+
+Ported from ``network/experiments/exp28_piece_geometry/corner_detect.py`` —
+keep algorithm changes in sync. Two adaptations for the backend:
+
+1. The ``shitomasi`` detector is dropped (exp28's M2 bake-off found it fails
+   structurally on tab bulbs; only ``polydp``/``curvature`` are used
+   downstream).
+2. ``scipy.ndimage.gaussian_filter1d`` and ``scipy.optimize.linear_sum_assignment``
+   are unavailable in the backend. Curvature smoothing uses
+   ``app.services.piece_geometry.contour.gaussian_filter1d_wrap`` (numerically
+   equivalent numpy replacement). The corner-disagreement metric's 4x4
+   optimal assignment is brute-forced over the 24 permutations of 4 elements
+   instead of using the Hungarian algorithm — for n=4 this is an exact,
+   not approximate, equivalent (`_optimal_assignment_max_distance`).
+
+Both detectors share a candidate-pool -> best-4-subset -> refinement
+pipeline built around puzzle structure: a true piece corner has locally
+STRAIGHT contour on both sides (the edge shoulder regions), while a tab bulb
+tip curves away immediately. Each candidate gets a "cornerness" score
+(shoulder straightness on both sides x local angle near 90 degrees), the
+best 4-subset is chosen by mean-cornerness x quadrilateral angle-score x
+spacing-balance x normalized area, and the winning corners are refined by
+intersecting the two fitted shoulder lines (which recovers the un-rounded
+corner that `corner_radius` rounds off the actual contour).
+"""
+
+import itertools
+import math
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import cv2
+import numpy as np
+
+from app.services.piece_geometry.contour import gaussian_filter1d_wrap, resample_contour
+
+# --- Shared config -----------------------------------------------------
+
+# All detectors snap candidates to a contour resampled to this many points.
+RESAMPLE_POINTS = 512
+
+CURVATURE_K = 12
+CURVATURE_SMOOTH_SIGMA = 2.0
+CURVATURE_MAX_CANDIDATES = 16
+
+POLYDP_EPSILON_FRACS = np.linspace(0.005, 0.05, 10)
+
+# Cap on the candidate pool entering the brute-force 4-subset search; when a
+# detector proposes more, the top candidates by cornerness are kept.
+MAX_SUBSET_CANDIDATES = 16
+
+# Cornerness windows, in resampled-contour samples: skip the first W1 samples
+# on each side of a candidate (~0.8% of perimeter, the corner-rounding zone),
+# then fit a line to the following samples out to W2 (~4% of perimeter, the
+# edge shoulder region).
+CORNERNESS_W1 = 4
+CORNERNESS_W2 = 24
+
+# Straightness falloff: shoulder-fit RMS residual (as a fraction of the piece
+# bbox diagonal) at which the straightness score drops to 1/e. Straight
+# shoulders sit well under this; curved tab necks sit several times above it.
+STRAIGHTNESS_FALLOFF = 0.004
+
+# Corner refinement: the shoulder-line intersection replaces the raw contour
+# point only when the lines are not near-parallel and the intersection stays
+# close to the candidate.
+REFINE_W1 = 2
+REFINE_W2 = 10
+REFINE_MIN_ANGLE_DEG = 20.0
+REFINE_MAX_SHIFT_FRAC = 0.03
+
+# Corner cross-check: polydp vs curvature max matched-corner distance (as a
+# fraction of the bbox diagonal) above which the piece is flagged.
+CORNER_DISAGREEMENT_FRAC = 0.03
+
+# All 24 permutations of 4 elements, used to brute-force the optimal
+# (minimum total distance) assignment between two 4-corner sets.
+_PERMUTATIONS_4 = list(itertools.permutations(range(4)))
+
+
+class InsufficientCornersError(RuntimeError):
+    """Raised when a detector cannot find enough candidate points to form a quadrilateral."""
+
+
+@dataclass(frozen=True)
+class CornerResult:
+    """Four detected piece corners with per-corner confidence.
+
+    Attributes:
+        corners: 4x2 float array, ordered clockwise starting near the
+            top-left corner.
+        confidences: One confidence value per corner, in [0, 1], aligned with
+            `corners`.
+        method: Name of the detector that produced this result.
+    """
+
+    corners: np.ndarray
+    confidences: List[float]
+    method: str
+
+
+@dataclass(frozen=True)
+class CandidateGeometry:
+    """Local shoulder geometry at one corner candidate.
+
+    Attributes:
+        cornerness: Straightness-before x straightness-after x local angle
+            score, in [0, 1]. Near 1 for true piece corners, near 0 for tab
+            bulb tips.
+        line_before: (centroid, away-pointing unit direction) of the line
+            fitted to the shoulder window preceding the candidate.
+        line_after: (centroid, away-pointing unit direction) of the line
+            fitted to the shoulder window following the candidate.
+        refine_line_before: Like `line_before` but fitted on the tight
+            refinement window.
+        refine_line_after: Like `line_after` but on the tight window.
+    """
+
+    cornerness: float
+    line_before: Tuple[np.ndarray, np.ndarray]
+    line_after: Tuple[np.ndarray, np.ndarray]
+    refine_line_before: Tuple[np.ndarray, np.ndarray]
+    refine_line_after: Tuple[np.ndarray, np.ndarray]
+
+
+# --- Geometry helpers ----------------------------------------------------
+
+
+def _cumulative_arc_length(contour: np.ndarray) -> np.ndarray:
+    """Compute cumulative closed-loop arc length at each contour point.
+
+    Args:
+        contour: Nx2 contour points, implicitly closed.
+
+    Returns:
+        Length-N array; element i is the arc length from point 0 to point i.
+    """
+    closed = np.vstack([contour, contour[:1]])
+    diffs = np.diff(closed, axis=0)
+    segment_lengths = np.sqrt((diffs**2).sum(axis=1))
+    return np.concatenate([[0.0], np.cumsum(segment_lengths)])[:-1]
+
+
+def _polygon_interior_angles(pts: np.ndarray) -> np.ndarray:
+    """Compute the interior angle (degrees) at each vertex of a quadrilateral.
+
+    Args:
+        pts: 4x2 array of vertices in order around the polygon.
+
+    Returns:
+        Length-4 array of interior angles in degrees.
+    """
+    angles = np.zeros(4)
+    for i in range(4):
+        prev_pt = pts[(i - 1) % 4]
+        curr_pt = pts[i]
+        next_pt = pts[(i + 1) % 4]
+        v1 = prev_pt - curr_pt
+        v2 = next_pt - curr_pt
+        cos_angle = np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2) + 1e-8)
+        angles[i] = np.degrees(np.arccos(np.clip(cos_angle, -1.0, 1.0)))
+    return angles
+
+
+def _quad_area(pts: np.ndarray) -> float:
+    """Shoelace-formula area of a quadrilateral.
+
+    Args:
+        pts: 4x2 array of vertices in order around the polygon.
+
+    Returns:
+        Absolute area.
+    """
+    x = pts[:, 0]
+    y = pts[:, 1]
+    return 0.5 * abs(np.dot(x, np.roll(y, -1)) - np.dot(y, np.roll(x, -1)))
+
+
+def _fit_line_pca(points: np.ndarray) -> Tuple[np.ndarray, np.ndarray, float]:
+    """Fit a line to 2D points via PCA.
+
+    Args:
+        points: Mx2 array of points.
+
+    Returns:
+        Tuple of (centroid, unit direction of the first principal component,
+        RMS perpendicular residual).
+    """
+    centroid = points.mean(axis=0)
+    centered = points - centroid
+    _, _, vt = np.linalg.svd(centered, full_matrices=False)
+    direction = vt[0]
+    normal = np.array([-direction[1], direction[0]])
+    residuals = centered @ normal
+    rms = float(np.sqrt(np.mean(residuals**2)))
+    return centroid, direction, rms
+
+
+def _intersect_lines(c1: np.ndarray, d1: np.ndarray, c2: np.ndarray, d2: np.ndarray) -> Optional[np.ndarray]:
+    """Intersect two lines given in point + direction form.
+
+    Args:
+        c1: A point on the first line.
+        d1: Unit direction of the first line.
+        c2: A point on the second line.
+        d2: Unit direction of the second line.
+
+    Returns:
+        The intersection point, or None when the lines are near-parallel.
+    """
+    matrix = np.column_stack([d1, -d2])
+    det = float(np.linalg.det(matrix))
+    if abs(det) < 1e-9:
+        return None
+    params = np.linalg.solve(matrix, c2 - c1)
+    return c1 + params[0] * d1
+
+
+def bbox_diagonal(contour: np.ndarray) -> float:
+    """Diagonal length of a contour's axis-aligned bounding box.
+
+    Args:
+        contour: Nx2 contour points.
+
+    Returns:
+        Euclidean length of the bbox diagonal.
+    """
+    extent = contour.max(axis=0) - contour.min(axis=0)
+    return float(np.linalg.norm(extent))
+
+
+def nearest_contour_index(contour: np.ndarray, point: Tuple[float, float]) -> int:
+    """Find the index of the contour point nearest to `point`.
+
+    Args:
+        contour: Nx2 contour points.
+        point: (x, y) query point.
+
+    Returns:
+        Index into `contour` of the nearest point.
+    """
+    dists = np.sum((contour - np.array(point)) ** 2, axis=1)
+    return int(np.argmin(dists))
+
+
+def _optimal_assignment_max_distance(a: np.ndarray, b: np.ndarray) -> float:
+    """Max matched-point distance under the minimum-total-distance assignment of two 4-point sets.
+
+    Brute-forces the 24 permutations of 4 elements to find the assignment
+    minimizing total distance, then returns the maximum distance under that
+    (winning) assignment. For n=4 this is an exact equivalent of
+    ``scipy.optimize.linear_sum_assignment(cdist(a, b)).max()`` — the
+    Hungarian algorithm's guaranteed-optimal result coincides with the
+    brute-force optimum, and 24 permutations is cheap enough to enumerate.
+
+    Args:
+        a: 4x2 point set.
+        b: 4x2 point set.
+
+    Returns:
+        The maximum matched-pair distance under the optimal assignment.
+    """
+    best_sum = float("inf")
+    best_max = 0.0
+    for perm in _PERMUTATIONS_4:
+        dists = np.linalg.norm(a - b[list(perm)], axis=1)
+        total = float(dists.sum())
+        if total < best_sum:
+            best_sum = total
+            best_max = float(dists.max())
+    return best_max
+
+
+def corner_max_distance_frac(a: np.ndarray, b: np.ndarray, diagonal: float) -> float:
+    """Max matched-corner distance between two 4-corner sets, as a fraction of the diagonal.
+
+    Args:
+        a: 4x2 corner set.
+        b: 4x2 corner set.
+        diagonal: Piece bbox diagonal for normalization.
+
+    Returns:
+        `_optimal_assignment_max_distance(a, b)` divided by `diagonal`.
+    """
+    return _optimal_assignment_max_distance(a, b) / max(diagonal, 1e-8)
+
+
+# --- Cornerness ------------------------------------------------------------
+
+
+def candidate_geometry(resampled: np.ndarray, index: int, diagonal: float) -> CandidateGeometry:
+    """Score one candidate's local shoulder geometry.
+
+    Fits a line to the contour window on each side of the candidate (skipping
+    the first `CORNERNESS_W1` samples for corner rounding, using the samples
+    out to `CORNERNESS_W2`). Straightness of each fit and the angle between
+    the two fitted lines combine into the cornerness score: a true piece
+    corner has two straight shoulders meeting near 90 degrees, while a tab
+    bulb tip curves away immediately on both sides.
+
+    Args:
+        resampled: Arc-length-resampled contour (`RESAMPLE_POINTS` x 2).
+        index: Candidate index into `resampled`.
+        diagonal: Piece bbox diagonal, for scale-normalizing fit residuals.
+
+    Returns:
+        The computed `CandidateGeometry`.
+    """
+    n = len(resampled)
+    idx_before = [(index - j) % n for j in range(CORNERNESS_W1, CORNERNESS_W2 + 1)]
+    idx_after = [(index + j) % n for j in range(CORNERNESS_W1, CORNERNESS_W2 + 1)]
+    pts_before = resampled[idx_before]
+    pts_after = resampled[idx_after]
+
+    centroid_b, dir_b, rms_b = _fit_line_pca(pts_before)
+    centroid_a, dir_a, rms_a = _fit_line_pca(pts_after)
+
+    scale = max(diagonal, 1e-8)
+    straightness_before = math.exp(-(rms_b / scale) / STRAIGHTNESS_FALLOFF)
+    straightness_after = math.exp(-(rms_a / scale) / STRAIGHTNESS_FALLOFF)
+
+    # Orient each direction away from the corner (from the window's near end
+    # toward its far end) so their angle approximates the interior angle.
+    if np.dot(dir_b, pts_before[-1] - pts_before[0]) < 0:
+        dir_b = -dir_b
+    if np.dot(dir_a, pts_after[-1] - pts_after[0]) < 0:
+        dir_a = -dir_a
+
+    cos_angle = float(np.clip(np.dot(dir_b, dir_a), -1.0, 1.0))
+    angle = math.degrees(math.acos(cos_angle))
+    local_angle_score = max(0.0, 1.0 - abs(angle - 90.0) / 45.0)
+
+    cornerness = straightness_before * straightness_after * local_angle_score
+
+    # Tight-window fits for refinement: right next to the corner the contour
+    # tangents point at the un-rounded corner.
+    ref_before = [(index - j) % n for j in range(REFINE_W1, REFINE_W2 + 1)]
+    ref_after = [(index + j) % n for j in range(REFINE_W1, REFINE_W2 + 1)]
+    ref_centroid_b, ref_dir_b, _ = _fit_line_pca(resampled[ref_before])
+    ref_centroid_a, ref_dir_a, _ = _fit_line_pca(resampled[ref_after])
+
+    return CandidateGeometry(
+        cornerness=cornerness,
+        line_before=(centroid_b, dir_b),
+        line_after=(centroid_a, dir_a),
+        refine_line_before=(ref_centroid_b, ref_dir_b),
+        refine_line_after=(ref_centroid_a, ref_dir_a),
+    )
+
+
+# --- Shared 4-subset scorer and refinement --------------------------------
+
+
+def best_four_subset(
+    contour: np.ndarray,
+    candidate_indices: Sequence[int],
+    arc_length: np.ndarray,
+    cornerness: Dict[int, float],
+    hull_area: float,
+) -> Tuple[Tuple[int, int, int, int], float, np.ndarray]:
+    """Brute-force the best 4-corner subset of a candidate index set.
+
+    Scores each combination by mean-cornerness x quadrilateral angle-score x
+    spacing-balance x normalized area.
+
+    Args:
+        contour: Nx2 contour points the candidate indices refer into.
+        candidate_indices: Indices into `contour` to consider as corners.
+        arc_length: Cumulative closed-loop arc length at each contour point.
+        cornerness: Per-candidate cornerness score.
+        hull_area: Convex hull area of the full contour, for area normalization.
+
+    Returns:
+        Tuple of (best 4-tuple of indices, its score, its per-corner angle scores).
+
+    Raises:
+        InsufficientCornersError: When fewer than 4 unique candidates are given.
+    """
+    unique = sorted(set(candidate_indices))
+    if len(unique) < 4:
+        raise InsufficientCornersError(f"Need >=4 candidate corners, got {len(unique)}")
+
+    perimeter = arc_length[-1] + np.linalg.norm(contour[-1] - contour[0])
+    hull_area = max(hull_area, 1e-8)
+    best_combo: Tuple[int, int, int, int] = tuple(unique[:4])  # type: ignore[assignment]
+    best_score = -1.0
+    best_corner_scores = np.zeros(4)
+
+    for combo in itertools.combinations(unique, 4):
+        pts = contour[list(combo)]
+        area_normalized = _quad_area(pts) / hull_area
+        if area_normalized <= 0:
+            continue
+        angles = _polygon_interior_angles(pts)
+        corner_scores = np.clip(1.0 - np.abs(angles - 90.0) / 45.0, 0.0, None)
+        angle_score = float(corner_scores.mean())
+
+        positions = np.sort(arc_length[list(combo)])
+        gaps = np.diff(np.concatenate([positions, positions[:1] + perimeter]))
+        spacing_balance = float(gaps.min() / gaps.max()) if gaps.max() > 0 else 0.0
+
+        mean_cornerness = float(np.mean([cornerness[i] for i in combo]))
+        score = mean_cornerness * angle_score * spacing_balance * area_normalized
+        if score > best_score:
+            best_score = score
+            best_combo = combo  # type: ignore[assignment]
+            best_corner_scores = corner_scores
+
+    return best_combo, best_score, best_corner_scores
+
+
+def _order_clockwise(corners: np.ndarray, confidences: np.ndarray) -> Tuple[np.ndarray, List[float]]:
+    """Order 4 corners clockwise (image coordinates, y-down) starting near the top-left.
+
+    Args:
+        corners: 4x2 array of corner points.
+        confidences: Length-4 array of per-corner confidences, aligned with `corners`.
+
+    Returns:
+        Tuple of (reordered 4x2 corners, reordered confidence list).
+    """
+    centroid = corners.mean(axis=0)
+    angles = np.arctan2(corners[:, 1] - centroid[1], corners[:, 0] - centroid[0])
+    order = np.argsort(angles)
+    ordered = corners[order]
+    ordered_conf = confidences[order]
+
+    start = int(np.argmin(ordered[:, 0] + ordered[:, 1]))
+    ordered = np.roll(ordered, -start, axis=0)
+    ordered_conf = np.roll(ordered_conf, -start, axis=0)
+    return ordered, ordered_conf.tolist()
+
+
+def _refine_corner(candidate_point: np.ndarray, geometry: CandidateGeometry, diagonal: float) -> np.ndarray:
+    """Refine a corner by intersecting its two fitted shoulder lines.
+
+    Args:
+        candidate_point: The candidate's raw contour point.
+        geometry: The candidate's shoulder geometry.
+        diagonal: Piece bbox diagonal, for the max-shift sanity check.
+
+    Returns:
+        The refined corner, or `candidate_point` unchanged when the shoulder
+        lines are near-parallel or the intersection lands too far away.
+    """
+    centroid_b, dir_b = geometry.refine_line_before
+    centroid_a, dir_a = geometry.refine_line_after
+
+    cos_angle = float(np.clip(abs(np.dot(dir_b, dir_a)), 0.0, 1.0))
+    angle_between = math.degrees(math.acos(cos_angle))
+    if angle_between < REFINE_MIN_ANGLE_DEG:
+        return candidate_point
+
+    intersection = _intersect_lines(centroid_b, dir_b, centroid_a, dir_a)
+    if intersection is None:
+        return candidate_point
+    if float(np.linalg.norm(intersection - candidate_point)) > REFINE_MAX_SHIFT_FRAC * diagonal:
+        return candidate_point
+    return intersection
+
+
+def _select_and_refine(resampled: np.ndarray, candidate_indices: Sequence[int], method: str) -> CornerResult:
+    """Shared back half of every detector: score candidates, pick 4, refine, order.
+
+    Args:
+        resampled: Arc-length-resampled contour (`RESAMPLE_POINTS` x 2).
+        candidate_indices: Candidate indices into `resampled`.
+        method: Detector name for the result.
+
+    Returns:
+        The final `CornerResult`.
+
+    Raises:
+        InsufficientCornersError: When fewer than 4 unique candidates are given.
+    """
+    unique = sorted(set(candidate_indices))
+    if len(unique) < 4:
+        raise InsufficientCornersError(f"Need >=4 candidate corners, got {len(unique)}")
+
+    diagonal = bbox_diagonal(resampled)
+    geometries = {i: candidate_geometry(resampled, i, diagonal) for i in unique}
+    cornerness = {i: g.cornerness for i, g in geometries.items()}
+    if len(unique) > MAX_SUBSET_CANDIDATES:
+        unique = sorted(sorted(unique, key=lambda i: -cornerness[i])[:MAX_SUBSET_CANDIDATES])
+    arc_length = _cumulative_arc_length(resampled)
+    hull_area = float(cv2.contourArea(cv2.convexHull(resampled.astype(np.float32))))
+
+    combo, _, quad_corner_scores = best_four_subset(resampled, unique, arc_length, cornerness, hull_area)
+
+    refined = np.zeros((4, 2))
+    confidences = np.zeros(4)
+    for j, idx in enumerate(combo):
+        geometry = geometries[idx]
+        refined[j] = _refine_corner(resampled[idx], geometry, diagonal)
+        confidences[j] = float(np.clip(geometry.cornerness * quad_corner_scores[j], 0.0, 1.0))
+
+    ordered, ordered_conf = _order_clockwise(refined, confidences)
+    return CornerResult(corners=ordered, confidences=ordered_conf, method=method)
+
+
+# --- Detectors ------------------------------------------------------------
+
+
+def detect_corners_curvature(contour: np.ndarray) -> CornerResult:
+    """Detect corners from local curvature (turn angle) along the resampled contour.
+
+    Args:
+        contour: Nx2 contour points in original image coordinates.
+
+    Returns:
+        The detected `CornerResult`.
+
+    Raises:
+        InsufficientCornersError: When fewer than 4 corner candidates survive.
+    """
+    resampled = resample_contour(contour, RESAMPLE_POINTS)
+    n = len(resampled)
+    k = CURVATURE_K
+
+    response = np.zeros(n)
+    for i in range(n):
+        p_prev = resampled[(i - k) % n]
+        p_curr = resampled[i]
+        p_next = resampled[(i + k) % n]
+        v1 = p_curr - p_prev
+        v2 = p_next - p_curr
+        cos_angle = np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2) + 1e-8)
+        response[i] = np.degrees(np.arccos(np.clip(cos_angle, -1.0, 1.0)))
+
+    response = gaussian_filter1d_wrap(response, sigma=CURVATURE_SMOOTH_SIGMA)
+
+    # ~3% of the perimeter: tight enough that a true corner is not suppressed
+    # by a nearby higher-curvature tab armpit, wide enough to dedupe peaks.
+    min_separation = n // 32
+    order = np.argsort(-response)
+    selected: List[int] = []
+    for idx in order:
+        if all(min(abs(idx - s), n - abs(idx - s)) >= min_separation for s in selected):
+            selected.append(int(idx))
+        if len(selected) >= CURVATURE_MAX_CANDIDATES:
+            break
+
+    if len(selected) < 4:
+        selected = [int(i) for i in order[:CURVATURE_MAX_CANDIDATES]]
+
+    return _select_and_refine(resampled, selected, "curvature")
+
+
+def detect_corners_polydp(contour: np.ndarray) -> CornerResult:
+    """Detect corners via an `approxPolyDP` epsilon sweep.
+
+    Sweeps the Douglas-Peucker epsilon from 0.5% to 5% of the perimeter,
+    collecting every vertex candidate seen across the sweep, then runs the
+    shared cornerness-based selection and shoulder-line refinement.
+
+    Args:
+        contour: Nx2 contour points in original image coordinates.
+
+    Returns:
+        The detected `CornerResult`.
+
+    Raises:
+        InsufficientCornersError: When fewer than 4 corner candidates survive.
+    """
+    resampled = resample_contour(contour, RESAMPLE_POINTS)
+    contour_cv = contour.astype(np.float32).reshape(-1, 1, 2)
+    perimeter = cv2.arcLength(contour_cv, closed=True)
+
+    candidates: set[int] = set()
+    for eps_frac in POLYDP_EPSILON_FRACS:
+        epsilon = eps_frac * perimeter
+        approx = cv2.approxPolyDP(contour_cv, epsilon, closed=True).reshape(-1, 2)
+        for pt in approx:
+            candidates.add(nearest_contour_index(resampled, (float(pt[0]), float(pt[1]))))
+
+    return _select_and_refine(resampled, sorted(candidates), "polydp")
+
+
+def detect_corners_with_cross_check(contour: np.ndarray) -> Tuple[CornerResult, bool]:
+    """Detect corners with polydp (primary) and curvature (cross-check).
+
+    Args:
+        contour: Nx2 contour points in original image coordinates.
+
+    Returns:
+        Tuple of (primary polydp `CornerResult`, corner_disagreement flag).
+        The flag is True when the curvature cross-check disagrees with
+        polydp by more than `CORNER_DISAGREEMENT_FRAC` of the bbox diagonal,
+        or when the cross-check itself fails to find 4 corners.
+
+    Raises:
+        InsufficientCornersError: When the primary (polydp) detector fails.
+    """
+    primary = detect_corners_polydp(contour)
+
+    disagreement = True
+    try:
+        cross_check = detect_corners_curvature(contour)
+        diagonal = bbox_diagonal(contour)
+        frac = corner_max_distance_frac(primary.corners, cross_check.corners, diagonal)
+        disagreement = frac > CORNER_DISAGREEMENT_FRAC
+    except InsufficientCornersError:
+        pass  # keep disagreement=True: no cross-check available
+
+    return primary, disagreement

--- a/backend/app/services/piece_geometry/edges.py
+++ b/backend/app/services/piece_geometry/edges.py
@@ -1,0 +1,222 @@
+"""Edge splitting, tab/blank/flat classification, and canonical edge frames.
+
+Ported from ``network/experiments/exp28_piece_geometry/edge_split.py`` (split
++ classify) and ``edge_match.py`` (``canonicalize_edge``) — keep algorithm
+changes in sync.
+
+Deviation from exp28: production pieces are photographed at an UNKNOWN
+orientation (exp28's north_star photos were all captured upright at
+rotation 0, so ``edge_split.py`` could map arcs to a N/E/S/W grid frame).
+This module keeps edges in CONTOUR TRAVERSAL ORDER instead — that dataset-
+specific grid mapping does not apply to freely-oriented production captures.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from app.services.piece_geometry.contour import resample_contour, resample_polyline
+from app.services.piece_geometry.corners import (
+    CornerResult,
+    InsufficientCornersError,
+    detect_corners_with_cross_check,
+    nearest_contour_index,
+)
+
+# Dense resampling used for edge splitting (finer than the detectors' 512).
+SPLIT_RESAMPLE_POINTS = 1024
+
+# Each edge arc is stored resampled to this many equidistant points.
+EDGE_POLYLINE_POINTS = 100
+
+# Tab/blank/flat threshold on |dominant deviation| / chord length. The
+# distribution measured across all 3,664 clean exp28 edges is strongly
+# bimodal: grid-truth flat edges cluster in [0, 0.04] (median 0.009) and
+# tab/blank features in [0.11, 0.42] (median 0.292). 0.07 sits mid-gap.
+FLAT_THRESHOLD = 0.07
+
+
+@dataclass(frozen=True)
+class Edge:
+    """One classified edge arc, in contour traversal order.
+
+    Attributes:
+        index: The edge's position (0-3) in contour traversal order, starting
+            at the corner nearest the top-left of the piece's bbox. Since
+            production photos have unknown orientation, this is NOT a grid
+            direction (N/E/S/W) — just a stable per-piece ordering.
+        edge_type: "tab", "blank", or "flat".
+        dominant_dev: Signed dominant deviation from the corner-to-corner
+            chord, normalized by chord length (positive = tab, negative =
+            blank).
+        max_dev: Max signed deviation (normalized).
+        min_dev: Min signed deviation (normalized).
+        chord_length_px: The edge's chord length in image pixels.
+        polyline: (100, 2) raw image-coordinate polyline, corner A -> corner B.
+        canonical_polyline: (100, 2) chord-normalized canonical polyline (see
+            `canonicalize_edge`).
+    """
+
+    index: int
+    edge_type: str
+    dominant_dev: float
+    max_dev: float
+    min_dev: float
+    chord_length_px: float
+    polyline: np.ndarray
+    canonical_polyline: np.ndarray
+
+
+def canonicalize_edge(polyline: np.ndarray) -> np.ndarray:
+    """Map an edge polyline to the canonical frame.
+
+    Translates the first point to the origin, rotates so the last point lies
+    on the +x axis, and scales so the chord length is 1.
+
+    Args:
+        polyline: Nx2 edge points, corner A first, corner B last.
+
+    Returns:
+        Nx2 canonical polyline (A at (0,0), B at (1,0)).
+    """
+    a = polyline[0]
+    chord = polyline[-1] - a
+    length = float(np.linalg.norm(chord))
+    if length < 1e-9:
+        return np.zeros_like(polyline)
+    cos_t = chord[0] / length
+    sin_t = chord[1] / length
+    rotation = np.array([[cos_t, sin_t], [-sin_t, cos_t]])
+    return (polyline - a) @ rotation.T / length
+
+
+def _signed_area(contour: np.ndarray) -> float:
+    """Shoelace signed area of a closed contour in image coordinates.
+
+    In image coordinates (y down), a visually-clockwise polygon has POSITIVE
+    signed area.
+
+    Args:
+        contour: Nx2 contour points.
+
+    Returns:
+        The signed area.
+    """
+    x = contour[:, 0]
+    y = contour[:, 1]
+    return 0.5 * float(np.dot(x, np.roll(y, -1)) - np.dot(y, np.roll(x, -1)))
+
+
+def _arc_slice(resampled: np.ndarray, start: int, end: int) -> np.ndarray:
+    """Extract the cyclic slice start..end (inclusive) from a closed contour.
+
+    Args:
+        resampled: Nx2 closed contour points.
+        start: Start index.
+        end: End index (may be cyclically before `start`).
+
+    Returns:
+        The arc points from `start` to `end` inclusive, in contour order.
+    """
+    if end >= start:
+        return resampled[start : end + 1]
+    return np.vstack([resampled[start:], resampled[: end + 1]])
+
+
+def classify_arc(arc: np.ndarray, centroid: np.ndarray) -> Tuple[str, float, float, float, float]:
+    """Classify one edge arc as tab/blank/flat from its chord deviation profile.
+
+    The chord runs between the arc's two endpoint corners. Every arc point
+    gets a signed perpendicular deviation from the chord, with positive
+    meaning away from the piece centroid. The dominant deviation (larger
+    magnitude of max/min) decides the type.
+
+    Args:
+        arc: Mx2 arc points, endpoints being the two corners.
+        centroid: The piece centroid (for the away-from-piece sign convention).
+
+    Returns:
+        Tuple of (edge type, dominant_dev, max_dev, min_dev, chord_length),
+        deviations normalized by chord length.
+    """
+    corner_a = arc[0]
+    corner_b = arc[-1]
+    chord = corner_b - corner_a
+    chord_length = float(np.linalg.norm(chord))
+    if chord_length < 1e-8:
+        return "flat", 0.0, 0.0, 0.0, chord_length
+    u = chord / chord_length
+
+    def cross_with_u(points: np.ndarray) -> np.ndarray:
+        rel = points - corner_a
+        return u[0] * rel[:, 1] - u[1] * rel[:, 0]
+
+    centroid_side = float(cross_with_u(centroid.reshape(1, 2))[0])
+    away_sign = -1.0 if centroid_side > 0 else 1.0
+
+    devs = cross_with_u(arc) * away_sign / chord_length
+    max_dev = float(devs.max())
+    min_dev = float(devs.min())
+    dominant_dev = max_dev if abs(max_dev) >= abs(min_dev) else min_dev
+
+    if abs(dominant_dev) < FLAT_THRESHOLD:
+        edge_type = "flat"
+    elif dominant_dev > 0:
+        edge_type = "tab"
+    else:
+        edge_type = "blank"
+    return edge_type, dominant_dev, max_dev, min_dev, chord_length
+
+
+def split_edges(contour: np.ndarray) -> Optional[Tuple[List[Edge], CornerResult, bool]]:
+    """Detect corners and split a contour into 4 classified, canonicalized edges.
+
+    Args:
+        contour: Nx2 contour in original image coordinates.
+
+    Returns:
+        Tuple of (4 edges in contour traversal order, the polydp
+        `CornerResult`, the corner_disagreement flag), or None when corner
+        detection fails or the detected corners collapse onto each other on
+        the resampled contour.
+    """
+    try:
+        primary, disagreement = detect_corners_with_cross_check(contour)
+    except InsufficientCornersError:
+        return None
+
+    resampled = resample_contour(contour, SPLIT_RESAMPLE_POINTS)
+    # Enforce visually-clockwise winding so traversal order matches the
+    # clockwise corner order.
+    if _signed_area(resampled) < 0:
+        resampled = resampled[::-1]
+
+    corner_idx = [nearest_contour_index(resampled, (float(c[0]), float(c[1]))) for c in primary.corners]
+    if len(set(corner_idx)) < 4:
+        return None
+
+    forward = [(corner_idx[(j + 1) % 4] - corner_idx[j]) % SPLIT_RESAMPLE_POINTS for j in range(4)]
+    if sum(forward) != SPLIT_RESAMPLE_POINTS:
+        return None
+
+    centroid = resampled.mean(axis=0)
+    edges: List[Edge] = []
+    for j in range(4):
+        arc = _arc_slice(resampled, corner_idx[j], corner_idx[(j + 1) % 4])
+        edge_type, dominant_dev, max_dev, min_dev, chord_length = classify_arc(arc, centroid)
+        polyline = resample_polyline(arc, EDGE_POLYLINE_POINTS)
+        edges.append(
+            Edge(
+                index=j,
+                edge_type=edge_type,
+                dominant_dev=dominant_dev,
+                max_dev=max_dev,
+                min_dev=min_dev,
+                chord_length_px=chord_length,
+                polyline=polyline,
+                canonical_polyline=canonicalize_edge(polyline),
+            )
+        )
+
+    return edges, primary, disagreement

--- a/backend/app/services/piece_geometry/fingerprint.py
+++ b/backend/app/services/piece_geometry/fingerprint.py
@@ -1,0 +1,319 @@
+"""Piece fingerprint: shape descriptor + spatial color descriptor, and piece-to-piece distances.
+
+Ported from ``network/experiments/exp28_piece_geometry/fingerprint.py`` —
+keep algorithm changes in sync.
+
+A fingerprint identifies one PHYSICAL piece from one photo and combines two
+signals:
+
+1. SHAPE: the piece's 4 canonical edge polylines (chord-normalized frames
+   from `app.services.piece_geometry.edges.canonicalize_edge`). Piece-to-piece
+   shape distance is the mean per-edge L2 distance, minimized over the 4
+   cyclic rotations of the edge order (robust to unknown photo orientation),
+   gated by an exact edge-type-signature match under the winning rotation
+   (falling back to the ungated minimum when no rotation's signature matches).
+2. SPATIAL COLOR: the piece bbox divided into a 3x3 grid, each cell holding a
+   gray-world-normalized a*b* histogram; cells with fewer than
+   `SPATIAL_MIN_PIXELS` masked pixels are empty. Spatial distance = mean
+   per-cell chi-square over cells non-empty on both sides, with the
+   candidate's grid rotated consistently with the shape edge shift k.
+
+A global gray-world a*b* histogram is also carried on the fingerprint for
+completeness (exp28 M6 found it a weaker standalone signal than the spatial
+descriptor); it is not part of the M7 z-sum score used for scan-lock
+thresholding (see `app.services.piece_geometry.scoring`).
+"""
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import cv2
+import numpy as np
+
+from app.services.piece_geometry.edges import Edge
+
+# Erosion radius (pixels) applied to the contour mask before sampling color,
+# to strip the background halo/anti-aliased edge.
+ERODE_PX = 5
+
+# a*b*-only histogram (lighting-robustness hypothesis): 16 bins/channel -> 256-d.
+AB_BINS = 16
+# OpenCV's 8-bit BGR2LAB maps all three channels into [0, 255].
+CHANNEL_RANGE = (0, 256)
+
+# Spatial color descriptor: the piece's axis-aligned bbox is divided into a
+# SPATIAL_GRID x SPATIAL_GRID grid; each cell gets a gray-world a*b*
+# histogram with SPATIAL_AB_BINS bins/channel; cells with fewer than
+# SPATIAL_MIN_PIXELS masked pixels are marked empty.
+SPATIAL_GRID = 3
+SPATIAL_AB_BINS = 8
+SPATIAL_MIN_PIXELS = 50
+
+EdgeTypes = Tuple[str, str, str, str]
+
+
+def _spatial_rotation_permutations() -> np.ndarray:
+    """Cell-index permutations of the spatial grid under CCW rotations.
+
+    Row k gives, for each query cell index (row-major 3x3), the CANDIDATE
+    cell index that occupies the same physical location once the candidate
+    piece is rotated CCW by k*90 degrees - matching the shape edge shift k
+    convention (query edge i pairs with candidate edge (i+k) mod 4).
+
+    Returns:
+        (4, SPATIAL_GRID**2) integer permutation array.
+    """
+    idx = np.arange(SPATIAL_GRID**2).reshape(SPATIAL_GRID, SPATIAL_GRID)
+    return np.stack([np.rot90(idx, k).flatten() for k in range(4)], axis=0)
+
+
+SPATIAL_ROT_PERMS = _spatial_rotation_permutations()
+
+
+@dataclass(frozen=True)
+class PieceFingerprint:
+    """One physical piece's fingerprint from one photo.
+
+    Attributes:
+        edge_types: Edge type per edge, in contour traversal order.
+        edges_canonical: (4, 100, 2) canonical edge polylines, contour order.
+        spatial_hists: (9, SPATIAL_AB_BINS**2) per-grid-cell gray-world a*b*
+            histograms (row-major 3x3 over the piece bbox), each
+            L1-normalized or zero.
+        spatial_nonempty: (9,) boolean flags, True where the cell has at
+            least `SPATIAL_MIN_PIXELS` masked pixels.
+        color_hist_ab_gw: 256-d L1-normalized global a*b* histogram after
+            gray-world normalization (kept on the record for completeness;
+            not used by the M7 z-sum score).
+    """
+
+    edge_types: EdgeTypes
+    edges_canonical: np.ndarray
+    spatial_hists: np.ndarray
+    spatial_nonempty: np.ndarray
+    color_hist_ab_gw: np.ndarray
+
+
+def build_piece_mask(image_shape: Tuple[int, ...], contour: np.ndarray, erode_px: int = ERODE_PX) -> np.ndarray:
+    """Rasterize a full-image-coordinate contour into an eroded binary mask.
+
+    Args:
+        image_shape: The source photo's (H, W[, C]) shape.
+        contour: Nx2 contour points in the photo's own pixel coordinates.
+        erode_px: Erosion radius in pixels, to strip the background halo.
+
+    Returns:
+        Binary mask (H, W) with values in {0, 255}.
+    """
+    mask = np.zeros(image_shape[:2], dtype=np.uint8)
+    cv2.fillPoly(mask, [contour.astype(np.int32)], (255,))
+    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (2 * erode_px + 1, 2 * erode_px + 1))
+    return cv2.erode(mask, kernel, iterations=1)
+
+
+def _gray_world_lab_pixels(bgr_pixels: np.ndarray) -> np.ndarray:
+    """Gray-world-normalize BGR pixels and convert them to L*a*b*.
+
+    Scales each BGR channel so the pixel-set mean is neutral, clips to
+    [0, 255], and converts the result to OpenCV 8-bit L*a*b*.
+
+    Args:
+        bgr_pixels: (N, 3) float BGR pixel values.
+
+    Returns:
+        (N, 3) L*a*b* pixel values after gray-world normalization.
+    """
+    channel_means = bgr_pixels.mean(axis=0)
+    gray = float(channel_means.mean())
+    scaled = bgr_pixels * (gray / np.maximum(channel_means, 1e-9))
+    scaled_u8 = np.clip(scaled, 0, 255).astype(np.uint8).reshape(-1, 1, 3)
+    return cv2.cvtColor(scaled_u8, cv2.COLOR_BGR2LAB).reshape(-1, 3).astype(np.float64)
+
+
+def _ab_histogram(lab_pixels: np.ndarray) -> np.ndarray:
+    """L1-normalized a*b*-only histogram (16x16) of L*a*b* pixels.
+
+    Args:
+        lab_pixels: (N, 3) L*a*b* pixel values in OpenCV 8-bit ranges.
+
+    Returns:
+        256-d L1-normalized histogram.
+    """
+    hist_ab, _, _ = np.histogram2d(lab_pixels[:, 1], lab_pixels[:, 2], bins=AB_BINS, range=(CHANNEL_RANGE,) * 2)
+    hist_ab = hist_ab.flatten()
+    return hist_ab / max(hist_ab.sum(), 1e-10)
+
+
+def compute_global_ab_gw_histogram(image_bgr: np.ndarray, mask: np.ndarray) -> np.ndarray:
+    """Compute the global gray-world a*b* histogram over masked pixels.
+
+    Args:
+        image_bgr: The full photo in OpenCV BGR channel order.
+        mask: Binary mask (H, W), values in {0, 255}; nonzero pixels are sampled.
+
+    Returns:
+        256-d L1-normalized histogram (all-zero when the mask is empty).
+    """
+    ys, xs = np.where(mask > 0)
+    if len(ys) == 0:
+        return np.zeros(AB_BINS**2, dtype=np.float64)
+    bgr_pixels = image_bgr[ys, xs].astype(np.float64)
+    return _ab_histogram(_gray_world_lab_pixels(bgr_pixels))
+
+
+def compute_spatial_color(
+    image_bgr: np.ndarray, mask: np.ndarray, contour: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Compute the 3x3 spatial gray-world a*b* color descriptor over masked pixels.
+
+    All masked pixels are gray-world normalized TOGETHER (one piece-level
+    illuminant correction), then binned per grid cell into an a*b* histogram.
+    Cells with fewer than `SPATIAL_MIN_PIXELS` masked pixels are marked empty.
+
+    Args:
+        image_bgr: The full photo in OpenCV BGR channel order.
+        mask: Binary mask (H, W), values in {0, 255}; nonzero pixels are sampled.
+        contour: Nx2 full contour in the photo's own pixel coordinates
+            (defines the bbox the grid spans).
+
+    Returns:
+        Tuple of (per-cell histograms (9, SPATIAL_AB_BINS**2), row-major cell
+        order, each L1-normalized or all-zero when empty; (9,) boolean
+        non-empty flags).
+    """
+    n_cells = SPATIAL_GRID**2
+    hists = np.zeros((n_cells, SPATIAL_AB_BINS**2), dtype=np.float64)
+    nonempty = np.zeros(n_cells, dtype=bool)
+
+    ys, xs = np.where(mask > 0)
+    if len(ys) == 0:
+        return hists, nonempty
+
+    lab_pixels = _gray_world_lab_pixels(image_bgr[ys, xs].astype(np.float64))
+
+    x1, y1 = contour[:, 0].min(), contour[:, 1].min()
+    x2, y2 = contour[:, 0].max(), contour[:, 1].max()
+    cell_cols = np.clip(((xs - x1) * SPATIAL_GRID / max(x2 - x1, 1e-9)).astype(np.int64), 0, SPATIAL_GRID - 1)
+    cell_rows = np.clip(((ys - y1) * SPATIAL_GRID / max(y2 - y1, 1e-9)).astype(np.int64), 0, SPATIAL_GRID - 1)
+    cell_idx = cell_rows * SPATIAL_GRID + cell_cols
+
+    for cell in range(n_cells):
+        in_cell = cell_idx == cell
+        if int(in_cell.sum()) < SPATIAL_MIN_PIXELS:
+            continue
+        cell_pixels = lab_pixels[in_cell]
+        hist, _, _ = np.histogram2d(
+            cell_pixels[:, 1], cell_pixels[:, 2], bins=SPATIAL_AB_BINS, range=(CHANNEL_RANGE,) * 2
+        )
+        hist = hist.flatten()
+        hists[cell] = hist / max(hist.sum(), 1e-10)
+        nonempty[cell] = True
+
+    return hists, nonempty
+
+
+def build_fingerprint(edges: List[Edge], image_bgr: np.ndarray, contour: np.ndarray) -> PieceFingerprint:
+    """Compute a piece's shape + spatial-color fingerprint.
+
+    Args:
+        edges: The piece's 4 classified, canonicalized edges (contour order).
+        image_bgr: The source photo in OpenCV BGR channel order.
+        contour: Nx2 full contour in the photo's own pixel coordinates.
+
+    Returns:
+        The computed `PieceFingerprint`.
+    """
+    edge_types: EdgeTypes = tuple(e.edge_type for e in edges)  # type: ignore[assignment]
+    edges_canonical = np.stack([e.canonical_polyline for e in edges], axis=0)
+    mask = build_piece_mask(image_bgr.shape, contour)
+    spatial_hists, spatial_nonempty = compute_spatial_color(image_bgr, mask, contour)
+    color_hist_ab_gw = compute_global_ab_gw_histogram(image_bgr, mask)
+    return PieceFingerprint(
+        edge_types=edge_types,
+        edges_canonical=edges_canonical,
+        spatial_hists=spatial_hists,
+        spatial_nonempty=spatial_nonempty,
+        color_hist_ab_gw=color_hist_ab_gw,
+    )
+
+
+def shape_pair_distance(
+    query_edges: np.ndarray,
+    query_types: EdgeTypes,
+    candidate_edges: np.ndarray,
+    candidate_types: EdgeTypes,
+) -> Tuple[float, int]:
+    """Rotation-invariant same-piece shape distance between two pieces, with the winning shift.
+
+    For each candidate cyclic shift k of the edge order, compares query edge
+    i (no mate-flip, same traversal) to candidate edge (i+k) mod 4 via mean
+    pointwise L2, and requires the shifted type signature to match the
+    query's exactly to be an eligible k. Returns the minimum eligible
+    per-edge-mean distance (falling back to the minimum over ALL k when no
+    shift's type signature matches) together with its winning k, so a
+    caller can keep a rotation-sensitive descriptor (spatial color)
+    consistent with the shape alignment.
+
+    Args:
+        query_edges: (4, 100, 2) canonical edges, contour order.
+        query_types: 4-tuple of edge types for the query.
+        candidate_edges: (4, 100, 2) canonical edges, contour order.
+        candidate_types: 4-tuple of edge types for the candidate.
+
+    Returns:
+        Tuple of (scalar shape distance, winning cyclic shift k in [0, 4)).
+    """
+    l2_by_k: List[float] = []
+    gate_by_k: List[bool] = []
+    for k in range(4):
+        shift = [(i + k) % 4 for i in range(4)]
+        shifted_types = tuple(candidate_types[j] for j in shift)
+        gate_by_k.append(shifted_types == query_types)
+        per_edge = [
+            float(np.mean(np.linalg.norm(query_edges[i] - candidate_edges[shift[i]], axis=1))) for i in range(4)
+        ]
+        l2_by_k.append(float(np.mean(per_edge)))
+
+    gated = [(dist, k) for k, (dist, ok) in enumerate(zip(l2_by_k, gate_by_k)) if ok]
+    if gated:
+        return min(gated, key=lambda pair: pair[0])
+    best_k = int(np.argmin(l2_by_k))
+    return l2_by_k[best_k], best_k
+
+
+def spatial_pair_distance(query: PieceFingerprint, candidate: PieceFingerprint, k: int) -> float:
+    """Spatial color chi-square distance between two pieces, rotation-consistent with shift k.
+
+    Args:
+        query: The query piece's fingerprint.
+        candidate: The candidate piece's fingerprint.
+        k: The cyclic edge shift chosen by `shape_pair_distance` for this pair.
+
+    Returns:
+        The mean per-cell chi-square distance over cells non-empty on both
+        sides (after rotating the candidate's grid by k), or 1.0 (max
+        chi-square distance) when no cell is non-empty on both sides.
+    """
+    perm = SPATIAL_ROT_PERMS[k % 4]
+    candidate_hists = candidate.spatial_hists[perm]
+    candidate_nonempty = candidate.spatial_nonempty[perm]
+    valid = query.spatial_nonempty & candidate_nonempty
+    if not valid.any():
+        return 1.0
+    p = query.spatial_hists[valid]
+    q = candidate_hists[valid]
+    per_cell = 0.5 * np.sum((p - q) ** 2 / (p + q + 1e-10), axis=1)
+    return float(per_cell.mean())
+
+
+def chi_square_distance(p: np.ndarray, q: np.ndarray) -> float:
+    """Chi-square distance between two L1-normalized histograms.
+
+    Args:
+        p: First histogram.
+        q: Second histogram, same shape as `p`.
+
+    Returns:
+        0.5 * sum((p - q)^2 / (p + q + eps)).
+    """
+    return float(0.5 * np.sum((p - q) ** 2 / (p + q + 1e-10)))

--- a/backend/app/services/piece_geometry/scoring.py
+++ b/backend/app/services/piece_geometry/scoring.py
@@ -13,8 +13,12 @@ which were stable across all four north_star backgrounds) is used instead.
 
 The `t_accept` / `t_new` scan-lock thresholds themselves live in
 `app.config.Settings` (`PIECE_GEOMETRY_T_ACCEPT` / `PIECE_GEOMETRY_T_NEW`)
-so they can be tuned via environment/config without a code change; their
-M7-frozen defaults are -4.78 and -0.80 respectively.
+so they can be tuned via environment/config without a code change. See
+`Settings` for the authoritative current defaults and the rationale: M7
+froze the strictest accept point (-4.78), but the shipped default relaxes
+`t_accept` to M7's FMR=1% ROC operating point so hands-free scan enrollment
+does not send most genuine re-scans to the gray zone; `t_new` stays at the
+M7-frozen -0.80.
 """
 
 from dataclasses import dataclass

--- a/backend/app/services/piece_geometry/scoring.py
+++ b/backend/app/services/piece_geometry/scoring.py
@@ -1,0 +1,96 @@
+"""Combined shape + spatial-color z-score for scan-lock accept/new/uncertain decisions.
+
+Ported from ``network/experiments/exp28_piece_geometry/collision_study.py``
+(M7) — keep algorithm changes in sync.
+
+``z = z_shape + z_spatial``, where each raw distance is z-normalized by the
+enroll gallery's own IMPOSTOR (distinct-piece) pairwise distance statistics.
+Per-gallery normalization is what makes one threshold transfer across
+galleries: each gallery's z is expressed in units of its own impostor
+spread. When a puzzle's piece store is too small to estimate its own
+impostor statistics reliably, `FALLBACK_STATS` (the M7-measured constants,
+which were stable across all four north_star backgrounds) is used instead.
+
+The `t_accept` / `t_new` scan-lock thresholds themselves live in
+`app.config.Settings` (`PIECE_GEOMETRY_T_ACCEPT` / `PIECE_GEOMETRY_T_NEW`)
+so they can be tuned via environment/config without a code change; their
+M7-frozen defaults are -4.78 and -0.80 respectively.
+"""
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+# Below this many enrolled pieces, a puzzle's own impostor statistics are too
+# noisy to trust; fall back to the cross-gallery M7 constants instead.
+MIN_GALLERY_FOR_STATS = 12
+
+# M7-measured impostor distance statistics (mean/std), which were nearly
+# identical across all four north_star enroll galleries (gray_fabric,
+# red_carpet, cardboard, wood) — see exp28's collision_study.py output.
+FALLBACK_SHAPE_MEAN = 0.079
+FALLBACK_SHAPE_STD = 0.030
+FALLBACK_SPATIAL_MEAN = 0.56
+FALLBACK_SPATIAL_STD = 0.14
+
+
+@dataclass(frozen=True)
+class GalleryStats:
+    """Impostor-distance normalization statistics for one enroll gallery.
+
+    Attributes:
+        shape_mean: Mean pairwise distinct-identity shape distance.
+        shape_std: Std of the same.
+        spatial_mean: Mean pairwise distinct-identity spatial color distance.
+        spatial_std: Std of the same.
+    """
+
+    shape_mean: float
+    shape_std: float
+    spatial_mean: float
+    spatial_std: float
+
+
+FALLBACK_STATS = GalleryStats(
+    shape_mean=FALLBACK_SHAPE_MEAN,
+    shape_std=FALLBACK_SHAPE_STD,
+    spatial_mean=FALLBACK_SPATIAL_MEAN,
+    spatial_std=FALLBACK_SPATIAL_STD,
+)
+
+
+def combined_z(d_shape: float, d_spatial: float, stats: GalleryStats) -> float:
+    """Combine shape + spatial-color distances into one z-normalized score.
+
+    Args:
+        d_shape: Raw rotation-invariant shape distance to a gallery piece.
+        d_spatial: Raw spatial color chi-square distance to the same piece.
+        stats: The enroll gallery's impostor normalization statistics.
+
+    Returns:
+        z = z_shape + z_spatial. Lower is more similar.
+    """
+    z_shape = (d_shape - stats.shape_mean) / max(stats.shape_std, 1e-9)
+    z_spatial = (d_spatial - stats.spatial_mean) / max(stats.spatial_std, 1e-9)
+    return z_shape + z_spatial
+
+
+def gallery_impostor_stats(pairwise_shape: Sequence[float], pairwise_spatial: Sequence[float]) -> GalleryStats:
+    """Compute impostor mean/std of shape and spatial distances within an enroll gallery.
+
+    Args:
+        pairwise_shape: All distinct-piece pairwise shape distances in the gallery.
+        pairwise_spatial: The matching pairwise spatial-color distances (same pairing/order).
+
+    Returns:
+        The gallery's `GalleryStats`.
+    """
+    shape_arr = np.array(pairwise_shape, dtype=np.float64)
+    spatial_arr = np.array(pairwise_spatial, dtype=np.float64)
+    return GalleryStats(
+        shape_mean=float(shape_arr.mean()),
+        shape_std=float(shape_arr.std()),
+        spatial_mean=float(spatial_arr.mean()),
+        spatial_std=float(spatial_arr.std()),
+    )

--- a/backend/app/services/piece_geometry/service.py
+++ b/backend/app/services/piece_geometry/service.py
@@ -1,0 +1,292 @@
+"""Piece-geometry pipeline orchestration: photo -> structured piece record.
+
+Ported from ``network/experiments/exp28_piece_geometry`` end to end (contour
+extraction, corner detection, edge splitting, fingerprinting) — keep
+algorithm changes in sync with `contour.py`, `corners.py`, `edges.py`, and
+`fingerprint.py` (each ported from the matching exp28 source file).
+
+Pipeline: photo bytes -> rembg background removal (reusing
+`app.services.background_remover.get_background_remover`, same as
+`app.services.piece_detector`) -> hardened alpha mask -> largest-component
+bbox -> CROP to bbox + 15% margin -> contour -> quality gate -> corners
+(polydp + curvature cross-check) -> edges (split + classify + canonicalize)
+-> fingerprint (shape + spatial color).
+
+The crop step is essential for calibration parity with exp28: the exp28
+pipeline (quality gates, corner windows, spatial color grid) was tuned on
+piece-bbox crops with a 15% margin (from dataset metadata), not on full
+camera frames. Running on the full frame both (a) counts stray objects far
+from the piece as extra components, and (b) computes area_ratio against the
+whole frame instead of a piece-sized crop. All pipeline stages therefore
+run WITHIN the crop; the returned record's contour, corners, and raw edge
+polylines are mapped back to full-image coordinates via the crop offset
+(the fingerprint's spatial grid is bbox-relative and stays in the crop
+frame).
+
+A record is ``lockable`` when the contour passed the quality gate, the two
+corner detectors agreed, and edges/fingerprint were successfully computed.
+Quality flags only assert what was actually measured: ``corner_disagreement``
+is None (not True) when corner detection never ran (e.g. the contour failed
+the quality gate).
+"""
+
+from dataclasses import dataclass, replace
+from typing import List, Optional, Tuple
+
+import cv2
+import numpy as np
+
+from app.services.background_remover import BackgroundRemover, get_background_remover
+from app.services.piece_geometry.contour import (
+    QualityMetrics,
+    alpha_to_mask,
+    contour_quality,
+    crop_with_margin,
+    largest_component_bbox,
+    mask_to_contour,
+)
+from app.services.piece_geometry.corners import InsufficientCornersError, detect_corners_with_cross_check
+from app.services.piece_geometry.edges import Edge, split_edges
+from app.services.piece_geometry.fingerprint import PieceFingerprint, build_fingerprint
+
+# rembg model used for piece-geometry segmentation, matching
+# app/services/piece_detector.py's default.
+REMBG_MODEL = "u2net"
+
+# Crop margin around the piece's bbox, matching exp28's dataset-crop margin.
+CROP_MARGIN_FRAC = 0.15
+
+
+@dataclass(frozen=True)
+class PieceGeometryRecord:
+    """The full result of running the piece-geometry pipeline on one photo.
+
+    Attributes:
+        contour: Full contour (Nx2, FULL-IMAGE pixel coordinates), or None
+            when no contour could be extracted at all.
+        corners: 4x2 corner points (polydp, full-image coordinates), or None
+            when corner detection never ran or failed.
+        corner_confidences: Per-corner confidences aligned with `corners`, or None.
+        corner_disagreement: True when the curvature cross-check disagreed
+            with polydp (or the cross-check itself couldn't run); False when
+            the detectors agreed; None when corner detection never ran at
+            all (contour missing, quality gate failed, or splitting failed)
+            — the flag only asserts what was actually measured.
+        edges: The piece's 4 classified, canonicalized edges (contour
+            order; raw polylines in full-image coordinates), or None when
+            splitting failed or the quality gate was not met.
+        fingerprint: The piece's shape + spatial-color fingerprint, or None
+            when `edges` is None. The spatial color grid is bbox-relative
+            (crop frame), which is invariant to the crop offset.
+        quality: Contour quality metrics, computed WITHIN the piece crop
+            (always populated; `is_clean=False` with zeroed metrics when no
+            contour was found at all).
+        lockable: True only when the piece is clean, corner detectors agree,
+            and edges/fingerprint were computed successfully — i.e. good
+            enough for the scan-lock UX to auto-accept without asking for
+            more frames.
+    """
+
+    contour: Optional[np.ndarray]
+    corners: Optional[np.ndarray]
+    corner_confidences: Optional[List[float]]
+    corner_disagreement: Optional[bool]
+    edges: Optional[List[Edge]]
+    fingerprint: Optional[PieceFingerprint]
+    quality: QualityMetrics
+    lockable: bool
+
+
+def _empty_quality_record() -> PieceGeometryRecord:
+    """Build the record returned when no contour could be extracted at all.
+
+    Returns:
+        A `PieceGeometryRecord` with every downstream field empty,
+        `corner_disagreement=None` (corners never ran), and `lockable=False`.
+    """
+    quality = QualityMetrics(n_large_components=0, border_touching=False, area_ratio=0.0, solidity=0.0, is_clean=False)
+    return PieceGeometryRecord(
+        contour=None,
+        corners=None,
+        corner_confidences=None,
+        corner_disagreement=None,
+        edges=None,
+        fingerprint=None,
+        quality=quality,
+        lockable=False,
+    )
+
+
+def _failed_stage_record(contour_full: np.ndarray, quality: QualityMetrics) -> PieceGeometryRecord:
+    """Build the record returned when the pipeline stopped after contour extraction.
+
+    Args:
+        contour_full: The extracted contour, already mapped to full-image coordinates.
+        quality: The crop-frame quality metrics.
+
+    Returns:
+        A `PieceGeometryRecord` with corners/edges/fingerprint empty and
+        `corner_disagreement=None` (corners never produced a measurement).
+    """
+    return PieceGeometryRecord(
+        contour=contour_full,
+        corners=None,
+        corner_confidences=None,
+        corner_disagreement=None,
+        edges=None,
+        fingerprint=None,
+        quality=quality,
+        lockable=False,
+    )
+
+
+class PieceGeometryService:
+    """Runs the full photo -> piece-geometry-record pipeline."""
+
+    def __init__(self, background_remover: Optional[BackgroundRemover] = None) -> None:
+        """Initialize the service.
+
+        Args:
+            background_remover: Background remover to use; defaults to the
+                shared singleton (matching `app.services.piece_detector`).
+                Injectable so tests can supply a mock, mirroring
+                `PieceDetector`'s pattern.
+        """
+        self._background_remover = background_remover or get_background_remover(REMBG_MODEL)
+
+    def process(self, image_bytes: bytes) -> PieceGeometryRecord:
+        """Run the piece-geometry pipeline on a single piece photo.
+
+        The photo is first reduced to a crop around the largest opaque
+        component's bbox (+15% margin), reproducing exp28's calibrated frame
+        of reference; every stage runs within that crop, and the returned
+        contour/corners/edge polylines are mapped back to full-image
+        coordinates.
+
+        Args:
+            image_bytes: Raw photo bytes (JPEG/PNG).
+
+        Returns:
+            The resulting `PieceGeometryRecord`. Downstream fields (corners,
+            edges, fingerprint) are None when an earlier stage fails or the
+            quality gate isn't met; `quality` and `lockable` are always
+            populated.
+        """
+        rgba = self._background_remover.remove_background(image_bytes).convert("RGBA")
+        rgba_arr = np.array(rgba)
+        full_mask = alpha_to_mask(rgba_arr[..., 3])
+
+        bbox = largest_component_bbox(full_mask)
+        if bbox is None:
+            return _empty_quality_record()
+
+        # Crop mask and color image to the piece bbox + margin: the whole
+        # calibrated pipeline runs in this crop frame (a stray object outside
+        # the crop must not fail the gate, and area_ratio is crop-relative).
+        mask_crop, (offset_x, offset_y) = crop_with_margin(full_mask, bbox, CROP_MARGIN_FRAC)
+        image_bgr_full = cv2.cvtColor(rgba_arr[..., :3], cv2.COLOR_RGB2BGR)
+        image_crop, _ = crop_with_margin(image_bgr_full, bbox, CROP_MARGIN_FRAC)
+        offset = np.array([offset_x, offset_y], dtype=np.float64)
+
+        contour = mask_to_contour(mask_crop)
+        if contour is None:
+            return _empty_quality_record()
+
+        quality = contour_quality(contour, mask_crop, (mask_crop.shape[0], mask_crop.shape[1]))
+        if not quality.is_clean:
+            return _failed_stage_record(contour + offset, quality)
+
+        split = split_edges(contour)
+        if split is None:
+            return _failed_stage_record(contour + offset, quality)
+
+        edges, corner_result, corner_disagreement = split
+        # Fingerprint is computed in the crop frame (its spatial grid is
+        # bbox-relative, so the crop offset cancels out).
+        fingerprint = build_fingerprint(edges, image_crop, contour)
+        lockable = quality.is_clean and not corner_disagreement
+
+        edges_full = [replace(edge, polyline=edge.polyline + offset) for edge in edges]
+        return PieceGeometryRecord(
+            contour=contour + offset,
+            corners=corner_result.corners + offset,
+            corner_confidences=corner_result.confidences,
+            corner_disagreement=corner_disagreement,
+            edges=edges_full,
+            fingerprint=fingerprint,
+            quality=quality,
+            lockable=lockable,
+        )
+
+
+def quick_quality_from_polygon(
+    polygon: List[Tuple[float, float]], canvas_size: int = 512
+) -> Tuple[bool, Optional[bool]]:
+    """Best-effort (lockable, corner_disagreement) flags from a normalized region polygon.
+
+    Used by the ``/api/v1/piece/preview`` endpoint's ``include_quality``
+    option: rasterizes the already-detected, already-simplified preview
+    polygon onto a fixed canvas and reruns corner detection on its dense
+    re-traced contour. This is a lightweight approximation of the full
+    pipeline (no fresh background-removal call), so the preview loop —
+    which is polled continuously while the piece camera is open — stays fast.
+
+    Args:
+        polygon: Normalized [0, 1] (x, y) points, as returned by
+            `app.services.piece_detector.PieceDetector.detect_region`.
+        canvas_size: Side length of the square raster canvas the polygon is
+            rendered onto before contour re-extraction.
+
+    Returns:
+        Tuple of (lockable, corner_disagreement). When the polygon is
+        empty/degenerate or corner detection never produces a measurement,
+        the result is (False, None) — the disagreement flag only asserts
+        what was actually measured.
+    """
+    if len(polygon) < 3:
+        return False, None
+
+    points = np.array([[x * canvas_size, y * canvas_size] for x, y in polygon], dtype=np.int32)
+    mask = np.zeros((canvas_size, canvas_size), dtype=np.uint8)
+    cv2.fillPoly(mask, [points], (255,))
+
+    # Evaluate in the same crop frame (bbox + margin) as the full pipeline so
+    # the crop-calibrated quality gates (notably area_ratio) apply correctly
+    # even when the piece covers a small part of the camera frame.
+    bbox = largest_component_bbox(mask)
+    if bbox is None:
+        return False, None
+    mask_crop, _ = crop_with_margin(mask, bbox, CROP_MARGIN_FRAC)
+
+    contour = mask_to_contour(mask_crop)
+    if contour is None:
+        return False, None
+
+    quality = contour_quality(contour, mask_crop, (mask_crop.shape[0], mask_crop.shape[1]))
+    try:
+        _, corner_disagreement = detect_corners_with_cross_check(contour)
+    except InsufficientCornersError:
+        return False, None
+
+    return quality.is_clean and not corner_disagreement, corner_disagreement
+
+
+_piece_geometry_service: Optional[PieceGeometryService] = None
+
+
+def get_piece_geometry_service() -> PieceGeometryService:
+    """Get or create the singleton PieceGeometryService instance.
+
+    Returns:
+        The shared PieceGeometryService instance.
+    """
+    global _piece_geometry_service
+    if _piece_geometry_service is None:
+        _piece_geometry_service = PieceGeometryService()
+    return _piece_geometry_service
+
+
+def reset_piece_geometry_service() -> None:
+    """Reset the singleton PieceGeometryService (test-only helper)."""
+    global _piece_geometry_service
+    _piece_geometry_service = None

--- a/backend/app/services/piece_geometry/store.py
+++ b/backend/app/services/piece_geometry/store.py
@@ -83,6 +83,13 @@ class PuzzlePieceStore:
 
     _pieces: List[EnrolledPiece] = field(default_factory=list)
     _next_id: int = 1
+    # Cached impostor stats and the gallery size they were computed for.
+    # `_gallery_stats` is O(n^2) in the gallery and runs on every locked frame,
+    # but the stats only change when a piece is enrolled — so cache them and let
+    # `_enroll` invalidate. The gallery is append-only (pieces are never removed
+    # or mutated in place), so the size is a sufficient cache key.
+    _cached_stats: Optional[GalleryStats] = None
+    _cached_stats_n: int = -1
 
     def _mint_piece_id(self) -> str:
         """Allocate the next stable piece id for this puzzle.
@@ -94,6 +101,25 @@ class PuzzlePieceStore:
         self._next_id += 1
         return piece_id
 
+    def _enroll(self, fingerprint: PieceFingerprint, is_clean: bool, corner_disagreement: bool) -> str:
+        """Mint an id, append the piece, and invalidate the cached impostor stats.
+
+        All enrollments route through here so the `_gallery_stats` cache can
+        never go stale behind an append.
+
+        Args:
+            fingerprint: The new piece's fingerprint.
+            is_clean: The enrolling photo's contour-quality gate result.
+            corner_disagreement: The enrolling photo's corner_disagreement flag.
+
+        Returns:
+            The freshly minted piece id.
+        """
+        piece_id = self._mint_piece_id()
+        self._pieces.append(EnrolledPiece(piece_id, fingerprint, is_clean, corner_disagreement))
+        self._cached_stats = None
+        return piece_id
+
     def _gallery_stats(self) -> GalleryStats:
         """Impostor shape/spatial statistics for the current gallery, or the M7 fallback.
 
@@ -103,6 +129,9 @@ class PuzzlePieceStore:
         """
         if len(self._pieces) < MIN_GALLERY_FOR_STATS:
             return FALLBACK_STATS
+
+        if self._cached_stats is not None and self._cached_stats_n == len(self._pieces):
+            return self._cached_stats
 
         pairwise_shape: List[float] = []
         pairwise_spatial: List[float] = []
@@ -117,7 +146,10 @@ class PuzzlePieceStore:
                 d_spatial = spatial_pair_distance(piece_a.fingerprint, piece_b.fingerprint, k)
                 pairwise_shape.append(d_shape)
                 pairwise_spatial.append(d_spatial)
-        return gallery_impostor_stats(pairwise_shape, pairwise_spatial)
+        stats = gallery_impostor_stats(pairwise_shape, pairwise_spatial)
+        self._cached_stats = stats
+        self._cached_stats_n = len(self._pieces)
+        return stats
 
     def _closest_match(self, fingerprint: PieceFingerprint, stats: GalleryStats) -> Tuple[str, float]:
         """Find the enrolled piece closest to `fingerprint` by combined z-score.
@@ -170,8 +202,7 @@ class PuzzlePieceStore:
             The `MatchResult`. See the module docstring for the verdict semantics.
         """
         if not self._pieces:
-            piece_id = self._mint_piece_id()
-            self._pieces.append(EnrolledPiece(piece_id, fingerprint, is_clean, corner_disagreement))
+            piece_id = self._enroll(fingerprint, is_clean, corner_disagreement)
             return MatchResult(MatchVerdict.NEW, piece_id, None, None)
 
         stats = self._gallery_stats()
@@ -181,8 +212,7 @@ class PuzzlePieceStore:
             return MatchResult(MatchVerdict.MATCHED, match_piece_id, match_piece_id, z_score)
 
         if z_score > settings.PIECE_GEOMETRY_T_NEW or enroll_uncertain:
-            piece_id = self._mint_piece_id()
-            self._pieces.append(EnrolledPiece(piece_id, fingerprint, is_clean, corner_disagreement))
+            piece_id = self._enroll(fingerprint, is_clean, corner_disagreement)
             return MatchResult(MatchVerdict.NEW, piece_id, None, z_score)
 
         return MatchResult(MatchVerdict.UNCERTAIN, None, match_piece_id, z_score)

--- a/backend/app/services/piece_geometry/store.py
+++ b/backend/app/services/piece_geometry/store.py
@@ -1,0 +1,277 @@
+"""Per-puzzle piece store: fingerprint dedupe ("new piece" vs "seen before").
+
+Ported from ``network/experiments/exp28_piece_geometry/collision_study.py``'s
+two-threshold scan-lock recipe (M7) — keep algorithm changes in sync.
+
+For each incoming photo's fingerprint, the store compares it against every
+piece already enrolled for the puzzle, combines shape + spatial-color
+distance into a z-score (`app.services.piece_geometry.scoring.combined_z`)
+against the closest match, and returns one of three verdicts:
+
+- ``matched`` (z < t_accept): the photo is the same physical piece as an
+  already-enrolled one; not re-enrolled, the existing piece_id is returned.
+- ``new`` (z > t_new, or the store is empty): a piece not seen before;
+  enrolled under a freshly minted piece_id.
+- ``uncertain`` (the gray zone in between): NOT enrolled; the closest
+  existing piece_id and the z-score are returned so the caller can ask the
+  user to rescan.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List, Optional, Tuple
+
+from app.config import settings
+from app.services.piece_geometry.fingerprint import PieceFingerprint, shape_pair_distance, spatial_pair_distance
+from app.services.piece_geometry.scoring import (
+    FALLBACK_STATS,
+    MIN_GALLERY_FOR_STATS,
+    GalleryStats,
+    combined_z,
+    gallery_impostor_stats,
+)
+
+
+class MatchVerdict(str, Enum):
+    """Outcome of comparing a new piece-photo fingerprint against a puzzle's store."""
+
+    MATCHED = "matched"
+    NEW = "new"
+    UNCERTAIN = "uncertain"
+
+
+@dataclass(frozen=True)
+class EnrolledPiece:
+    """One physical piece enrolled in a puzzle's store.
+
+    Attributes:
+        piece_id: The piece's stable id within this puzzle (e.g. "p001").
+        fingerprint: The piece's shape + spatial-color fingerprint.
+        is_clean: Whether the enrolling photo's contour passed the quality gate.
+        corner_disagreement: The enrolling photo's corner_disagreement flag.
+    """
+
+    piece_id: str
+    fingerprint: PieceFingerprint
+    is_clean: bool
+    corner_disagreement: bool
+
+
+@dataclass(frozen=True)
+class MatchResult:
+    """The verdict of `PuzzlePieceStore.add_or_match`.
+
+    Attributes:
+        verdict: matched / new / uncertain.
+        piece_id: This photo's piece id — the matched piece's id (matched),
+            a freshly minted id (new), or None (uncertain: not enrolled).
+        match_piece_id: The closest existing piece's id, when a comparison
+            was made (matched and uncertain); None otherwise.
+        z_score: The closest match's combined z-score, when a comparison was
+            made; None when the store was empty.
+    """
+
+    verdict: MatchVerdict
+    piece_id: Optional[str]
+    match_piece_id: Optional[str]
+    z_score: Optional[float]
+
+
+@dataclass
+class PuzzlePieceStore:
+    """In-memory fingerprint gallery + dedupe for one puzzle's scanned pieces."""
+
+    _pieces: List[EnrolledPiece] = field(default_factory=list)
+    _next_id: int = 1
+
+    def _mint_piece_id(self) -> str:
+        """Allocate the next stable piece id for this puzzle.
+
+        Returns:
+            A short id like "p001", unique within this puzzle's store.
+        """
+        piece_id = f"p{self._next_id:03d}"
+        self._next_id += 1
+        return piece_id
+
+    def _gallery_stats(self) -> GalleryStats:
+        """Impostor shape/spatial statistics for the current gallery, or the M7 fallback.
+
+        Returns:
+            `FALLBACK_STATS` when fewer than `MIN_GALLERY_FOR_STATS` pieces
+            are enrolled; otherwise the gallery's own impostor statistics.
+        """
+        if len(self._pieces) < MIN_GALLERY_FOR_STATS:
+            return FALLBACK_STATS
+
+        pairwise_shape: List[float] = []
+        pairwise_spatial: List[float] = []
+        for i, piece_a in enumerate(self._pieces):
+            for piece_b in self._pieces[i + 1 :]:
+                d_shape, k = shape_pair_distance(
+                    piece_a.fingerprint.edges_canonical,
+                    piece_a.fingerprint.edge_types,
+                    piece_b.fingerprint.edges_canonical,
+                    piece_b.fingerprint.edge_types,
+                )
+                d_spatial = spatial_pair_distance(piece_a.fingerprint, piece_b.fingerprint, k)
+                pairwise_shape.append(d_shape)
+                pairwise_spatial.append(d_spatial)
+        return gallery_impostor_stats(pairwise_shape, pairwise_spatial)
+
+    def _closest_match(self, fingerprint: PieceFingerprint, stats: GalleryStats) -> Tuple[str, float]:
+        """Find the enrolled piece closest to `fingerprint` by combined z-score.
+
+        Args:
+            fingerprint: The query piece's fingerprint.
+            stats: Normalization statistics to combine distances with.
+
+        Returns:
+            Tuple of (closest piece's id, its combined z-score).
+        """
+        best_z = float("inf")
+        best_piece_id = self._pieces[0].piece_id
+        for enrolled in self._pieces:
+            d_shape, k = shape_pair_distance(
+                fingerprint.edges_canonical,
+                fingerprint.edge_types,
+                enrolled.fingerprint.edges_canonical,
+                enrolled.fingerprint.edge_types,
+            )
+            d_spatial = spatial_pair_distance(fingerprint, enrolled.fingerprint, k)
+            z = combined_z(d_shape, d_spatial, stats)
+            if z < best_z:
+                best_z = z
+                best_piece_id = enrolled.piece_id
+        return best_piece_id, best_z
+
+    def add_or_match(
+        self,
+        fingerprint: PieceFingerprint,
+        is_clean: bool,
+        corner_disagreement: bool,
+        enroll_uncertain: bool = False,
+    ) -> MatchResult:
+        """Compare a piece-photo fingerprint against this puzzle's store and enroll if new.
+
+        Args:
+            fingerprint: The photo's shape + spatial-color fingerprint.
+            is_clean: The photo's contour-quality gate result.
+            corner_disagreement: The photo's corner_disagreement flag.
+            enroll_uncertain: When True, a gray-zone (uncertain) verdict
+                enrolls the photo as a NEW piece instead of reporting
+                uncertainty — the client's escape hatch after its own
+                confirmation UX (M7 measured that 97.9% of genuinely-new
+                pieces land in the gray zone, so a session could otherwise
+                never enroll a second piece). Matched and new verdicts are
+                unaffected.
+
+        Returns:
+            The `MatchResult`. See the module docstring for the verdict semantics.
+        """
+        if not self._pieces:
+            piece_id = self._mint_piece_id()
+            self._pieces.append(EnrolledPiece(piece_id, fingerprint, is_clean, corner_disagreement))
+            return MatchResult(MatchVerdict.NEW, piece_id, None, None)
+
+        stats = self._gallery_stats()
+        match_piece_id, z_score = self._closest_match(fingerprint, stats)
+
+        if z_score < settings.PIECE_GEOMETRY_T_ACCEPT:
+            return MatchResult(MatchVerdict.MATCHED, match_piece_id, match_piece_id, z_score)
+
+        if z_score > settings.PIECE_GEOMETRY_T_NEW or enroll_uncertain:
+            piece_id = self._mint_piece_id()
+            self._pieces.append(EnrolledPiece(piece_id, fingerprint, is_clean, corner_disagreement))
+            return MatchResult(MatchVerdict.NEW, piece_id, None, z_score)
+
+        return MatchResult(MatchVerdict.UNCERTAIN, None, match_piece_id, z_score)
+
+    def list_pieces(self) -> List[EnrolledPiece]:
+        """List all pieces enrolled so far, in enrollment order.
+
+        Returns:
+            A shallow copy of the enrolled-piece list.
+        """
+        return list(self._pieces)
+
+
+class PieceGeometryStore:
+    """Piece-geometry stores for every puzzle, keyed by puzzle_id."""
+
+    def __init__(self) -> None:
+        """Initialize an empty collection of per-puzzle stores."""
+        self._stores: Dict[str, PuzzlePieceStore] = {}
+
+    def _get_or_create(self, puzzle_id: str) -> PuzzlePieceStore:
+        """Get a puzzle's store, creating an empty one on first access.
+
+        Args:
+            puzzle_id: The puzzle's id.
+
+        Returns:
+            The puzzle's `PuzzlePieceStore`.
+        """
+        if puzzle_id not in self._stores:
+            self._stores[puzzle_id] = PuzzlePieceStore()
+        return self._stores[puzzle_id]
+
+    def add_or_match(
+        self,
+        puzzle_id: str,
+        fingerprint: Optional[PieceFingerprint],
+        is_clean: bool,
+        corner_disagreement: bool,
+        enroll_uncertain: bool = False,
+    ) -> MatchResult:
+        """Compare a piece-photo fingerprint against one puzzle's store and enroll if new.
+
+        Args:
+            puzzle_id: The puzzle the photo belongs to.
+            fingerprint: The photo's fingerprint, or None when a prior
+                pipeline stage (contour/corners/edges) failed.
+            is_clean: The photo's contour-quality gate result.
+            corner_disagreement: The photo's corner_disagreement flag.
+            enroll_uncertain: When True, a gray-zone verdict enrolls the
+                photo as a new piece (see `PuzzlePieceStore.add_or_match`).
+                Has no effect when `fingerprint` is None: a failed pipeline
+                produced nothing that could be enrolled.
+
+        Returns:
+            `MatchResult(UNCERTAIN, None, None, None)` when `fingerprint` is
+            None (nothing to compare or enroll); otherwise the puzzle
+            store's `add_or_match` result.
+        """
+        if fingerprint is None:
+            return MatchResult(MatchVerdict.UNCERTAIN, None, None, None)
+        return self._get_or_create(puzzle_id).add_or_match(
+            fingerprint, is_clean, corner_disagreement, enroll_uncertain=enroll_uncertain
+        )
+
+    def list_pieces(self, puzzle_id: str) -> List[EnrolledPiece]:
+        """List all pieces enrolled for one puzzle.
+
+        Args:
+            puzzle_id: The puzzle's id.
+
+        Returns:
+            The puzzle's enrolled pieces, or an empty list when the puzzle
+            has no store yet.
+        """
+        store = self._stores.get(puzzle_id)
+        return store.list_pieces() if store else []
+
+
+_piece_geometry_store: Optional[PieceGeometryStore] = None
+
+
+def get_piece_geometry_store() -> PieceGeometryStore:
+    """Get or create the singleton PieceGeometryStore instance.
+
+    Returns:
+        The shared PieceGeometryStore instance.
+    """
+    global _piece_geometry_store
+    if _piece_geometry_store is None:
+        _piece_geometry_store = PieceGeometryStore()
+    return _piece_geometry_store

--- a/backend/tests/piece_geometry_fixtures.py
+++ b/backend/tests/piece_geometry_fixtures.py
@@ -1,0 +1,184 @@
+"""Shared synthetic-piece helpers for piece-geometry tests.
+
+Builds deterministic puzzle_shapes pieces (fixed `TabParameters()`, no
+reliance on the global `random` module) and rasterizes them into masks and
+painted BGR images, mirroring
+`network/experiments/exp28_piece_geometry/synth_benchmark.py`'s
+`rasterize_piece` closely enough to reuse for corner/edge ground truth.
+"""
+
+from io import BytesIO
+from typing import List, Sequence, Tuple
+
+import cv2
+import numpy as np
+from PIL import Image
+from puzzle_shapes import PieceConfig, TabParameters, generate_piece_path
+
+PIECE_SIZE_PX = 500.0
+CANVAS_PAD_FRAC = 0.15
+
+BGRColor = Tuple[int, int, int]
+
+
+def deterministic_config(edge_types: Sequence[str]) -> PieceConfig:
+    """Build a PieceConfig with fixed (non-random) tab parameters.
+
+    Args:
+        edge_types: 4 edge types ("tab"/"blank"/"flat"), contour order
+            [bottom, right, top, left] per `puzzle_shapes.generate_piece_geometry`.
+
+    Returns:
+        A `PieceConfig` that rasterizes identically on every call.
+    """
+    return PieceConfig(edge_types=list(edge_types), edge_params=[TabParameters()] * 4)
+
+
+def rasterize_piece(config: PieceConfig, piece_size_px: float = PIECE_SIZE_PX) -> Tuple[np.ndarray, np.ndarray]:
+    """Rasterize a piece config's path to a filled mask, with matching ground-truth corners.
+
+    Args:
+        config: The piece configuration to rasterize.
+        piece_size_px: Pixel size of the base square's side.
+
+    Returns:
+        Tuple of (mask (H, W) uint8 in {0, 255}, ground-truth corners (4x2)
+        in the SAME order as `generate_piece_geometry`'s base square:
+        bottom-left, bottom-right, top-right, top-left, in pixel coordinates).
+    """
+    x, y = generate_piece_path(config)
+    path = np.column_stack([x, y])
+    gt_local = np.array(
+        [[0.0, 0.0], [config.size, 0.0], [config.size, config.size], [0.0, config.size]],
+    )
+
+    scale = piece_size_px / config.size
+    pad = CANVAS_PAD_FRAC * config.size
+
+    min_xy = path.min(axis=0)
+    max_y = path[:, 1].max()
+
+    def to_pixels(pts: np.ndarray) -> np.ndarray:
+        px = (pts[:, 0] - min_xy[0] + pad) * scale
+        py = (max_y - pts[:, 1] + pad) * scale
+        return np.column_stack([px, py])
+
+    path_px = to_pixels(path)
+    gt_px = to_pixels(gt_local)
+
+    extent = path.max(axis=0) - min_xy
+    canvas_w = int(np.ceil((extent[0] + 2 * pad) * scale))
+    canvas_h = int(np.ceil((extent[1] + 2 * pad) * scale))
+
+    mask = np.zeros((canvas_h, canvas_w), dtype=np.uint8)
+    cv2.fillPoly(mask, [path_px.astype(np.int32)], (255,))
+    return mask, gt_px
+
+
+def paint_quadrants(mask: np.ndarray, colors: Sequence[BGRColor]) -> np.ndarray:
+    """Paint a BGR image with 4 distinct colors over the mask's bbox quadrants.
+
+    Distinct per-quadrant colors give the 3x3 spatial color descriptor real
+    signal to distinguish pieces on (a flat single-color fill gray-world-
+    normalizes to the same neutral color regardless of hue, which would make
+    every piece's spatial descriptor identical).
+
+    Args:
+        mask: Binary mask (H, W) with values in {0, 255}.
+        colors: 4 BGR colors for (top-left, top-right, bottom-left, bottom-right).
+
+    Returns:
+        A BGR image (H, W, 3): background gray, piece region painted by quadrant.
+    """
+    height, width = mask.shape
+    image = np.full((height, width, 3), (128, 128, 128), dtype=np.uint8)
+    half_h, half_w = height // 2, width // 2
+    image[:half_h, :half_w] = colors[0]
+    image[:half_h, half_w:] = colors[1]
+    image[half_h:, :half_w] = colors[2]
+    image[half_h:, half_w:] = colors[3]
+    return image
+
+
+def rgba_from_mask_and_image(mask: np.ndarray, image_bgr: np.ndarray) -> Image.Image:
+    """Build a PIL RGBA image from a binary mask and a BGR color image, mimicking rembg output.
+
+    Args:
+        mask: Binary mask (H, W) with values in {0, 255}, used as the alpha channel.
+        image_bgr: BGR color image (H, W, 3), same shape as `mask`.
+
+    Returns:
+        An RGBA `PIL.Image.Image` with `image_bgr`'s colors and `mask` as alpha.
+    """
+    rgb = cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB)
+    rgba = np.dstack([rgb, mask])
+    return Image.fromarray(rgba, mode="RGBA")
+
+
+def encode_png(image: Image.Image) -> bytes:
+    """Encode a PIL image as PNG bytes.
+
+    Args:
+        image: The image to encode.
+
+    Returns:
+        PNG-encoded bytes.
+    """
+    buffer = BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+# Two visually and geometrically distinct pieces, used across fingerprint/store/API tests.
+PIECE_A_EDGE_TYPES: List[str] = ["tab", "blank", "flat", "tab"]
+PIECE_A_COLORS: List[BGRColor] = [(80, 120, 200), (20, 200, 20), (200, 20, 20), (20, 20, 200)]
+
+PIECE_B_EDGE_TYPES: List[str] = ["blank", "tab", "tab", "blank"]
+PIECE_B_COLORS: List[BGRColor] = [(200, 20, 20), (20, 20, 200), (80, 120, 200), (20, 200, 20)]
+
+
+def embed_in_frame(
+    mask: np.ndarray,
+    image_bgr: np.ndarray,
+    frame_shape: Tuple[int, int],
+    offset: Tuple[int, int],
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Paste a piece mask + color image into a larger (camera-frame-sized) canvas.
+
+    Simulates a real capture where the piece covers only part of the frame,
+    exercising the service's largest-component crop step.
+
+    Args:
+        mask: Piece binary mask (h, w) in {0, 255}.
+        image_bgr: Piece BGR color image (h, w, 3), same shape as `mask`.
+        frame_shape: (frame_height, frame_width) of the output canvas.
+        offset: (x, y) top-left position to paste the piece at.
+
+    Returns:
+        Tuple of (frame_mask (H, W), frame_bgr (H, W, 3)): transparent gray
+        frame with the piece pasted at `offset`.
+    """
+    frame_h, frame_w = frame_shape
+    piece_h, piece_w = mask.shape
+    x, y = offset
+    frame_mask = np.zeros((frame_h, frame_w), dtype=np.uint8)
+    frame_bgr = np.full((frame_h, frame_w, 3), (128, 128, 128), dtype=np.uint8)
+    frame_mask[y : y + piece_h, x : x + piece_w] = mask
+    frame_bgr[y : y + piece_h, x : x + piece_w] = image_bgr
+    return frame_mask, frame_bgr
+
+
+def make_piece_rgba(edge_types: Sequence[str], colors: Sequence[BGRColor]) -> Image.Image:
+    """Build a full synthetic piece photo (RGBA, alpha = piece mask) end to end.
+
+    Args:
+        edge_types: 4 edge types for `deterministic_config`.
+        colors: 4 quadrant BGR colors for `paint_quadrants`.
+
+    Returns:
+        The synthetic piece as an RGBA `PIL.Image.Image`.
+    """
+    config = deterministic_config(edge_types)
+    mask, _ = rasterize_piece(config)
+    image_bgr = paint_quadrants(mask, colors)
+    return rgba_from_mask_and_image(mask, image_bgr)

--- a/backend/tests/test_piece_geometry_api.py
+++ b/backend/tests/test_piece_geometry_api.py
@@ -1,0 +1,422 @@
+"""API tests for the piece-geometry endpoints and the preview include_quality flag."""
+
+import os
+import shutil
+from datetime import datetime, timedelta, timezone
+from io import BytesIO
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+from piece_geometry_fixtures import (
+    PIECE_A_COLORS,
+    PIECE_A_EDGE_TYPES,
+    PIECE_B_COLORS,
+    PIECE_B_EDGE_TYPES,
+    deterministic_config,
+    encode_png,
+    make_piece_rgba,
+    rasterize_piece,
+)
+from PIL import Image, ImageDraw
+
+from app.main import app, settings
+from app.services.piece_detector import DetectedRegion
+from app.services.piece_geometry import store as store_module
+from app.services.piece_geometry.contour import mask_to_contour
+from app.services.piece_geometry.service import PieceGeometryService
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _ensure_upload_dir() -> Generator[None, None, None]:
+    """Recreate UPLOAD_DIR before each test (another module's fixture may have removed it)."""
+    os.makedirs(settings.UPLOAD_DIR, exist_ok=True)
+    yield
+    shutil.rmtree(settings.UPLOAD_DIR, ignore_errors=True)
+
+
+def create_test_token() -> str:
+    """Create a valid test JWT token for authentication (mirrors tests/test_main.py)."""
+    expire = datetime.now(timezone.utc) + timedelta(hours=1)
+    payload = {
+        "sub": "test-user-id",
+        "email": "test@example.com",
+        "name": "Test User",
+        "picture": None,
+        "exp": expire,
+    }
+    return jwt.encode(payload, settings.JWT_SECRET, algorithm=settings.JWT_ALGORITHM)
+
+
+def get_auth_header() -> dict[str, str]:
+    """Create an authorization header with a valid test token."""
+    return {"Authorization": f"Bearer {create_test_token()}"}
+
+
+def make_photo_jpeg() -> bytes:
+    """Create an in-memory JPEG photo with a bright rectangle on a dark background."""
+    image = Image.new("RGB", (800, 600), (20, 20, 20))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((100, 80, 700, 520), fill=(220, 210, 190))
+    buffer = BytesIO()
+    image.save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+def upload_test_puzzle() -> str:
+    """Upload a throwaway puzzle and return its puzzle_id."""
+    response = client.post(
+        "/api/v1/puzzle/upload",
+        files={"file": ("photo.jpg", BytesIO(make_photo_jpeg()), "image/jpeg")},
+        headers=get_auth_header(),
+    )
+    assert response.status_code == 200
+    return str(response.json()["puzzle_id"])
+
+
+def mocked_geometry_service() -> PieceGeometryService:
+    """A PieceGeometryService whose mocked background remover echoes the uploaded RGBA PNG.
+
+    The test uploads are RGBA PNGs whose alpha channel IS the piece mask, so
+    "segmentation" is simply decoding the upload — this keeps the mocked-rembg
+    pattern while letting different uploads carry different pieces.
+    """
+    remover = MagicMock()
+    remover.remove_background.side_effect = lambda image_bytes: Image.open(BytesIO(image_bytes)).convert("RGBA")
+    return PieceGeometryService(background_remover=remover)
+
+
+def geometry_files(
+    edge_types: list[str] = PIECE_A_EDGE_TYPES,
+    colors: list[tuple[int, int, int]] = PIECE_A_COLORS,
+) -> dict[str, tuple[str, BytesIO, str]]:
+    """Build the multipart files dict for a piece-geometry photo upload.
+
+    Args:
+        edge_types: The synthetic piece's 4 edge types.
+        colors: The synthetic piece's 4 quadrant BGR colors.
+
+    Returns:
+        The multipart files dict.
+    """
+    rgba = make_piece_rgba(edge_types, colors)
+    return {"file": ("piece.png", BytesIO(encode_png(rgba)), "image/png")}
+
+
+class TestUploadPieceGeometry:
+    """Tests for POST /api/v1/puzzle/{puzzle_id}/piece/geometry."""
+
+    def test_requires_auth(self) -> None:
+        """The endpoint rejects unauthenticated requests."""
+        puzzle_id = upload_test_puzzle()
+
+        response = client.post(f"/api/v1/puzzle/{puzzle_id}/piece/geometry", files=geometry_files())
+
+        assert response.status_code in (401, 403)
+
+    def test_unknown_puzzle_returns_404(self) -> None:
+        """A geometry upload against a nonexistent puzzle_id returns 404."""
+        with patch("app.main.get_piece_geometry_service", return_value=mocked_geometry_service()):
+            response = client.post(
+                "/api/v1/puzzle/does-not-exist/piece/geometry",
+                files=geometry_files(),
+                headers=get_auth_header(),
+            )
+
+        assert response.status_code == 404
+
+    def test_no_file_returns_400(self) -> None:
+        """Omitting the file returns 400."""
+        puzzle_id = upload_test_puzzle()
+
+        response = client.post(f"/api/v1/puzzle/{puzzle_id}/piece/geometry", headers=get_auth_header())
+
+        assert response.status_code == 400
+
+    def test_invalid_image_bytes_returns_400(self) -> None:
+        """Non-image bytes are rejected before the pipeline runs."""
+        puzzle_id = upload_test_puzzle()
+
+        response = client.post(
+            f"/api/v1/puzzle/{puzzle_id}/piece/geometry",
+            files={"file": ("piece.png", BytesIO(b"not an image"), "image/png")},
+            headers=get_auth_header(),
+        )
+
+        assert response.status_code == 400
+
+    def test_first_upload_returns_new_and_valid_record(self) -> None:
+        """The first photo of a piece is enrolled as new, with a valid geometric record."""
+        puzzle_id = upload_test_puzzle()
+
+        with patch("app.main.get_piece_geometry_service", return_value=mocked_geometry_service()):
+            response = client.post(
+                f"/api/v1/puzzle/{puzzle_id}/piece/geometry",
+                files=geometry_files(),
+                headers=get_auth_header(),
+            )
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["status"] == "new"
+        assert result["piece_id"] == "p001"
+        assert result["match_piece_id"] is None
+        assert result["lockable"] is True
+        assert result["quality"]["is_clean"] is True
+        assert result["quality"]["corner_disagreement"] is False
+        assert len(result["record"]["corners"]) == 4
+        assert len(result["record"]["edges"]) == 4
+        for edge in result["record"]["edges"]:
+            assert edge["type"] in ("tab", "blank", "flat")
+            assert len(edge["polyline"]) == 100
+        # include_contour defaults to false: the (large) contour is omitted.
+        assert result["record"]["contour"] is None
+
+    def test_include_contour_true_adds_the_contour_polyline(self) -> None:
+        """include_contour=true adds the full contour to the response."""
+        puzzle_id = upload_test_puzzle()
+
+        with patch("app.main.get_piece_geometry_service", return_value=mocked_geometry_service()):
+            response = client.post(
+                f"/api/v1/puzzle/{puzzle_id}/piece/geometry?include_contour=true",
+                files=geometry_files(),
+                headers=get_auth_header(),
+            )
+
+        assert response.status_code == 200
+        contour = response.json()["record"]["contour"]
+        assert contour is not None
+        assert len(contour) > 0
+
+    def test_same_piece_photographed_twice_returns_matched_with_same_piece_id(self) -> None:
+        """Posting the identical synthetic piece a second time matches the first enrollment."""
+        puzzle_id = upload_test_puzzle()
+
+        with patch("app.main.get_piece_geometry_service", return_value=mocked_geometry_service()):
+            first = client.post(
+                f"/api/v1/puzzle/{puzzle_id}/piece/geometry",
+                files=geometry_files(),
+                headers=get_auth_header(),
+            )
+            second = client.post(
+                f"/api/v1/puzzle/{puzzle_id}/piece/geometry",
+                files=geometry_files(),
+                headers=get_auth_header(),
+            )
+
+        assert first.json()["status"] == "new"
+        first_piece_id = first.json()["piece_id"]
+
+        assert second.status_code == 200
+        second_body = second.json()
+        assert second_body["status"] == "matched"
+        assert second_body["piece_id"] == first_piece_id
+        assert second_body["match_piece_id"] == first_piece_id
+        assert second_body["z_score"] is not None
+        assert second_body["z_score"] < 0
+
+    def test_uncertain_default_reports_without_enrolling(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A gray-zone verdict with the default on_uncertain=report is not enrolled (unchanged behavior)."""
+        puzzle_id = upload_test_puzzle()
+
+        with patch("app.main.get_piece_geometry_service", return_value=mocked_geometry_service()):
+            first = client.post(
+                f"/api/v1/puzzle/{puzzle_id}/piece/geometry",
+                files=geometry_files(),
+                headers=get_auth_header(),
+            )
+            assert first.json()["status"] == "new"
+
+            # Force every comparison into the gray zone so the genuinely
+            # different piece B lands there deterministically.
+            monkeypatch.setattr(store_module.settings, "PIECE_GEOMETRY_T_ACCEPT", -1e9)
+            monkeypatch.setattr(store_module.settings, "PIECE_GEOMETRY_T_NEW", 1e9)
+            response = client.post(
+                f"/api/v1/puzzle/{puzzle_id}/piece/geometry",
+                files=geometry_files(PIECE_B_EDGE_TYPES, PIECE_B_COLORS),
+                headers=get_auth_header(),
+            )
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["status"] == "uncertain"
+        assert result["piece_id"] is None
+        assert result["match_piece_id"] == "p001"
+        assert result["z_score"] is not None
+
+        listing = client.get(f"/api/v1/puzzle/{puzzle_id}/piece/geometry", headers=get_auth_header())
+        assert len(listing.json()["pieces"]) == 1  # not enrolled
+
+    def test_on_uncertain_enroll_enrolls_and_is_matchable_afterwards(self) -> None:
+        """on_uncertain=enroll turns a gray-zone verdict into an enrollment; a re-scan then matches it."""
+        puzzle_id = upload_test_puzzle()
+
+        with patch("app.main.get_piece_geometry_service", return_value=mocked_geometry_service()):
+            first = client.post(
+                f"/api/v1/puzzle/{puzzle_id}/piece/geometry",
+                files=geometry_files(),
+                headers=get_auth_header(),
+            )
+            assert first.json()["piece_id"] == "p001"
+
+            # Gray-zone thresholds only for the escape-hatch post.
+            with pytest.MonkeyPatch.context() as gray:
+                gray.setattr(store_module.settings, "PIECE_GEOMETRY_T_ACCEPT", -1e9)
+                gray.setattr(store_module.settings, "PIECE_GEOMETRY_T_NEW", 1e9)
+                enrolled = client.post(
+                    f"/api/v1/puzzle/{puzzle_id}/piece/geometry?on_uncertain=enroll",
+                    files=geometry_files(PIECE_B_EDGE_TYPES, PIECE_B_COLORS),
+                    headers=get_auth_header(),
+                )
+
+            assert enrolled.status_code == 200
+            enrolled_body = enrolled.json()
+            assert enrolled_body["status"] == "new"
+            assert enrolled_body["piece_id"] == "p002"
+            assert enrolled_body["z_score"] is not None
+
+            # With normal thresholds restored, an identical re-scan of piece B
+            # matches the piece the escape hatch enrolled.
+            rescan = client.post(
+                f"/api/v1/puzzle/{puzzle_id}/piece/geometry",
+                files=geometry_files(PIECE_B_EDGE_TYPES, PIECE_B_COLORS),
+                headers=get_auth_header(),
+            )
+
+        rescan_body = rescan.json()
+        assert rescan_body["status"] == "matched"
+        assert rescan_body["piece_id"] == "p002"
+        assert rescan_body["match_piece_id"] == "p002"
+
+        listing = client.get(f"/api/v1/puzzle/{puzzle_id}/piece/geometry", headers=get_auth_header())
+        assert [p["piece_id"] for p in listing.json()["pieces"]] == ["p001", "p002"]
+
+
+class TestListPieceGeometry:
+    """Tests for GET /api/v1/puzzle/{puzzle_id}/piece/geometry."""
+
+    def test_requires_auth(self) -> None:
+        """The endpoint rejects unauthenticated requests."""
+        puzzle_id = upload_test_puzzle()
+
+        response = client.get(f"/api/v1/puzzle/{puzzle_id}/piece/geometry")
+
+        assert response.status_code in (401, 403)
+
+    def test_unknown_puzzle_returns_404(self) -> None:
+        """Listing a nonexistent puzzle_id returns 404."""
+        response = client.get("/api/v1/puzzle/does-not-exist/piece/geometry", headers=get_auth_header())
+
+        assert response.status_code == 404
+
+    def test_empty_puzzle_has_no_pieces(self) -> None:
+        """A freshly uploaded puzzle with no geometry scans yet has an empty piece list."""
+        puzzle_id = upload_test_puzzle()
+
+        response = client.get(f"/api/v1/puzzle/{puzzle_id}/piece/geometry", headers=get_auth_header())
+
+        assert response.status_code == 200
+        assert response.json() == {"puzzle_id": puzzle_id, "pieces": []}
+
+    def test_lists_enrolled_pieces_without_polylines(self) -> None:
+        """After one upload, the list endpoint reports the enrolled piece's summary (no polylines)."""
+        puzzle_id = upload_test_puzzle()
+        with patch("app.main.get_piece_geometry_service", return_value=mocked_geometry_service()):
+            client.post(
+                f"/api/v1/puzzle/{puzzle_id}/piece/geometry",
+                files=geometry_files(),
+                headers=get_auth_header(),
+            )
+
+        response = client.get(f"/api/v1/puzzle/{puzzle_id}/piece/geometry", headers=get_auth_header())
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["puzzle_id"] == puzzle_id
+        assert len(result["pieces"]) == 1
+        piece = result["pieces"][0]
+        assert piece["piece_id"] == "p001"
+        assert len(piece["edge_types"]) == 4
+        assert piece["is_clean"] is True
+        assert piece["corner_disagreement"] is False
+        assert "polyline" not in piece
+
+
+class TestPreviewIncludeQuality:
+    """Tests for the /api/v1/piece/preview include_quality flag."""
+
+    def _clean_piece_polygon(self) -> list[tuple[float, float]]:
+        """A normalized polygon closely tracing a clean synthetic piece contour."""
+        config = deterministic_config(["tab", "blank", "flat", "tab"])
+        mask, _ = rasterize_piece(config)
+        contour = mask_to_contour(mask)
+        assert contour is not None
+        height, width = mask.shape
+        return [(float(x) / width, float(y) / height) for x, y in contour[::7]]
+
+    def test_default_response_is_unchanged(self) -> None:
+        """Without include_quality, lockable/corner_disagreement are null and detection is unaffected."""
+        detector = MagicMock()
+        detector.detect_region.return_value = DetectedRegion(
+            polygon=[(0.1, 0.2), (0.8, 0.2), (0.8, 0.9), (0.1, 0.9)],
+            bbox=(0.1, 0.2, 0.7, 0.7),
+            confidence=0.87,
+        )
+
+        with patch("app.main.get_piece_detector", return_value=detector):
+            response = client.post(
+                "/api/v1/piece/preview",
+                files={"file": ("photo.jpg", BytesIO(make_photo_jpeg()), "image/jpeg")},
+                headers=get_auth_header(),
+            )
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["found"] is True
+        assert result["confidence"] == 0.87
+        assert result["lockable"] is None
+        assert result["corner_disagreement"] is None
+
+    def test_include_quality_true_adds_flags_for_a_clean_region(self) -> None:
+        """include_quality=true adds lockable=True/corner_disagreement=False for a clean piece polygon."""
+        detector = MagicMock()
+        detector.detect_region.return_value = DetectedRegion(
+            polygon=self._clean_piece_polygon(),
+            bbox=(0.1, 0.2, 0.7, 0.7),
+            confidence=0.9,
+        )
+
+        with patch("app.main.get_piece_detector", return_value=detector):
+            response = client.post(
+                "/api/v1/piece/preview?include_quality=true",
+                files={"file": ("photo.jpg", BytesIO(make_photo_jpeg()), "image/jpeg")},
+                headers=get_auth_header(),
+            )
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["found"] is True
+        assert result["corner_disagreement"] is False
+        assert result["lockable"] is True
+
+    def test_include_quality_true_with_not_found_stays_false(self) -> None:
+        """When no region is detected, include_quality doesn't add flags (found=False short-circuits)."""
+        detector = MagicMock()
+        detector.detect_region.return_value = None
+
+        with patch("app.main.get_piece_detector", return_value=detector):
+            response = client.post(
+                "/api/v1/piece/preview?include_quality=true",
+                files={"file": ("photo.jpg", BytesIO(make_photo_jpeg()), "image/jpeg")},
+                headers=get_auth_header(),
+            )
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["found"] is False
+        assert result["lockable"] is None
+        assert result["corner_disagreement"] is None

--- a/backend/tests/test_piece_geometry_contour.py
+++ b/backend/tests/test_piece_geometry_contour.py
@@ -1,0 +1,227 @@
+"""Tests for app.services.piece_geometry.contour."""
+
+import cv2
+import numpy as np
+import pytest
+from piece_geometry_fixtures import deterministic_config, rasterize_piece
+
+from app.services.piece_geometry.contour import (
+    _gaussian_kernel1d,
+    alpha_to_mask,
+    contour_quality,
+    gaussian_filter1d_wrap,
+    mask_to_contour,
+    resample_contour,
+    resample_polyline,
+    smooth_contour,
+)
+
+
+class TestGaussianFilter1dWrap:
+    """Equivalence tests for the numpy circular-Gaussian replacement of scipy's gaussian_filter1d."""
+
+    def test_kernel_is_normalized_and_symmetric(self) -> None:
+        """The hand-built kernel sums to 1 and is symmetric about its center."""
+        kernel = _gaussian_kernel1d(sigma=2.0)
+
+        assert kernel.sum() == pytest.approx(1.0)
+        assert np.allclose(kernel, kernel[::-1])
+
+    def test_impulse_response_matches_hand_computed_kernel(self) -> None:
+        """Filtering a unit impulse reproduces the kernel weights exactly (hand-computed case).
+
+        scipy.ndimage.gaussian_filter1d(impulse, sigma, mode="wrap") returns
+        the kernel itself (circularly shifted to the impulse's position) —
+        this is the defining property of a (circular) convolution/correlation
+        with a delta function. We verify the numpy replacement against an
+        independently hand-computed kernel (not by importing scipy, which the
+        backend does not depend on).
+        """
+        sigma = 1.5
+        n = 16
+        impulse = np.zeros(n)
+        impulse[0] = 1.0
+
+        filtered = gaussian_filter1d_wrap(impulse, sigma=sigma)
+
+        # Hand-computed normalized Gaussian kernel, truncate=4.0 (scipy's default):
+        # radius = int(4.0 * 1.5 + 0.5) = 6.
+        radius = int(4.0 * sigma + 0.5)
+        offsets = np.arange(-radius, radius + 1)
+        raw = np.exp(-0.5 * (offsets / sigma) ** 2)
+        expected_kernel = raw / raw.sum()
+
+        # The impulse sits at index 0, so filtered[j] = kernel[radius - j] wrapped,
+        # i.e. filtered[(-offset) % n] == expected_kernel[radius + offset].
+        for offset, weight in zip(offsets, expected_kernel):
+            assert filtered[(-offset) % n] == pytest.approx(weight)
+
+    def test_constant_signal_is_unchanged(self) -> None:
+        """A constant periodic signal is a fixed point of the filter (kernel sums to 1)."""
+        values = np.full(32, 7.0)
+
+        filtered = gaussian_filter1d_wrap(values, sigma=2.0)
+
+        assert np.allclose(filtered, 7.0)
+
+    def test_smooths_a_noisy_periodic_signal(self) -> None:
+        """Smoothing reduces sample-to-sample variation on a noisy periodic signal."""
+        rng = np.random.default_rng(0)
+        n = 200
+        t = np.linspace(0, 2 * np.pi, n, endpoint=False)
+        clean = np.sin(t)
+        noisy = clean + rng.normal(0, 0.5, size=n)
+
+        filtered = gaussian_filter1d_wrap(noisy, sigma=3.0)
+
+        noisy_roughness = np.sum(np.diff(noisy, append=noisy[:1]) ** 2)
+        filtered_roughness = np.sum(np.diff(filtered, append=filtered[:1]) ** 2)
+        assert filtered_roughness < noisy_roughness
+
+
+class TestSmoothContour:
+    """Tests for smooth_contour."""
+
+    def test_preserves_length_and_shape(self) -> None:
+        """Smoothing a contour keeps its point count and roughly its shape."""
+        theta = np.linspace(0, 2 * np.pi, 100, endpoint=False)
+        contour = np.column_stack([50 * np.cos(theta) + 100, 50 * np.sin(theta) + 100])
+
+        smoothed = smooth_contour(contour, sigma=2.0)
+
+        assert smoothed.shape == contour.shape
+        # A circle is already smooth: filtering shouldn't move points much.
+        assert np.allclose(smoothed, contour, atol=1.5)
+
+
+class TestMaskToContour:
+    """Tests for mask_to_contour."""
+
+    def test_single_blob_returns_contour(self) -> None:
+        """A single filled rectangle yields a non-empty contour."""
+        mask = np.zeros((100, 100), dtype=np.uint8)
+        mask[20:80, 20:80] = 255
+
+        contour = mask_to_contour(mask)
+
+        assert contour is not None
+        assert contour.shape[1] == 2
+        assert len(contour) > 0
+
+    def test_empty_mask_returns_none(self) -> None:
+        """An all-background mask yields no contour."""
+        mask = np.zeros((100, 100), dtype=np.uint8)
+
+        assert mask_to_contour(mask) is None
+
+    def test_picks_largest_of_multiple_blobs(self) -> None:
+        """With two separate blobs, the larger one's contour is returned."""
+        mask = np.zeros((200, 200), dtype=np.uint8)
+        mask[10:30, 10:30] = 255  # small blob, 20x20
+        mask[80:180, 60:190] = 255  # large blob, 100x130
+
+        contour = mask_to_contour(mask)
+
+        assert contour is not None
+        x, y, w, h = int(contour[:, 0].min()), int(contour[:, 1].min()), 0, 0
+        w = int(contour[:, 0].max()) - x
+        h = int(contour[:, 1].max()) - y
+        assert (x, y) == (60, 80)
+        assert abs(w - 129) <= 1 and abs(h - 99) <= 1
+
+
+class TestAlphaToMask:
+    """Tests for alpha_to_mask."""
+
+    def test_hardens_soft_alpha(self) -> None:
+        """Alpha above the threshold becomes 255, at/below becomes 0."""
+        alpha = np.array([0, 100, 128, 129, 255], dtype=np.uint8)
+
+        mask = alpha_to_mask(alpha)
+
+        assert list(mask) == [0, 0, 0, 255, 255]
+
+
+class TestResample:
+    """Tests for resample_contour and resample_polyline."""
+
+    def test_resample_contour_preserves_point_count_and_covers_shape(self) -> None:
+        """Resampling a square contour to N points keeps the square's bounding box."""
+        contour = np.array([[0.0, 0.0], [100.0, 0.0], [100.0, 100.0], [0.0, 100.0]])
+
+        resampled = resample_contour(contour, 40)
+
+        assert resampled.shape == (40, 2)
+        assert resampled[:, 0].min() >= -1e-6
+        assert resampled[:, 0].max() <= 100 + 1e-6
+
+    def test_resample_polyline_keeps_endpoints(self) -> None:
+        """An open polyline's resampled endpoints match the input endpoints."""
+        points = np.array([[0.0, 0.0], [10.0, 0.0], [10.0, 10.0]])
+
+        resampled = resample_polyline(points, 10)
+
+        assert np.allclose(resampled[0], points[0])
+        assert np.allclose(resampled[-1], points[-1])
+        assert resampled.shape == (10, 2)
+
+
+class TestContourQuality:
+    """Tests for contour_quality using synthetic puzzle_shapes pieces and hand-built masks."""
+
+    def test_clean_piece_passes(self) -> None:
+        """A single well-formed synthetic piece contour passes the quality gate."""
+        config = deterministic_config(["tab", "blank", "flat", "tab"])
+        mask, _ = rasterize_piece(config)
+        contour = mask_to_contour(mask)
+        assert contour is not None
+
+        quality = contour_quality(contour, mask, mask.shape)
+
+        assert quality.is_clean is True
+        assert quality.n_large_components == 1
+        assert quality.border_touching is False
+
+    def test_two_blob_mask_fails_is_clean(self) -> None:
+        """A mask with two comparably-sized components fails the single-component gate."""
+        mask = np.zeros((300, 300), dtype=np.uint8)
+        mask[20:140, 20:140] = 255  # ~120x120 blob
+        mask[160:280, 160:280] = 255  # ~120x120 blob, same size -> both "large"
+        contour = mask_to_contour(mask)
+        assert contour is not None
+
+        quality = contour_quality(contour, mask, mask.shape)
+
+        assert quality.n_large_components == 2
+        assert quality.is_clean is False
+
+    def test_border_touching_fails_gate(self) -> None:
+        """A contour touching the crop edge fails the border gate."""
+        mask = np.zeros((100, 100), dtype=np.uint8)
+        mask[0:80, 0:80] = 255  # touches the top-left border
+        contour = mask_to_contour(mask)
+        assert contour is not None
+
+        quality = contour_quality(contour, mask, mask.shape)
+
+        assert quality.border_touching is True
+        assert quality.is_clean is False
+
+    def test_low_solidity_fails_gate(self) -> None:
+        """A ragged, star-shaped contour with low solidity fails the gate."""
+        center = (100, 100)
+        outer, inner = 90, 20
+        angles = np.linspace(0, 2 * np.pi, 16, endpoint=False)
+        radii = np.where(np.arange(16) % 2 == 0, outer, inner)
+        points = np.column_stack([center[0] + radii * np.cos(angles), center[1] + radii * np.sin(angles)]).astype(
+            np.int32
+        )
+        mask = np.zeros((200, 200), dtype=np.uint8)
+        cv2.fillPoly(mask, [points], (255,))
+        contour = mask_to_contour(mask)
+        assert contour is not None
+
+        quality = contour_quality(contour, mask, mask.shape)
+
+        assert quality.solidity < 0.6
+        assert quality.is_clean is False

--- a/backend/tests/test_piece_geometry_corners.py
+++ b/backend/tests/test_piece_geometry_corners.py
@@ -1,0 +1,154 @@
+"""Tests for app.services.piece_geometry.corners."""
+
+import itertools
+
+import numpy as np
+import pytest
+from piece_geometry_fixtures import deterministic_config, rasterize_piece
+
+from app.services.piece_geometry.contour import mask_to_contour
+from app.services.piece_geometry.corners import (
+    InsufficientCornersError,
+    bbox_diagonal,
+    corner_max_distance_frac,
+    detect_corners_curvature,
+    detect_corners_polydp,
+    detect_corners_with_cross_check,
+)
+
+SUCCESS_THRESHOLD_PCT = 3.0
+
+
+def _corner_error_pct(predicted: np.ndarray, gt_corners: np.ndarray) -> float:
+    """Max matched-corner error as a percentage of the piece diagonal.
+
+    Brute-forces the optimal (minimum total distance) assignment over the 24
+    permutations of 4 elements, mirroring
+    `network/experiments/exp28_piece_geometry/synth_benchmark.py`'s
+    `score_corners` without depending on scipy.
+    """
+    best_sum = float("inf")
+    best_max = 0.0
+    for perm in itertools.permutations(range(4)):
+        dists = np.linalg.norm(predicted - gt_corners[list(perm)], axis=1)
+        total = float(dists.sum())
+        if total < best_sum:
+            best_sum = total
+            best_max = float(dists.max())
+    diagonal = float(np.linalg.norm(gt_corners[0] - gt_corners[2]))
+    return 100.0 * best_max / diagonal
+
+
+class TestDetectCornersPolydp:
+    """Corner-detection accuracy on synthetic pieces with known ground truth."""
+
+    @pytest.mark.parametrize(
+        "edge_types",
+        [
+            ["tab", "blank", "flat", "tab"],
+            ["tab", "blank", "tab", "blank"],
+            ["flat", "flat", "tab", "blank"],
+        ],
+    )
+    def test_corners_within_tolerance_of_ground_truth(self, edge_types: list[str]) -> None:
+        """The 4 detected corners are within 3% of the piece diagonal from ground truth."""
+        config = deterministic_config(edge_types)
+        mask, gt_corners = rasterize_piece(config)
+        contour = mask_to_contour(mask)
+        assert contour is not None
+
+        result = detect_corners_polydp(contour)
+
+        assert result.corners.shape == (4, 2)
+        error_pct = _corner_error_pct(result.corners, gt_corners)
+        assert error_pct <= SUCCESS_THRESHOLD_PCT
+
+    def test_curvature_detector_also_within_tolerance(self) -> None:
+        """The curvature cross-check detector also lands within tolerance."""
+        config = deterministic_config(["tab", "blank", "flat", "tab"])
+        mask, gt_corners = rasterize_piece(config)
+        contour = mask_to_contour(mask)
+        assert contour is not None
+
+        result = detect_corners_curvature(contour)
+
+        error_pct = _corner_error_pct(result.corners, gt_corners)
+        assert error_pct <= SUCCESS_THRESHOLD_PCT
+
+    def test_corners_ordered_clockwise_from_top_left(self) -> None:
+        """Corners come back ordered clockwise starting near the top-left."""
+        config = deterministic_config(["tab", "blank", "tab", "blank"])
+        mask, _ = rasterize_piece(config)
+        contour = mask_to_contour(mask)
+        assert contour is not None
+
+        result = detect_corners_polydp(contour)
+
+        centroid = result.corners.mean(axis=0)
+        angles: np.ndarray = np.arctan2(result.corners[:, 1] - centroid[1], result.corners[:, 0] - centroid[0])
+        # Clockwise in image coords (y down) means increasing angle when
+        # traversed in order (arctan2 in [-pi, pi], wrapping once).
+        diffs: np.ndarray = np.diff(np.concatenate([angles, angles[:1] + 2 * np.pi]))
+        assert bool(np.all(diffs > 0))
+
+    def test_too_few_candidates_raises(self) -> None:
+        """A near-perfect circle (few polydp vertices survive a tight sweep) still yields 4 corners.
+
+        This documents the failure mode rather than forcing it: with only 3
+        raw contour points, `InsufficientCornersError` is raised.
+        """
+        triangle = np.array([[0.0, 0.0], [10.0, 0.0], [5.0, 10.0]])
+
+        with pytest.raises(InsufficientCornersError):
+            detect_corners_polydp(triangle)
+
+
+class TestCornerDisagreement:
+    """Tests for corner_max_distance_frac (the brute-force Hungarian-equivalent) and the cross-check."""
+
+    def test_identical_corner_sets_have_zero_distance(self) -> None:
+        """Comparing a corner set to itself gives zero distance regardless of point order."""
+        corners = np.array([[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]])
+        shuffled = corners[[2, 0, 3, 1]]
+
+        frac = corner_max_distance_frac(corners, shuffled, diagonal=float(np.linalg.norm(corners[0] - corners[2])))
+
+        assert frac == pytest.approx(0.0, abs=1e-9)
+
+    def test_matches_brute_force_minimum_sum_assignment(self) -> None:
+        """corner_max_distance_frac picks the same assignment as an independent brute-force search."""
+        a = np.array([[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]])
+        # b is `a` cyclically shifted by one position plus small jitter, so the
+        # optimal assignment isn't the identity permutation.
+        b = np.array([[0.3, 10.2], [0.1, -0.2], [9.8, 0.4], [10.1, 9.7]])
+
+        frac = corner_max_distance_frac(a, b, diagonal=1.0)
+
+        best_sum = min(
+            sum(np.linalg.norm(a[i] - b[perm[i]]) for i in range(4)) for perm in itertools.permutations(range(4))
+        )
+        best_perm = min(
+            itertools.permutations(range(4)),
+            key=lambda perm: sum(np.linalg.norm(a[i] - b[perm[i]]) for i in range(4)),
+        )
+        expected_max = max(np.linalg.norm(a[i] - b[best_perm[i]]) for i in range(4))
+        assert best_sum > 0  # sanity: the jitter actually perturbed the points
+        assert frac == pytest.approx(expected_max, rel=1e-6)
+
+    def test_cross_check_agrees_on_clean_synthetic_piece(self) -> None:
+        """The polydp and curvature detectors agree (no disagreement flag) on a clean synthetic piece."""
+        config = deterministic_config(["tab", "blank", "flat", "tab"])
+        mask, _ = rasterize_piece(config)
+        contour = mask_to_contour(mask)
+        assert contour is not None
+
+        primary, disagreement = detect_corners_with_cross_check(contour)
+
+        assert primary.method == "polydp"
+        assert disagreement is False
+
+    def test_bbox_diagonal_of_unit_square(self) -> None:
+        """bbox_diagonal of a unit square is sqrt(2)."""
+        square = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+
+        assert bbox_diagonal(square) == pytest.approx(np.sqrt(2))

--- a/backend/tests/test_piece_geometry_edges.py
+++ b/backend/tests/test_piece_geometry_edges.py
@@ -1,0 +1,125 @@
+"""Tests for app.services.piece_geometry.edges."""
+
+from collections import Counter
+
+import numpy as np
+import pytest
+from piece_geometry_fixtures import deterministic_config, rasterize_piece
+
+from app.services.piece_geometry.contour import mask_to_contour
+from app.services.piece_geometry.edges import canonicalize_edge, classify_arc, split_edges
+
+
+class TestClassifyArc:
+    """Unit tests for classify_arc's chord-deviation classification."""
+
+    def test_straight_arc_is_flat(self) -> None:
+        """An arc lying exactly on its chord is classified flat."""
+        arc = np.array([[0.0, 0.0], [5.0, 0.0], [10.0, 0.0]])
+        centroid = np.array([5.0, -10.0])  # "inside" the piece, above the arc
+
+        edge_type, dominant_dev, _, _, chord_length = classify_arc(arc, centroid)
+
+        assert edge_type == "flat"
+        assert dominant_dev == pytest.approx(0.0)
+        assert chord_length == pytest.approx(10.0)
+
+    def test_bulge_away_from_centroid_is_tab(self) -> None:
+        """An arc that bulges away from the piece centroid is a tab."""
+        arc = np.array([[0.0, 0.0], [5.0, -5.0], [10.0, 0.0]])
+        centroid = np.array([5.0, 10.0])  # centroid is on the +y side; bulge is -y (away)
+
+        edge_type, dominant_dev, _, _, _ = classify_arc(arc, centroid)
+
+        assert edge_type == "tab"
+        assert dominant_dev > 0
+
+    def test_dip_toward_centroid_is_blank(self) -> None:
+        """An arc that dips toward the piece centroid is a blank."""
+        arc = np.array([[0.0, 0.0], [5.0, 5.0], [10.0, 0.0]])
+        centroid = np.array([5.0, 10.0])  # centroid is on the +y side; dip is +y (toward)
+
+        edge_type, dominant_dev, _, _, _ = classify_arc(arc, centroid)
+
+        assert edge_type == "blank"
+        assert dominant_dev < 0
+
+
+class TestCanonicalizeEdge:
+    """Tests for canonicalize_edge."""
+
+    def test_endpoints_map_to_origin_and_unit_x(self) -> None:
+        """Corner A maps to (0,0) and corner B maps to (1,0), regardless of original frame."""
+        polyline = np.array([[10.0, 20.0], [15.0, 25.0], [20.0, 30.0]])
+
+        canonical = canonicalize_edge(polyline)
+
+        assert np.allclose(canonical[0], [0.0, 0.0])
+        assert np.allclose(canonical[-1], [1.0, 0.0])
+
+    def test_degenerate_zero_length_chord_returns_zeros(self) -> None:
+        """A polyline whose endpoints coincide returns an all-zero canonical polyline."""
+        polyline = np.array([[5.0, 5.0], [5.0, 5.0], [5.0, 5.0]])
+
+        canonical = canonicalize_edge(polyline)
+
+        assert np.allclose(canonical, 0.0)
+
+
+class TestSplitEdges:
+    """End-to-end edge classification on synthetic puzzle_shapes pieces."""
+
+    @pytest.mark.parametrize(
+        "edge_types",
+        [
+            ["tab", "flat", "blank", "flat"],
+            ["tab", "blank", "tab", "blank"],
+            ["flat", "flat", "tab", "blank"],
+        ],
+    )
+    def test_detected_type_multiset_matches_configured_signature(self, edge_types: list[str]) -> None:
+        """The set of detected edge types (counts) matches the configured signature.
+
+        Corner ordering/winding normalization means the detected edge at
+        index 0 does not necessarily correspond to the configured edge at
+        index 0, so this compares multisets of types rather than a
+        positional mapping (still a precise correctness check: it verifies
+        exactly how many tabs/blanks/flats were found).
+        """
+        config = deterministic_config(edge_types)
+        mask, _ = rasterize_piece(config)
+        contour = mask_to_contour(mask)
+        assert contour is not None
+
+        result = split_edges(contour)
+
+        assert result is not None
+        edges, _, disagreement = result
+        assert disagreement is False
+        assert len(edges) == 4
+        assert Counter(e.edge_type for e in edges) == Counter(edge_types)
+
+    def test_edges_carry_100_point_polylines_and_canonical_frames(self) -> None:
+        """Each edge has a 100-point raw polyline and a chord-normalized canonical polyline."""
+        config = deterministic_config(["tab", "blank", "flat", "tab"])
+        mask, _ = rasterize_piece(config)
+        contour = mask_to_contour(mask)
+        assert contour is not None
+
+        result = split_edges(contour)
+
+        assert result is not None
+        edges, _, _ = result
+        for edge in edges:
+            assert edge.polyline.shape == (100, 2)
+            assert edge.canonical_polyline.shape == (100, 2)
+            assert np.allclose(edge.canonical_polyline[0], [0.0, 0.0])
+            assert np.allclose(edge.canonical_polyline[-1], [1.0, 0.0])
+
+    def test_too_few_contour_points_returns_none(self) -> None:
+        """A contour with too few points for corner detection fails to split cleanly."""
+        triangle = np.array([[0.0, 0.0], [10.0, 0.0], [5.0, 10.0]])
+
+        result = split_edges(triangle)
+
+        assert result is None

--- a/backend/tests/test_piece_geometry_fingerprint.py
+++ b/backend/tests/test_piece_geometry_fingerprint.py
@@ -15,6 +15,7 @@ from piece_geometry_fixtures import (
 from app.services.piece_geometry.contour import mask_to_contour
 from app.services.piece_geometry.edges import split_edges
 from app.services.piece_geometry.fingerprint import (
+    PieceFingerprint,
     build_fingerprint,
     chi_square_distance,
     shape_pair_distance,
@@ -23,7 +24,7 @@ from app.services.piece_geometry.fingerprint import (
 from app.services.piece_geometry.scoring import FALLBACK_STATS, combined_z
 
 
-def _build_fingerprint(edge_types: list[str], colors: list[tuple[int, int, int]]):
+def _build_fingerprint(edge_types: list[str], colors: list[tuple[int, int, int]]) -> PieceFingerprint:
     """Build a PieceFingerprint for a synthetic piece."""
     config = deterministic_config(edge_types)
     mask, _ = rasterize_piece(config)

--- a/backend/tests/test_piece_geometry_fingerprint.py
+++ b/backend/tests/test_piece_geometry_fingerprint.py
@@ -100,7 +100,7 @@ class TestFingerprintSelfConsistency:
         d_spatial_other = spatial_pair_distance(fp_a, fp_b, k_other)
         z_other = combined_z(d_shape_other, d_spatial_other, FALLBACK_STATS)
 
-        assert z_self < -4.78  # t_accept default
+        assert z_self < -4.78  # below even the strict M7 t_accept (production default is -3.98)
         assert z_other > -0.80  # t_new default
         assert z_self < z_other
 

--- a/backend/tests/test_piece_geometry_fingerprint.py
+++ b/backend/tests/test_piece_geometry_fingerprint.py
@@ -1,0 +1,125 @@
+"""Tests for app.services.piece_geometry.fingerprint."""
+
+import numpy as np
+import pytest
+from piece_geometry_fixtures import (
+    PIECE_A_COLORS,
+    PIECE_A_EDGE_TYPES,
+    PIECE_B_COLORS,
+    PIECE_B_EDGE_TYPES,
+    deterministic_config,
+    paint_quadrants,
+    rasterize_piece,
+)
+
+from app.services.piece_geometry.contour import mask_to_contour
+from app.services.piece_geometry.edges import split_edges
+from app.services.piece_geometry.fingerprint import (
+    build_fingerprint,
+    chi_square_distance,
+    shape_pair_distance,
+    spatial_pair_distance,
+)
+from app.services.piece_geometry.scoring import FALLBACK_STATS, combined_z
+
+
+def _build_fingerprint(edge_types: list[str], colors: list[tuple[int, int, int]]):
+    """Build a PieceFingerprint for a synthetic piece."""
+    config = deterministic_config(edge_types)
+    mask, _ = rasterize_piece(config)
+    contour = mask_to_contour(mask)
+    assert contour is not None
+    split = split_edges(contour)
+    assert split is not None
+    edges, _, _ = split
+    image_bgr = paint_quadrants(mask, colors)
+    return build_fingerprint(edges, image_bgr, contour)
+
+
+class TestChiSquareDistance:
+    """Tests for chi_square_distance."""
+
+    def test_identical_histograms_have_zero_distance(self) -> None:
+        """Comparing a histogram to itself yields distance 0."""
+        hist = np.array([0.5, 0.3, 0.2])
+
+        assert chi_square_distance(hist, hist) == pytest.approx(0.0)
+
+    def test_disjoint_histograms_have_max_distance(self) -> None:
+        """Completely disjoint L1-normalized histograms yield distance 1."""
+        p = np.array([1.0, 0.0])
+        q = np.array([0.0, 1.0])
+
+        assert chi_square_distance(p, q) == pytest.approx(1.0)
+
+
+class TestFingerprintSelfConsistency:
+    """Same-piece vs different-piece fingerprint distance and z-score behavior."""
+
+    def test_same_piece_photographed_twice_has_low_shape_distance(self) -> None:
+        """Two fingerprints built from the identical piece/photo have ~zero shape distance."""
+        fp1 = _build_fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+        fp2 = _build_fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+
+        d_shape, k = shape_pair_distance(fp1.edges_canonical, fp1.edge_types, fp2.edges_canonical, fp2.edge_types)
+
+        assert d_shape == pytest.approx(0.0, abs=1e-9)
+        assert k == 0
+
+    def test_different_pieces_have_higher_shape_distance(self) -> None:
+        """Two geometrically different pieces have a larger shape distance than a self-comparison."""
+        fp_a = _build_fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+        fp_a2 = _build_fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+        fp_b = _build_fingerprint(PIECE_B_EDGE_TYPES, PIECE_B_COLORS)
+
+        d_self, _ = shape_pair_distance(fp_a.edges_canonical, fp_a.edge_types, fp_a2.edges_canonical, fp_a2.edge_types)
+        d_other, _ = shape_pair_distance(fp_a.edges_canonical, fp_a.edge_types, fp_b.edges_canonical, fp_b.edge_types)
+
+        assert d_other > d_self
+
+    def test_combined_z_separates_genuine_from_impostor(self) -> None:
+        """z-score for a genuine (self) re-scan is far below the impostor z, using the M7 fallback stats.
+
+        This mirrors the store's own accept/new decision inputs: genuine
+        z should land comfortably under `t_accept` and the impostor z should
+        land comfortably above `t_new` (see app.config.Settings).
+        """
+        fp_a = _build_fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+        fp_a2 = _build_fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+        fp_b = _build_fingerprint(PIECE_B_EDGE_TYPES, PIECE_B_COLORS)
+
+        d_shape_self, k_self = shape_pair_distance(
+            fp_a.edges_canonical, fp_a.edge_types, fp_a2.edges_canonical, fp_a2.edge_types
+        )
+        d_spatial_self = spatial_pair_distance(fp_a, fp_a2, k_self)
+        z_self = combined_z(d_shape_self, d_spatial_self, FALLBACK_STATS)
+
+        d_shape_other, k_other = shape_pair_distance(
+            fp_a.edges_canonical, fp_a.edge_types, fp_b.edges_canonical, fp_b.edge_types
+        )
+        d_spatial_other = spatial_pair_distance(fp_a, fp_b, k_other)
+        z_other = combined_z(d_shape_other, d_spatial_other, FALLBACK_STATS)
+
+        assert z_self < -4.78  # t_accept default
+        assert z_other > -0.80  # t_new default
+        assert z_self < z_other
+
+
+class TestSpatialColorDescriptor:
+    """Tests for the 3x3 spatial gray-world a*b* color descriptor."""
+
+    def test_quadrant_painted_piece_has_nonempty_cells(self) -> None:
+        """A piece painted with distinct quadrant colors has several non-empty spatial cells."""
+        fp = _build_fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+
+        assert fp.spatial_hists.shape == (9, 64)
+        assert fp.spatial_nonempty.sum() >= 4
+
+    def test_spatial_distance_to_self_is_near_zero(self) -> None:
+        """The spatial color distance from a piece to an identical re-photograph is ~0."""
+        fp1 = _build_fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+        fp2 = _build_fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+
+        distance = spatial_pair_distance(fp1, fp2, k=0)
+
+        assert distance == pytest.approx(0.0, abs=1e-6)

--- a/backend/tests/test_piece_geometry_service.py
+++ b/backend/tests/test_piece_geometry_service.py
@@ -1,0 +1,195 @@
+"""Tests for app.services.piece_geometry.service."""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+from piece_geometry_fixtures import (
+    PIECE_A_COLORS,
+    PIECE_A_EDGE_TYPES,
+    deterministic_config,
+    embed_in_frame,
+    encode_png,
+    make_piece_rgba,
+    paint_quadrants,
+    rasterize_piece,
+    rgba_from_mask_and_image,
+)
+from PIL import Image
+
+from app.services.piece_geometry.contour import mask_to_contour
+from app.services.piece_geometry.service import PieceGeometryService, quick_quality_from_polygon
+
+
+def _mocked_service(rgba: Image.Image) -> PieceGeometryService:
+    """Build a PieceGeometryService whose background remover returns a fixed RGBA image."""
+    remover = MagicMock()
+    remover.remove_background.return_value = rgba
+    return PieceGeometryService(background_remover=remover)
+
+
+class TestPieceGeometryServiceProcess:
+    """Tests for PieceGeometryService.process using an injected mocked background remover."""
+
+    def test_clean_piece_produces_a_full_lockable_record(self) -> None:
+        """A clean synthetic piece photo produces corners, edges, and a fingerprint, and is lockable."""
+        rgba = make_piece_rgba(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+        service = _mocked_service(rgba)
+
+        record = service.process(encode_png(rgba))
+
+        assert record.quality.is_clean is True
+        assert record.corner_disagreement is False
+        assert record.corners is not None and record.corners.shape == (4, 2)
+        assert record.edges is not None and len(record.edges) == 4
+        assert record.fingerprint is not None
+        assert record.lockable is True
+
+    def test_background_remover_receives_the_raw_bytes(self) -> None:
+        """The service hands the raw photo bytes to the background remover, unchanged."""
+        rgba = make_piece_rgba(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+        remover = MagicMock()
+        remover.remove_background.return_value = rgba
+        service = PieceGeometryService(background_remover=remover)
+        payload = encode_png(rgba)
+
+        service.process(payload)
+
+        remover.remove_background.assert_called_once_with(payload)
+
+    def test_empty_alpha_produces_an_empty_unlockable_record(self) -> None:
+        """A fully transparent segmentation result yields no contour and lockable=False."""
+        empty_rgba = Image.fromarray(np.zeros((100, 100, 4), dtype=np.uint8), mode="RGBA")
+        service = _mocked_service(empty_rgba)
+
+        record = service.process(encode_png(empty_rgba))
+
+        assert record.contour is None
+        assert record.corners is None
+        assert record.edges is None
+        assert record.fingerprint is None
+        assert record.quality.is_clean is False
+        assert record.lockable is False
+        # Corners never ran, so the disagreement flag asserts nothing.
+        assert record.corner_disagreement is None
+
+    def test_second_blob_inside_the_crop_fails_the_quality_gate(self) -> None:
+        """A comparable second blob NEAR the piece (inside the crop margin) fails is_clean.
+
+        Corner detection never runs, so corner_disagreement stays None.
+        """
+        mask = np.zeros((300, 300), dtype=np.uint8)
+        mask[20:140, 20:140] = 255  # the "piece": 120x120
+        mask[30:130, 148:156] = 255  # distractor inside the bbox+15% crop window
+        image_bgr = paint_quadrants(mask, PIECE_A_COLORS)
+        rgba = rgba_from_mask_and_image(mask, image_bgr)
+        service = _mocked_service(rgba)
+
+        record = service.process(encode_png(rgba))
+
+        assert record.contour is not None
+        assert record.quality.is_clean is False
+        assert record.quality.n_large_components == 2
+        assert record.corners is None
+        assert record.edges is None
+        assert record.fingerprint is None
+        assert record.lockable is False
+        assert record.corner_disagreement is None
+
+    def test_distractor_far_from_the_piece_is_excluded_by_the_crop(self) -> None:
+        """A stray object far from the piece must not fail the gate: the crop excludes it.
+
+        This reproduces the north_star integration gap (paper arrow in the
+        frame counted as a second component, area_ratio diluted by the full
+        frame): the pipeline must run on the piece's bbox crop, exp28's
+        calibrated frame of reference.
+        """
+        config = deterministic_config(PIECE_A_EDGE_TYPES)
+        piece_mask, _ = rasterize_piece(config)
+        piece_bgr = paint_quadrants(piece_mask, PIECE_A_COLORS)
+        frame_mask, frame_bgr = embed_in_frame(piece_mask, piece_bgr, frame_shape=(1200, 1700), offset=(100, 100))
+        # Distractor blob far outside the piece's bbox+15% crop window.
+        frame_mask[1050:1110, 1450:1510] = 255
+        frame_bgr[1050:1110, 1450:1510] = (0, 200, 200)
+        rgba = rgba_from_mask_and_image(frame_mask, frame_bgr)
+        service = _mocked_service(rgba)
+
+        record = service.process(encode_png(rgba))
+
+        assert record.quality.is_clean is True
+        assert record.quality.n_large_components == 1
+        assert record.corner_disagreement is False
+        assert record.lockable is True
+        assert record.fingerprint is not None
+
+    def test_record_coordinates_are_in_full_image_space(self) -> None:
+        """Contour, corners, and edge polylines come back in full-image (not crop) coordinates."""
+        offset_x, offset_y = 300, 250
+        config = deterministic_config(PIECE_A_EDGE_TYPES)
+        piece_mask, gt_corners = rasterize_piece(config)
+        piece_bgr = paint_quadrants(piece_mask, PIECE_A_COLORS)
+        frame_mask, frame_bgr = embed_in_frame(
+            piece_mask, piece_bgr, frame_shape=(1400, 1600), offset=(offset_x, offset_y)
+        )
+        rgba = rgba_from_mask_and_image(frame_mask, frame_bgr)
+        service = _mocked_service(rgba)
+
+        record = service.process(encode_png(rgba))
+
+        assert record.corners is not None and record.contour is not None and record.edges is not None
+        expected_corners = gt_corners + np.array([offset_x, offset_y])
+        diagonal = float(np.linalg.norm(expected_corners[0] - expected_corners[2]))
+        # Each detected corner is within 3% of the diagonal of its ground-truth
+        # position IN FULL-IMAGE coordinates (order-independent).
+        for corner in record.corners:
+            nearest = float(np.min(np.linalg.norm(expected_corners - corner, axis=1)))
+            assert nearest <= 0.03 * diagonal
+        # The contour lives around the paste position, not around the origin.
+        assert record.contour[:, 0].min() >= offset_x - 5
+        assert record.contour[:, 1].min() >= offset_y - 5
+        # Edge polylines are offset consistently with the contour.
+        for edge in record.edges:
+            assert edge.polyline[:, 0].min() >= offset_x - 5
+            assert edge.polyline[:, 1].min() >= offset_y - 5
+
+
+class TestQuickQualityFromPolygon:
+    """Tests for quick_quality_from_polygon (the /piece/preview include_quality helper)."""
+
+    def test_clean_piece_polygon_is_lockable(self) -> None:
+        """A polygon closely tracing a clean synthetic piece is reported lockable."""
+        config = deterministic_config(["tab", "blank", "flat", "tab"])
+        mask, _ = rasterize_piece(config)
+        contour = mask_to_contour(mask)
+        assert contour is not None
+        height, width = mask.shape
+        polygon = [(float(x) / width, float(y) / height) for x, y in contour[::7]]  # thin but dense enough
+
+        lockable, corner_disagreement = quick_quality_from_polygon(polygon)
+
+        assert corner_disagreement is False
+        assert lockable is True
+
+    def test_degenerate_polygon_is_not_lockable(self) -> None:
+        """Fewer than 3 points can't form a region: (False, None) — nothing was measured."""
+        assert quick_quality_from_polygon([(0.1, 0.1), (0.2, 0.2)]) == (False, None)
+
+    def test_empty_polygon_is_not_lockable(self) -> None:
+        """An empty polygon list is handled without error and asserts no measurement."""
+        assert quick_quality_from_polygon([]) == (False, None)
+
+    def test_small_in_frame_piece_is_still_lockable(self) -> None:
+        """A clean piece covering a small fraction of the frame passes (crop-relative area gate)."""
+        config = deterministic_config(["tab", "blank", "flat", "tab"])
+        mask, _ = rasterize_piece(config)
+        contour = mask_to_contour(mask)
+        assert contour is not None
+        height, width = mask.shape
+        # Scale the polygon down to ~1/5 of the frame in each dimension: the
+        # piece then covers ~1.6% of the full frame, far below the 5% gate
+        # that would apply if quality were (wrongly) computed frame-relative.
+        polygon = [(0.4 + 0.2 * float(x) / width, 0.4 + 0.2 * float(y) / height) for x, y in contour[::7]]
+
+        lockable, corner_disagreement = quick_quality_from_polygon(polygon)
+
+        assert corner_disagreement is False
+        assert lockable is True

--- a/backend/tests/test_piece_geometry_store.py
+++ b/backend/tests/test_piece_geometry_store.py
@@ -1,0 +1,174 @@
+"""Tests for app.services.piece_geometry.store."""
+
+from typing import List, Tuple
+
+import pytest
+from piece_geometry_fixtures import (
+    PIECE_A_COLORS,
+    PIECE_A_EDGE_TYPES,
+    PIECE_B_COLORS,
+    PIECE_B_EDGE_TYPES,
+    deterministic_config,
+    paint_quadrants,
+    rasterize_piece,
+)
+
+from app.services.piece_geometry import store as store_module
+from app.services.piece_geometry.contour import mask_to_contour
+from app.services.piece_geometry.edges import split_edges
+from app.services.piece_geometry.fingerprint import PieceFingerprint, build_fingerprint
+from app.services.piece_geometry.store import MatchVerdict, PieceGeometryStore, PuzzlePieceStore
+
+
+def _fingerprint(edge_types: List[str], colors: List[Tuple[int, int, int]]) -> PieceFingerprint:
+    """Build a real PieceFingerprint for a synthetic piece."""
+    config = deterministic_config(edge_types)
+    mask, _ = rasterize_piece(config)
+    contour = mask_to_contour(mask)
+    assert contour is not None
+    split = split_edges(contour)
+    assert split is not None
+    edges, _, _ = split
+    image_bgr = paint_quadrants(mask, colors)
+    return build_fingerprint(edges, image_bgr, contour)
+
+
+class TestPuzzlePieceStoreVerdicts:
+    """new -> matched -> uncertain transitions using real synthetic fingerprints."""
+
+    def test_first_piece_is_always_new(self) -> None:
+        """An empty store always enrolls the first photo as new, with no z-score."""
+        store = PuzzlePieceStore()
+        fp = _fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+
+        result = store.add_or_match(fp, is_clean=True, corner_disagreement=False)
+
+        assert result.verdict == MatchVerdict.NEW
+        assert result.piece_id == "p001"
+        assert result.match_piece_id is None
+        assert result.z_score is None
+        assert [p.piece_id for p in store.list_pieces()] == ["p001"]
+
+    def test_rescanning_the_same_piece_matches(self) -> None:
+        """Re-submitting the same physical piece's fingerprint matches the enrolled piece_id."""
+        store = PuzzlePieceStore()
+        fp1 = _fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+        store.add_or_match(fp1, is_clean=True, corner_disagreement=False)
+
+        fp1_again = _fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+        result = store.add_or_match(fp1_again, is_clean=True, corner_disagreement=False)
+
+        assert result.verdict == MatchVerdict.MATCHED
+        assert result.piece_id == "p001"
+        assert result.match_piece_id == "p001"
+        assert result.z_score is not None
+        assert result.z_score < 0
+        # Not re-enrolled: still only one piece in the store.
+        assert len(store.list_pieces()) == 1
+
+    def test_a_clearly_different_piece_is_enrolled_as_new(self) -> None:
+        """A geometrically and visually distinct piece is enrolled under a fresh piece_id."""
+        store = PuzzlePieceStore()
+        fp_a = _fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+        store.add_or_match(fp_a, is_clean=True, corner_disagreement=False)
+
+        fp_b = _fingerprint(PIECE_B_EDGE_TYPES, PIECE_B_COLORS)
+        result = store.add_or_match(fp_b, is_clean=True, corner_disagreement=False)
+
+        assert result.verdict == MatchVerdict.NEW
+        assert result.piece_id == "p002"
+        assert result.match_piece_id is None
+        assert result.z_score is not None
+        assert len(store.list_pieces()) == 2
+
+    def test_gray_zone_is_uncertain_and_not_enrolled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A z-score between t_accept and t_new is uncertain and does not enroll."""
+        store = PuzzlePieceStore()
+        fp_a = _fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+        store.add_or_match(fp_a, is_clean=True, corner_disagreement=False)
+
+        # Patch the exact settings object app.services.piece_geometry.store reads at
+        # call time (via store_module, not a fresh `from app.config import settings`,
+        # since some other test module's fixture may have re-imported app.config and
+        # left a *different* Settings instance bound to that name in between).
+        monkeypatch.setattr(store_module.settings, "PIECE_GEOMETRY_T_ACCEPT", -1e9)  # nothing can be "matched"
+        monkeypatch.setattr(store_module.settings, "PIECE_GEOMETRY_T_NEW", 1e9)  # nothing can be "new"
+
+        fp_b = _fingerprint(PIECE_B_EDGE_TYPES, PIECE_B_COLORS)
+        result = store.add_or_match(fp_b, is_clean=True, corner_disagreement=False)
+
+        assert result.verdict == MatchVerdict.UNCERTAIN
+        assert result.piece_id is None
+        assert result.match_piece_id == "p001"
+        assert result.z_score is not None
+        # Not enrolled: the store still has only the first piece.
+        assert len(store.list_pieces()) == 1
+
+    def test_enroll_uncertain_turns_a_gray_zone_verdict_into_new(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With enroll_uncertain=True, a gray-zone photo is enrolled as a new piece."""
+        store = PuzzlePieceStore()
+        fp_a = _fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+        store.add_or_match(fp_a, is_clean=True, corner_disagreement=False)
+
+        # Force every comparison into the gray zone (same trick as above).
+        monkeypatch.setattr(store_module.settings, "PIECE_GEOMETRY_T_ACCEPT", -1e9)
+        monkeypatch.setattr(store_module.settings, "PIECE_GEOMETRY_T_NEW", 1e9)
+
+        fp_b = _fingerprint(PIECE_B_EDGE_TYPES, PIECE_B_COLORS)
+        result = store.add_or_match(fp_b, is_clean=True, corner_disagreement=False, enroll_uncertain=True)
+
+        assert result.verdict == MatchVerdict.NEW
+        assert result.piece_id == "p002"
+        assert result.z_score is not None
+        assert len(store.list_pieces()) == 2
+
+
+class TestGalleryStatsFallback:
+    """The store falls back to M7 constants below MIN_GALLERY_FOR_STATS pieces."""
+
+    def test_small_gallery_uses_fallback_stats(self) -> None:
+        """With fewer than 12 enrolled pieces, _gallery_stats returns the fallback constants."""
+        from app.services.piece_geometry.scoring import FALLBACK_STATS
+
+        store = PuzzlePieceStore()
+        store.add_or_match(_fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS), True, False)
+
+        stats = store._gallery_stats()  # inspects the fallback boundary directly
+
+        assert stats == FALLBACK_STATS
+
+
+class TestPieceGeometryStore:
+    """Tests for the puzzle_id-keyed PieceGeometryStore wrapper."""
+
+    def test_stores_are_isolated_per_puzzle(self) -> None:
+        """Two puzzles' piece stores don't share enrolled pieces or id sequences."""
+        store = PieceGeometryStore()
+        fp_a = _fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+        fp_b = _fingerprint(PIECE_B_EDGE_TYPES, PIECE_B_COLORS)
+
+        result_1 = store.add_or_match("puzzle-1", fp_a, True, False)
+        result_2 = store.add_or_match("puzzle-2", fp_b, True, False)
+
+        assert result_1.piece_id == "p001"
+        assert result_2.piece_id == "p001"
+        assert len(store.list_pieces("puzzle-1")) == 1
+        assert len(store.list_pieces("puzzle-2")) == 1
+
+    def test_none_fingerprint_is_uncertain_and_not_enrolled(self) -> None:
+        """A None fingerprint (an earlier pipeline stage failed) is reported uncertain, never enrolled."""
+        store = PieceGeometryStore()
+
+        result = store.add_or_match("puzzle-1", None, is_clean=False, corner_disagreement=True)
+
+        assert result.verdict == MatchVerdict.UNCERTAIN
+        assert result.piece_id is None
+        assert result.match_piece_id is None
+        assert result.z_score is None
+        assert store.list_pieces("puzzle-1") == []
+
+    def test_list_pieces_for_unknown_puzzle_is_empty(self) -> None:
+        """Listing a puzzle with no store yet returns an empty list, not an error."""
+        store = PieceGeometryStore()
+
+        assert store.list_pieces("never-seen") == []

--- a/backend/tests/test_piece_geometry_store.py
+++ b/backend/tests/test_piece_geometry_store.py
@@ -138,6 +138,31 @@ class TestGalleryStatsFallback:
         assert stats == FALLBACK_STATS
 
 
+class TestGalleryStatsCaching:
+    """_gallery_stats is O(n^2); it caches and invalidates only when the gallery grows."""
+
+    def test_stats_are_cached_between_calls_and_invalidated_on_enroll(self) -> None:
+        """Repeated _gallery_stats calls reuse the cached object until a piece is enrolled."""
+        from app.services.piece_geometry.scoring import MIN_GALLERY_FOR_STATS
+
+        store = PuzzlePieceStore()
+        fp = _fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+        # Enroll exactly enough pieces to leave the fallback regime, so
+        # _gallery_stats takes the real (cacheable) branch.
+        for _ in range(MIN_GALLERY_FOR_STATS):
+            store._enroll(fp, True, False)
+
+        first = store._gallery_stats()
+        second = store._gallery_stats()
+        # Same object identity => the second call reused the cache, not recomputed.
+        assert first is second
+
+        # Enrolling a piece must invalidate the cache: the next call recomputes.
+        store._enroll(fp, True, False)
+        third = store._gallery_stats()
+        assert third is not first
+
+
 class TestPieceGeometryStore:
     """Tests for the puzzle_id-keyed PieceGeometryStore wrapper."""
 

--- a/docs/piece-geometry-scanning.html
+++ b/docs/piece-geometry-scanning.html
@@ -143,6 +143,18 @@
     background: var(--good-soft); color: var(--good); border-radius: 6px;
   }
   .milestone .success::before { content: "✓ Done when: "; font-weight: 700; }
+  .milestone .outcome {
+    margin-top: 0.6rem; font-size: 0.88rem; padding: 0.55rem 0.75rem;
+    background: var(--accent-soft); border-left: 3px solid var(--accent); border-radius: 6px;
+  }
+  .milestone .outcome::before { content: "◆ Result (2026-07-16): "; font-weight: 700; color: var(--accent); }
+  .badge {
+    font-size: 0.7rem; font-weight: 700; padding: 0.1rem 0.5rem; border-radius: 999px;
+    letter-spacing: 0.05em;
+  }
+  .badge.done { background: var(--good-soft); color: var(--good); }
+  .badge.next { background: var(--accent-soft); color: var(--accent); }
+  .badge.skip { background: var(--warn-soft); color: var(--warn); }
   .phasehead {
     margin: 2.25rem 0 0.25rem; font-size: 0.8rem; font-weight: 700;
     letter-spacing: 0.1em; text-transform: uppercase;
@@ -161,8 +173,13 @@
 <div class="wrap">
 
 <header>
-  <span class="kicker">Pussel · brainstorm · 2026-07-16</span>
+  <span class="kicker">Pussel · brainstorm &amp; living results log · 2026-07-16</span>
   <h1>The Second Column: Scanning Exact Piece Geometry</h1>
+  <p class="subtitle" style="margin-top:0.5rem">
+    <strong>Status:</strong> M1–M4 completed in <code>network/experiments/exp28_piece_geometry/</code>
+    (detailed log: <code>HANDOFF.md</code> there). Result blocks (◆) below record what each milestone
+    actually found. M5 deferred (optional). M6 is next.
+  </p>
   <p class="subtitle">
     Today Pussel answers <em>"where in the picture does this piece go?"</em> by matching surface
     texture (SIFT→NCC hybrid, 76.7% on real photos). This document explores the complementary
@@ -383,7 +400,7 @@
 <p class="phasedesc">Prove we can turn an existing real photo into four labeled edges. Everything runs as scripts in <code>network/experiments/</code>, evaluated with contact sheets like exp25.</p>
 
 <div class="milestone">
-  <h4><span class="mtag a">M1</span> High-fidelity contour extraction</h4>
+  <h4><span class="mtag a">M1</span> High-fidelity contour extraction <span class="badge done">DONE ✓</span></h4>
   <div class="meta">~2–4 sessions · builds on <code>piece_detector.py</code> + <code>background_remover.py</code></div>
   <ul>
     <li>Upgrade the existing rembg pipeline from "≤60-point UI polygon" to a full-resolution, smoothed, closed contour (mask → morphological cleanup → <code>findContours</code> → light smoothing).</li>
@@ -391,10 +408,22 @@
     <li>Note which backgrounds fail (the red carpet will be the stress test) — this <em>defines the capture protocol</em> for the eventual scanning mat.</li>
   </ul>
   <div class="success">≥95% of pieces yield a single clean closed contour on at least the 2 friendly backgrounds; failure modes are catalogued.</div>
+  <div class="outcome">
+    <strong>Criterion met on all four backgrounds, not just two.</strong> rembg (u2net) clean rates over
+    944 photos: gray_fabric 98.7%, red_carpet 97.9%, wood 96.2%, cardboard 95.3%. The Otsu-threshold
+    baseline is dead on textured real backgrounds (0.8–22.5%) — rembg is the extraction method, full stop.
+    Gate-failure taxonomy (28 cases): 17 multi-component segmentations, 8 border-touching crops, 3
+    implausible shapes. Visual review found what the gate cannot: on <em>wood</em>, a few pieces per sheet
+    pass the gate but the contour follows dark <em>artwork</em> boundaries instead of the piece edge
+    (dark art blends into wood tones); gray fabric and red carpet sheets are essentially flawless, with
+    drop shadows correctly excluded. <strong>Capture-protocol consequence: the scanning mat should be
+    neutral gray fabric.</strong> These wood "silent failures" resurface as the dominant error source in
+    M3 and M4 — segmentation quality upper-bounds the whole column.
+  </div>
 </div>
 
 <div class="milestone">
-  <h4><span class="mtag a">M2</span> Corner detection bake-off</h4>
+  <h4><span class="mtag a">M2</span> Corner detection bake-off <span class="badge done">DONE ✓</span></h4>
   <div class="meta">~3–5 sessions · the known-fragile step, so measure it properly</div>
   <ul>
     <li>Hand-label 4 corners on a ~60-piece subset (tiny matplotlib click tool — an afternoon).</li>
@@ -402,43 +431,97 @@
     <li>Benchmark corner error (as % of piece size) per method per background.</li>
   </ul>
   <div class="success">Best method places all 4 corners within 3% of piece size on ≥90% of the subset; we know its failure modes well enough to design the manual-nudge fallback.</div>
+  <div class="outcome">
+    <strong>Criterion met — polydp 98.5% and curvature 97.0%</strong> of 200 synthetic pieces (known
+    ground-truth corners, random rotation + blur + noise) within 3% worst-corner error, median ~0.7%.
+    The literature's warning proved exact: naïve subset scoring picked <em>tab-bulb tips</em> (bigger
+    quadrilaterals) — initial rates were just 68% / 29.5%. Three changes fixed it: (1) a
+    <em>cornerness prior</em> — true corners have locally straight contour shoulders on both sides,
+    tab tips curve away immediately (PCA line fits + angle-near-90° score per candidate);
+    (2) quad area normalized by hull area so it can't dominate; (3) corners refined as the
+    <em>intersection of the shoulder lines</em>, recovering the un-rounded corner that corner_radius
+    hides (p97 error 3.6% → 0.8%). Shi-Tomasi is structurally unusable (13.5%): goodFeaturesToTrack
+    never even proposes rounded true corners (~33% missing from its pool). On real photos the corner
+    overlays look excellent; synthetic random pieces are <em>harder</em> than real ones (more extreme
+    tabs), so these numbers are conservative. Quantitative real-photo eval awaits optional hand labels
+    (<code>label_corners.py</code> click tool is ready). Working recipe: <strong>polydp primary,
+    curvature as cross-check</strong> — their disagreement (&gt;3% of bbox diagonal) is the per-piece
+    quality flag.
+  </div>
 </div>
 
 <div class="milestone">
-  <h4><span class="mtag a">M3</span> Edge splitting + tab/blank/flat classification</h4>
+  <h4><span class="mtag a">M3</span> Edge splitting + tab/blank/flat classification <span class="badge done">DONE ✓</span></h4>
   <div class="meta">~1–2 sessions · literature says this is the easy part</div>
   <ul>
     <li>Split contour at corners into 4 arcs; chord-midpoint-vs-centroid test per arc.</li>
     <li>Ground truth is nearly free: north_star grid positions tell us which edges are flat (border pieces), and interlocking neighbors constrain tab/blank parity — hand-verify the remainder on contact sheets.</li>
   </ul>
   <div class="success">≥98% edge-type accuracy across all cleanly-contoured pieces. Output: every north_star piece stored as a draft piece record (contour + corners + 4 typed edges).</div>
+  <div class="outcome">
+    <strong>Criterion met: flat-edge accuracy vs grid ground truth 99.68% (gray_fabric), 98.38%
+    (red_carpet)</strong>; wood 97.25%, cardboard 98.0%. The chord-deviation distribution is strongly
+    bimodal exactly as the literature promised — flat edges deviate &lt;4% of chord length, tabs/blanks
+    11–42% — so FLAT_THRESHOLD=0.07 sits in a wide safe gap; classification itself is genuinely the
+    easy step. Neighbor tab↔blank complementarity: 99.4% of adjacent pairs on gray_fabric.
+    Cross-background signature consistency 80.5%, dragged down by two things that are <em>not</em>
+    classifier errors: (1) wood segmentation leaks from M1 corrupting corners (the corner_disagreement
+    flags concentrate exactly there), and (2) <strong>toddler puzzles (peppa_kitchen 90.2%,
+    peppa_aquarium 94.1%) have genuinely figural border edges</strong> — physically shaped cutouts on
+    "flat" borders, verified visually — so the "border ⇒ flat" ground-truth assumption is what's wrong;
+    standard die-cut puzzles score 99.5–100%. Output achieved: 916 piece records (corners + 4 typed
+    edges + 100-pt polyline per edge), 0 splitting failures.
+  </div>
 </div>
 
 <div class="milestone">
-  <h4><span class="mtag a">M4</span> Edge complementarity matching — the first payoff</h4>
+  <h4><span class="mtag a">M4</span> Edge complementarity matching — the first payoff <span class="badge done">DONE ✓</span></h4>
   <div class="meta">~3–4 sessions · the milestone that proves the column's core value</div>
   <ul>
     <li>Normalize each edge (rotate to axis, arc-length resample to 100 points); match edge A against flipped edge B via chamfer distance. Also try the ~6-scalar descriptor variant.</li>
     <li>Evaluation is beautiful here: north_star grid positions give every true neighbor pair. For each interior edge, rank all candidate mating edges in the same puzzle — where does the true neighbor rank?</li>
   </ul>
   <div class="success">Report: true mating edge ranked #1 for X% of edges, top-5 for Y% — per puzzle brand. This number tells us how strong the geometry signal is on our actual puzzles (the jigsawlutioner brand-dependence question, answered with our data).</div>
+  <div class="outcome">
+    <strong>Reported: true mate top-1 = 67.4%, top-3 = 85.2%, top-5 = 90.5%</strong> over 1,878
+    interior-edge queries against ~25-candidate pools (all type-compatible edges of other pieces,
+    no orientation leak); gray_fabric top-1 = 77.4%, and median rank of the true mate is 1 on every
+    gray_fabric puzzle. Metric bake-off: <strong>plain pointwise L2 on canonical chord-normalized
+    100-pt polylines wins</strong> — chamfer loses (61.9% — arc-length index alignment carries
+    information; nearest-point freedom lets impostors cheat), the 6-scalar descriptor collapses too
+    much shape (29.3%), and the chord-length penalty <em>actively hurts</em> (28.2% — camera distance
+    varies per photo, empirically confirming the scale-free design decision). The corner_disagreement
+    quality gate is worth ~8 top-1 points (67.4% vs 59.4% including flagged records). The mate-flip
+    transform was verified exactly (distance 0.0) on a puzzle_shapes shared-edge pair.
+    <strong>The jigsawlutioner question, answered on our data: die-cut shape collisions are real</strong> —
+    median best-impostor/true-mate margin is only 1.22×, and failures are visibly <em>near-identical
+    competing tabs</em>, not matcher errors. Geometry is a strong ranker but cannot be a sole
+    accept/reject threshold: <strong>color must join the fingerprint (→ M6/M7)</strong>, exactly as
+    §3 predicted.
+  </div>
 </div>
 
 <div class="milestone">
-  <h4><span class="mtag a">M5</span> Fit TabParameters to real edges (optional, parallel)</h4>
+  <h4><span class="mtag a">M5</span> Fit TabParameters to real edges (optional, parallel) <span class="badge skip">DEFERRED</span></h4>
   <div class="meta">~2–3 sessions · reuses <code>optimize_torch.py</code> nearly as-is</div>
   <ul>
     <li>Wire M3's edge arcs into the existing chamfer/Hausdorff parameter fitter; record fit residuals.</li>
     <li>Compare real fitted parameter distributions against the synthetic generator's <code>TabParameters.random()</code> ranges — a free realism audit of the synthetic pipeline.</li>
   </ul>
   <div class="success">Median fit residual below an agreed IoU/chamfer threshold on tab/blank edges; a plot of real vs. synthetic parameter distributions (feeds back into the CNN column).</div>
+  <div class="outcome">
+    Deferred after M4: nothing downstream hard-depends on the parametric fit (matching works directly
+    on polylines, and the corner_disagreement flag covers the quality-gate role that fit residuals
+    were meant to play). Revisit if/when (a) compact hashable descriptors are needed at scale, or
+    (b) the synthetic generator's realism audit becomes a priority for the CNN column.
+  </div>
 </div>
 
 <p class="phasehead b">Phase B · Piece identity</p>
 <p class="phasedesc">From "an edge matches an edge" to "I recognize this specific piece" — the prerequisite for the scan-and-lock UX.</p>
 
 <div class="milestone">
-  <h4><span class="mtag b">M6</span> Piece fingerprint + re-identification benchmark</h4>
+  <h4><span class="mtag b">M6</span> Piece fingerprint + re-identification benchmark <span class="badge next">NEXT ▶</span></h4>
   <div class="meta">~3–4 sessions · north_star's 4-backgrounds-per-piece design was made for this</div>
   <ul>
     <li>Fingerprint = rotation-invariant shape descriptor (canonically ordered 4-edge descriptors) + LAB color histogram (+ optionally a small patch embedding).</li>
@@ -511,13 +594,13 @@
   <tr><th>Risk</th><th>Likelihood</th><th>Mitigation</th></tr>
   <tr>
     <td>Corner detection unreliable on real photos (the field's universal pain point)</td>
-    <td>High</td>
-    <td>M2 measures it before anything depends on it; design the piece record to carry corner confidence; plan a one-tap manual nudge in the app as the escape hatch.</td>
+    <td>High → <strong>retired by M2</strong></td>
+    <td>Confirmed as the hard step (naïve scoring hit only 29–68%), then solved with the shoulder-straightness cornerness prior + line-intersection refinement: 97–98.5% within 3% error. The polydp/curvature disagreement flag is the per-piece confidence signal (worth ~8 top-1 matching points in M4).</td>
   </tr>
   <tr>
     <td>Shape collisions — our puzzle brands reuse die-cut tab shapes, weakening geometry-only matching</td>
-    <td>Medium–high (kids' puzzles are rarely Ravensburger-grade)</td>
-    <td>Exactly why the fingerprint is shape <em>+ color</em> from day one; M4/M7 quantify the problem per brand instead of discovering it in production.</td>
+    <td><strong>Confirmed by M4</strong></td>
+    <td>Median best-impostor margin just 1.22×; failures are visibly near-identical competing tabs. Geometry ranks (top-5 90.5%) but cannot threshold — shape <em>+ color</em> fingerprints (M6/M7) carry identity, as planned.</td>
   </tr>
   <tr>
     <td>Perspective tilt distorts tab geometry from handheld capture</td>
@@ -536,8 +619,8 @@
   </tr>
   <tr>
     <td>rembg (u2net) too slow or imprecise for full-res contour work</td>
-    <td>Low–medium</td>
-    <td>On a controlled mat, classical thresholding may beat it — M1 compares both. rembg stays the fallback for messy backgrounds.</td>
+    <td><strong>Resolved by M1 — inverted</strong></td>
+    <td>rembg is the winner (95–99% clean); Otsu thresholding is unusable on textured real surfaces (0.8–22.5%). Remaining rembg weakness: dark artwork against wood — solved by mat choice (gray fabric), not by algorithm.</td>
   </tr>
 </table>
 </div>

--- a/docs/piece-geometry-scanning.html
+++ b/docs/piece-geometry-scanning.html
@@ -176,9 +176,11 @@
   <span class="kicker">Pussel · brainstorm &amp; living results log · 2026-07-16</span>
   <h1>The Second Column: Scanning Exact Piece Geometry</h1>
   <p class="subtitle" style="margin-top:0.5rem">
-    <strong>Status:</strong> M1–M4 completed in <code>network/experiments/exp28_piece_geometry/</code>
+    <strong>Status:</strong> M1–M4 and M6 completed in <code>network/experiments/exp28_piece_geometry/</code>
     (detailed log: <code>HANDOFF.md</code> there). Result blocks (◆) below record what each milestone
-    actually found. M5 deferred (optional). M6 is next.
+    actually found. M5 deferred (optional). M6's ≥95% criterion was not met on the harsh
+    cross-background benchmark (91.5%) but the gap is isolated to wood-query capture quality.
+    M7 is next.
   </p>
   <p class="subtitle">
     Today Pussel answers <em>"where in the picture does this piece go?"</em> by matching surface
@@ -521,7 +523,7 @@
 <p class="phasedesc">From "an edge matches an edge" to "I recognize this specific piece" — the prerequisite for the scan-and-lock UX.</p>
 
 <div class="milestone">
-  <h4><span class="mtag b">M6</span> Piece fingerprint + re-identification benchmark <span class="badge next">NEXT ▶</span></h4>
+  <h4><span class="mtag b">M6</span> Piece fingerprint + re-identification benchmark <span class="badge done">DONE — CRITERION NOT MET</span></h4>
   <div class="meta">~3–4 sessions · north_star's 4-backgrounds-per-piece design was made for this</div>
   <ul>
     <li>Fingerprint = rotation-invariant shape descriptor (canonically ordered 4-edge descriptors) + LAB color histogram (+ optionally a small patch embedding).</li>
@@ -529,10 +531,27 @@
     <li>Ablate: shape only vs. color only vs. combined.</li>
   </ul>
   <div class="success">Top-1 re-ID ≥95% combined, with the ablation quantifying how much each signal contributes.</div>
+  <div class="outcome">
+    <strong>Criterion not met on the deliberately-harsh cross-background benchmark: 91.5% top-1 /
+    97.5% top-5</strong> (enroll on one background, query on the other three, 236-piece cross-puzzle
+    gallery, hyperparameters frozen on validation cells only; progression across three iterations
+    81.5% → 86.1% → 91.5%). The ablation was full of lessons: <em>fusion style matters more than
+    features</em> — a z-normalized linear blend degenerated to shape-only even though failures were
+    gross color mismatches, while reciprocal-rank fusion worked; gray-world normalization more than
+    doubled color-only accuracy (22.8% → 50.7%); and the milestone's discovery is the
+    <strong>3×3 spatial color layout, which alone beats shape</strong> (85.2% vs 81.5%) and dissolves
+    same-palette sibling confusion — RRF(shape, spatial) reached 94.3%. The entire remaining gap is
+    <strong>wood-query capture quality</strong> (underexposed, warm-cast photos of dark artwork):
+    excluding wood queries, cells run 94.8–97.5%. Within-puzzle ("which of my 24 pieces is this"):
+    up to 96.2% top-1 / 99.6% top-5. Production outlook: the app's same-mat, same-session scenario
+    is strictly easier than every benchmarked cell — ≥95% looks realistic on the gray mat, but
+    proving it needs a same-background repeat-capture set. Fix path: capture-time exposure/WB
+    control, not more descriptor engineering.
+  </div>
 </div>
 
 <div class="milestone">
-  <h4><span class="mtag b">M7</span> Uniqueness / collision study</h4>
+  <h4><span class="mtag b">M7</span> Uniqueness / collision study <span class="badge next">NEXT ▶</span></h4>
   <div class="meta">~1–2 sessions · mostly analysis on M6's data</div>
   <ul>
     <li>Genuine-vs-impostor similarity distributions; per-brand shape collision rates (do our kids' puzzles reuse die-cut shapes like jigsawlutioner warns?).</li>

--- a/docs/piece-geometry-scanning.html
+++ b/docs/piece-geometry-scanning.html
@@ -176,14 +176,15 @@
   <span class="kicker">Pussel · brainstorm &amp; living results log · 2026-07-16</span>
   <h1>The Second Column: Scanning Exact Piece Geometry</h1>
   <p class="subtitle" style="margin-top:0.5rem">
-    <strong>Status: Phases A, B, and C complete</strong> (M1–M4, M6, M7 researched in
-    <code>network/experiments/exp28_piece_geometry/</code> — detailed log: <code>HANDOFF.md</code> there;
-    M5 deferred, optional; M8 shipped the stack as production backend code in
-    <code>backend/app/services/piece_geometry/</code> with E2E verification on real photos).
+    <strong>Status: Phases A, B, C complete; Phase D underway — M9 done, M10 next</strong>
+    (M1–M4, M6, M7 researched in <code>network/experiments/exp28_piece_geometry/</code> — detailed
+    log: <code>HANDOFF.md</code> there; M5 deferred, optional; M8 shipped the stack as production
+    backend code in <code>backend/app/services/piece_geometry/</code> with E2E verification on real
+    photos; M9 put the live outline overlay in the iOS camera, verified on a physical iPhone).
     Result blocks (◆) below record what each milestone actually found. The scoring stack:
     rembg contour → polydp corners → typed edges + canonical polylines → shape+spatial-color
     fingerprint → one z-sum score for ranking (95.2% top-1 cross-background) and thresholding
-    (M7 recipe). Next: Phase D (M9, iOS live overlay).
+    (M7 recipe). Next: M10, scan-and-lock.
   </p>
   <p class="subtitle">
     Today Pussel answers <em>"where in the picture does this piece go?"</em> by matching surface
@@ -616,17 +617,31 @@
 <p class="phasedesc">Only now touch Swift — with a proven algorithm behind a stable API. Split into three small steps so each is demoable on-device.</p>
 
 <div class="milestone">
-  <h4><span class="mtag d">M9</span> Live outline overlay in the iOS preview <span class="badge next">NEXT ▶</span></h4>
+  <h4><span class="mtag d">M9</span> Live outline overlay in the iOS preview <span class="badge done">DONE ✓</span></h4>
   <div class="meta">~2–3 sessions · iOS catches up to what the web frontend already does</div>
   <ul>
     <li>Add an <code>AVCaptureVideoDataOutput</code> frame tap to the existing <code>PieceCameraSession</code>; throttle-stream downscaled frames to the (extended) preview endpoint; draw the returned polygon over the preview layer.</li>
     <li>Optional spike alongside: on-device <code>VNDetectContoursRequest</code> for the rough outline at full frame rate, with the backend doing the precise work — decide based on felt latency.</li>
   </ul>
   <div class="success">Point phone at a piece → its outline appears live within ~300ms and tracks as the piece/phone moves.</div>
+  <div class="outcome">
+    <strong>Criterion met — verified live on a physical iPhone 15 by the user.</strong> The camera
+    session gained an <code>AVCaptureVideoDataOutput</code> tap streaming throttled 480px JPEGs
+    (≥250ms interval, one in flight) to the preview endpoint with quality flags; the outline renders
+    as a CAShapeLayer — yellow detected, green lockable — with 120ms animated tracking. Pure logic
+    (throttle, coordinate mapping) is extracted and unit-tested; 76 iOS tests pass. Two lessons worth
+    keeping: (1) <em>never guess buffer orientation</em> — the first device build drew the outline
+    rotated and offset because a fixed sensor-rotation assumption was wrong; the fix rotates buffers
+    to portrait at the connection level (<code>videoRotationAngle=90</code>) so the streamed frame is
+    pixel-identical to the preview, mapped by one unit-tested aspect-fill transform on device and
+    Simulator alike. (2) iOS 26 Simulator camera-permission dialogs cannot be scripted away, so DEBUG
+    Simulator builds skip the real capture session entirely and a <code>pusseldebug://previewloop</code>
+    command feeds fake frames through the identical pipeline for tap-free demos.
+  </div>
 </div>
 
 <div class="milestone">
-  <h4><span class="mtag d">M10</span> Scan-and-lock: the "mark it green" moment</h4>
+  <h4><span class="mtag d">M10</span> Scan-and-lock: the "mark it green" moment <span class="badge next">NEXT ▶</span></h4>
   <div class="meta">~3–4 sessions · the heart of the vision</div>
   <ul>
     <li>Stability tracking across frames (contour IoU between consecutive detections); when stable + quality-gated (sharpness, size, corner confidence), auto-capture a full-res frame, run full geometry extraction, and flip the overlay to a locked/green state with haptic feedback.</li>

--- a/docs/piece-geometry-scanning.html
+++ b/docs/piece-geometry-scanning.html
@@ -176,8 +176,8 @@
   <span class="kicker">Pussel · brainstorm &amp; living results log · 2026-07-16</span>
   <h1>The Second Column: Scanning Exact Piece Geometry</h1>
   <p class="subtitle" style="margin-top:0.5rem">
-    <strong>Status: Phases A, B, C complete; Phase D underway — M9 done, M10 built and
-    Simulator-E2E-verified (on-device 10-piece run pending)</strong>
+    <strong>Status: Phases A, B, C complete; Phase D underway — M9 and M10 done (scan-and-lock
+    verified on-device: hands-free lock → enroll → piece list, dedupe on re-scans)</strong>
     (M1–M4, M6, M7 researched in <code>network/experiments/exp28_piece_geometry/</code> — detailed
     log: <code>HANDOFF.md</code> there; M5 deferred, optional; M8 shipped the stack as production
     backend code in <code>backend/app/services/piece_geometry/</code> with E2E verification on real
@@ -185,7 +185,7 @@
     Result blocks (◆) below record what each milestone actually found. The scoring stack:
     rembg contour → polydp corners → typed edges + canonical polylines → shape+spatial-color
     fingerprint → one z-sum score for ranking (95.2% top-1 cross-background) and thresholding
-    (M7 recipe). Next: confirm M10's on-device success criterion, then M11 (neighbor suggestions).
+    (M7 recipe). Next: M11, neighbor suggestions.
   </p>
   <p class="subtitle">
     Today Pussel answers <em>"where in the picture does this piece go?"</em> by matching surface
@@ -642,7 +642,7 @@
 </div>
 
 <div class="milestone">
-  <h4><span class="mtag d">M10</span> Scan-and-lock: the "mark it green" moment <span class="badge done">BUILT ✓ — device run pending</span></h4>
+  <h4><span class="mtag d">M10</span> Scan-and-lock: the "mark it green" moment <span class="badge done">DONE ✓</span></h4>
   <div class="meta">~3–4 sessions · the heart of the vision</div>
   <ul>
     <li>Stability tracking across frames (contour IoU between consecutive detections); when stable + quality-gated (sharpness, size, corner confidence), auto-capture a full-res frame, run full geometry extraction, and flip the overlay to a locked/green state with haptic feedback.</li>
@@ -668,7 +668,22 @@
     uncertain status has a second, fingerprint-less flavor (contour quality gate failed —
     <code>z_score = null</code>) for which the confirm chip would be a dead end
     (<code>on_uncertain=enroll</code> has nothing to enroll); the controller now maps it to a
-    distinct "couldn't read the piece" verdict that just keeps scanning. 110 iOS tests pass.
+    distinct "couldn't read the piece" verdict that just keeps scanning.
+    <br /><br />
+    <strong>Verified on the physical iPhone 15 with real pieces</strong> — and the device run drove
+    three same-day product fixes: (1) a stale (backend-restarted) puzzle id now self-heals — the
+    scanner's 404 triggers a re-upload and one retry, watched live as 404 → upload → lock; (2)
+    enrolled pieces now join the puzzle page's piece list as regular capture entries (position
+    prediction, overlay marker, disk persistence — which is also where gallery thumbnails come back
+    from on later scanner visits), with matched verdicts adding nothing so the list stays
+    duplicate-free; (3) enrollment went hands-free — M7's own measurement (97.9% of new pieces land
+    in the gray zone) meant the confirm chip cost one tap per piece, so <code>t_accept</code> moved
+    to M7's FMR=1% ROC point (−3.98; gray-zone re-scans ~26–30% → ~8% at 1% wrong-lock risk) and
+    gray-zone verdicts auto-enroll. Observed end state on-device: new piece → zero-tap lock →
+    enrolled → predicted → in the piece list; re-pointing at scanned pieces → "Already scanned" with
+    zero duplicates across repeated re-locks. Dark/black surfaces defeat the preview detector (no
+    outline, no lock) exactly as M1 predicted — wood and mid-tones work; the gray mat remains the
+    recommendation. 114 iOS + 212 backend tests pass.
   </div>
 </div>
 

--- a/docs/piece-geometry-scanning.html
+++ b/docs/piece-geometry-scanning.html
@@ -176,7 +176,8 @@
   <span class="kicker">Pussel · brainstorm &amp; living results log · 2026-07-16</span>
   <h1>The Second Column: Scanning Exact Piece Geometry</h1>
   <p class="subtitle" style="margin-top:0.5rem">
-    <strong>Status: Phases A, B, C complete; Phase D underway — M9 done, M10 next</strong>
+    <strong>Status: Phases A, B, C complete; Phase D underway — M9 done, M10 built and
+    Simulator-E2E-verified (on-device 10-piece run pending)</strong>
     (M1–M4, M6, M7 researched in <code>network/experiments/exp28_piece_geometry/</code> — detailed
     log: <code>HANDOFF.md</code> there; M5 deferred, optional; M8 shipped the stack as production
     backend code in <code>backend/app/services/piece_geometry/</code> with E2E verification on real
@@ -184,7 +185,7 @@
     Result blocks (◆) below record what each milestone actually found. The scoring stack:
     rembg contour → polydp corners → typed edges + canonical polylines → shape+spatial-color
     fingerprint → one z-sum score for ranking (95.2% top-1 cross-background) and thresholding
-    (M7 recipe). Next: M10, scan-and-lock.
+    (M7 recipe). Next: confirm M10's on-device success criterion, then M11 (neighbor suggestions).
   </p>
   <p class="subtitle">
     Today Pussel answers <em>"where in the picture does this piece go?"</em> by matching surface
@@ -641,13 +642,34 @@
 </div>
 
 <div class="milestone">
-  <h4><span class="mtag d">M10</span> Scan-and-lock: the "mark it green" moment <span class="badge next">NEXT ▶</span></h4>
+  <h4><span class="mtag d">M10</span> Scan-and-lock: the "mark it green" moment <span class="badge done">BUILT ✓ — device run pending</span></h4>
   <div class="meta">~3–4 sessions · the heart of the vision</div>
   <ul>
     <li>Stability tracking across frames (contour IoU between consecutive detections); when stable + quality-gated (sharpness, size, corner confidence), auto-capture a full-res frame, run full geometry extraction, and flip the overlay to a locked/green state with haptic feedback.</li>
     <li>Scanned pieces accumulate in a session gallery (thumbnail + edge-type glyph, e.g. <code>T·B·F·T</code>).</li>
   </ul>
   <div class="success">Scan 10 physical pieces in under 2 minutes, each locking automatically without pressing a shutter; re-pointing at an already-scanned piece shows "already scanned" instead of duplicating.</div>
+  <div class="outcome">
+    <strong>Implemented and E2E-verified in the Simulator against the real backend; the
+    10-physical-pieces criterion awaits the on-device run.</strong> A hands-free scan screen
+    (<code>PieceScanView</code>, opened from a viewfinder tile in the piece grid) reuses the M9
+    camera/streamer/overlay stack and adds a <code>PieceScanStabilityTracker</code> (bbox-IoU ≥ 0.8
+    between consecutive lockable detections, ≥ 1 s and ≥ 3 samples, latched) feeding a
+    <code>PieceScanController</code> state machine: stable → auto-capture (no shutter) → downscaled
+    JPEG → <code>POST …/piece/geometry</code> → verdict UX. <em>new</em> → green "Piece locked ✓
+    T·B·F·T" capsule + full-screen flash + success haptic + gallery add; <em>matched</em> → orange
+    "Already scanned" + warning haptic + highlight of the matching gallery tile (never a duplicate);
+    <em>uncertain</em> → scanning continues with a one-tap "add as new piece" chip that re-posts with
+    <code>on_uncertain=enroll</code>. The session gallery pre-fills from the GET endpoint (edge-type
+    glyphs; placeholder tile for pieces scanned in an earlier app run). All verdict paths were
+    exercised live in the Simulator via <code>pusseldebug://scan</code> + <code>previewloop</code>
+    with north_star photos: p001 enrolled, re-scan matched, gray-zone p002 confirmed-and-enrolled
+    (backend store verified via GET). The E2E again caught what unit tests couldn't: the backend's
+    uncertain status has a second, fingerprint-less flavor (contour quality gate failed —
+    <code>z_score = null</code>) for which the confirm chip would be a dead end
+    (<code>on_uncertain=enroll</code> has nothing to enroll); the controller now maps it to a
+    distinct "couldn't read the piece" verdict that just keeps scanning. 110 iOS tests pass.
+  </div>
 </div>
 
 <div class="milestone">

--- a/docs/piece-geometry-scanning.html
+++ b/docs/piece-geometry-scanning.html
@@ -1,0 +1,567 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Piece Geometry Scanning — Brainstorm &amp; Milestones</title>
+<style>
+  :root {
+    --bg: #f7f6f3;
+    --surface: #ffffff;
+    --ink: #1e2229;
+    --muted: #5c6470;
+    --line: #e3e0d8;
+    --accent: #b4551f;
+    --accent-soft: #f6e3d7;
+    --good: #2c6e49;
+    --good-soft: #e2efe7;
+    --warn: #8a5a00;
+    --warn-soft: #f7ecd4;
+    --risk: #9c2f2f;
+    --risk-soft: #f7e2e2;
+    --code-bg: #eeece6;
+    --phase-a: #2c5f8a;
+    --phase-b: #6d4c9f;
+    --phase-c: #2c6e49;
+    --phase-d: #b4551f;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #16181d;
+      --surface: #1f232b;
+      --ink: #e8e6e1;
+      --muted: #9aa1ac;
+      --line: #32363f;
+      --accent: #e08a55;
+      --accent-soft: #3a2a1f;
+      --good: #6fbf8f;
+      --good-soft: #1f3328;
+      --warn: #d9a94a;
+      --warn-soft: #362c17;
+      --risk: #e07a7a;
+      --risk-soft: #3a2222;
+      --code-bg: #2a2e37;
+      --phase-a: #6ea3cf;
+      --phase-b: #a98fd6;
+      --phase-c: #6fbf8f;
+      --phase-d: #e08a55;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font: 16px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  }
+  .wrap { max-width: 960px; margin: 0 auto; padding: 3rem 1.5rem 5rem; }
+  header h1 { font-size: 2rem; line-height: 1.2; margin: 0 0 0.5rem; }
+  header .subtitle { color: var(--muted); font-size: 1.05rem; max-width: 46rem; }
+  .kicker {
+    display: inline-block; font-size: 0.75rem; font-weight: 700; letter-spacing: 0.12em;
+    text-transform: uppercase; color: var(--accent); margin-bottom: 0.75rem;
+  }
+  nav.toc {
+    margin: 2rem 0; padding: 1rem 1.25rem; background: var(--surface);
+    border: 1px solid var(--line); border-radius: 10px; font-size: 0.95rem;
+  }
+  nav.toc strong { display: block; margin-bottom: 0.35rem; }
+  nav.toc a { color: var(--accent); text-decoration: none; }
+  nav.toc a:hover { text-decoration: underline; }
+  nav.toc ol { margin: 0; padding-left: 1.3rem; columns: 2; column-gap: 2.5rem; }
+  @media (max-width: 640px) { nav.toc ol { columns: 1; } }
+  h2 {
+    font-size: 1.45rem; margin: 3rem 0 1rem; padding-top: 1rem;
+    border-top: 2px solid var(--line);
+  }
+  h3 { font-size: 1.1rem; margin: 1.75rem 0 0.5rem; }
+  p { margin: 0.6rem 0 1rem; }
+  code {
+    font: 0.85em ui-monospace, "SF Mono", Menlo, monospace;
+    background: var(--code-bg); padding: 0.1em 0.35em; border-radius: 4px;
+  }
+  a { color: var(--accent); }
+  table {
+    width: 100%; border-collapse: collapse; margin: 1rem 0 1.5rem;
+    font-size: 0.92rem; background: var(--surface); border: 1px solid var(--line);
+    border-radius: 8px; overflow: hidden;
+  }
+  .tablewrap { overflow-x: auto; }
+  th, td { text-align: left; padding: 0.55rem 0.8rem; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { background: var(--code-bg); font-weight: 650; }
+  tr:last-child td { border-bottom: none; }
+  .pill {
+    display: inline-block; padding: 0.05rem 0.55rem; border-radius: 999px;
+    font-size: 0.75rem; font-weight: 650; white-space: nowrap;
+  }
+  .pill.have { background: var(--good-soft); color: var(--good); }
+  .pill.partial { background: var(--warn-soft); color: var(--warn); }
+  .pill.missing { background: var(--risk-soft); color: var(--risk); }
+  .callout {
+    margin: 1.25rem 0; padding: 0.9rem 1.1rem; border-radius: 8px;
+    border-left: 4px solid var(--accent); background: var(--accent-soft);
+  }
+  .callout.insight { border-left-color: var(--good); background: var(--good-soft); }
+  .callout.risk { border-left-color: var(--risk); background: var(--risk-soft); }
+  .callout strong:first-child { display: block; margin-bottom: 0.2rem; }
+
+  /* pipeline diagram */
+  .pipeline {
+    display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: stretch;
+    margin: 1.25rem 0;
+  }
+  .stage {
+    flex: 1 1 130px; min-width: 120px; background: var(--surface);
+    border: 1px solid var(--line); border-radius: 8px; padding: 0.6rem 0.7rem;
+    position: relative;
+  }
+  .stage .num {
+    font-size: 0.7rem; font-weight: 700; color: var(--accent);
+    letter-spacing: 0.08em; text-transform: uppercase;
+  }
+  .stage .name { font-weight: 650; font-size: 0.9rem; margin: 0.1rem 0; }
+  .stage .detail { font-size: 0.78rem; color: var(--muted); line-height: 1.4; }
+
+  /* milestones */
+  .milestone {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 10px;
+    padding: 1.1rem 1.3rem; margin: 1rem 0;
+  }
+  .milestone h4 { margin: 0 0 0.4rem; font-size: 1.02rem; display: flex; gap: 0.6rem; align-items: baseline; flex-wrap: wrap; }
+  .mtag {
+    font-size: 0.72rem; font-weight: 700; padding: 0.1rem 0.55rem; border-radius: 999px;
+    color: #fff; letter-spacing: 0.04em;
+  }
+  .mtag.a { background: var(--phase-a); }
+  .mtag.b { background: var(--phase-b); }
+  .mtag.c { background: var(--phase-c); }
+  .mtag.d { background: var(--phase-d); }
+  .milestone .meta { font-size: 0.85rem; color: var(--muted); margin-bottom: 0.5rem; }
+  .milestone ul { margin: 0.4rem 0; padding-left: 1.2rem; font-size: 0.93rem; }
+  .milestone .success {
+    margin-top: 0.6rem; font-size: 0.88rem; padding: 0.5rem 0.75rem;
+    background: var(--good-soft); color: var(--good); border-radius: 6px;
+  }
+  .milestone .success::before { content: "✓ Done when: "; font-weight: 700; }
+  .phasehead {
+    margin: 2.25rem 0 0.25rem; font-size: 0.8rem; font-weight: 700;
+    letter-spacing: 0.1em; text-transform: uppercase;
+  }
+  .phasehead.a { color: var(--phase-a); }
+  .phasehead.b { color: var(--phase-b); }
+  .phasehead.c { color: var(--phase-c); }
+  .phasehead.d { color: var(--phase-d); }
+  .phasedesc { color: var(--muted); font-size: 0.92rem; margin: 0 0 0.75rem; }
+  ul.compact { margin: 0.4rem 0 1rem; padding-left: 1.25rem; }
+  ul.compact li { margin: 0.25rem 0; }
+  footer { margin-top: 3.5rem; padding-top: 1rem; border-top: 1px solid var(--line); color: var(--muted); font-size: 0.85rem; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header>
+  <span class="kicker">Pussel · brainstorm · 2026-07-16</span>
+  <h1>The Second Column: Scanning Exact Piece Geometry</h1>
+  <p class="subtitle">
+    Today Pussel answers <em>"where in the picture does this piece go?"</em> by matching surface
+    texture (SIFT→NCC hybrid, 76.7% on real photos). This document explores the complementary
+    column: <em>"what is this piece's exact outer shape?"</em> — extracting the contour, the tabs
+    and blanks per side, fingerprinting pieces uniquely by geometry + color, and eventually doing
+    it live in the iOS camera preview, piece by piece, with scanned pieces highlighted as "locked".
+  </p>
+</header>
+
+<nav class="toc">
+  <strong>Contents</strong>
+  <ol>
+    <li><a href="#why">Why geometry is worth a column</a></li>
+    <li><a href="#have">What we already have</a></li>
+    <li><a href="#field">What the field says</a></li>
+    <li><a href="#pipeline">The proposed pipeline</a></li>
+    <li><a href="#decisions">Key design decisions</a></li>
+    <li><a href="#milestones">Milestones</a></li>
+    <li><a href="#risks">Risks &amp; mitigations</a></li>
+    <li><a href="#next">Suggested first step</a></li>
+  </ol>
+</nav>
+
+<h2 id="why">1 · Why geometry is worth a column</h2>
+<p>
+  The texture matcher answers a <em>global</em> question (position in the finished picture) and needs
+  the box-lid overview photo to do it. Geometry answers a <em>local</em> question — which pieces
+  physically interlock — and needs nothing but the pieces themselves. That makes it useful in
+  situations texture can't reach:
+</p>
+<ul class="compact">
+  <li><strong>Sky and solid-color regions</strong> where texture matching has nothing to grip — shape complementarity still works. (Existence proof: Stuff Made Here's robot assembled a 4000-piece <em>single-color</em> puzzle on shape alone.)</li>
+  <li><strong>Neighbor suggestions</strong>: "these 3 pieces likely attach to the piece you just placed" — shape narrows candidates, texture/color across the seam confirms.</li>
+  <li><strong>Unique piece identity</strong>: a persistent fingerprint (shape + surface color) lets the app remember pieces across frames and across sessions — the foundation for the "scan pieces one by one, mark them green" camera experience.</li>
+  <li><strong>A second, independent signal</strong> to fuse with the texture matcher — the two fail in different ways, so combining them should beat either alone.</li>
+</ul>
+
+<h2 id="have">2 · What we already have (repo inventory)</h2>
+<p>A surprising amount of this column already exists in pieces — including the hardest mathematical part.</p>
+
+<div class="tablewrap">
+<table>
+  <tr><th>Asset</th><th>Where</th><th>Status</th><th>Relevance</th></tr>
+  <tr>
+    <td><strong>Parametric piece model</strong> — 11-parameter <code>TabParameters</code> (neck width, bulb width, height, curvature, asymmetry…), cubic-Bezier edges, <code>PieceConfig</code> with 4 edge types (tab/blank/flat)</td>
+    <td><code>shared/puzzle_shapes/</code> (<code>models.py</code>, <code>geometry.py</code>)</td>
+    <td><span class="pill have">have</span></td>
+    <td>This is exactly the compact, semantic representation a scanned edge should be described in. It's JSON-serializable — a scanned piece becomes a tiny record.</td>
+  </tr>
+  <tr>
+    <td><strong>Contour→parameters fitter</strong> — PyTorch (MPS-capable) gradient optimization of <code>TabParameters</code> against a reference contour via chamfer / soft-Hausdorff loss; plus a scipy L-BFGS-B variant</td>
+    <td><code>network/docs/puzzle_shape_generation/scripts/optimize_torch.py</code>, <code>losses_torch.py</code>, <code>geometry_torch.py</code></td>
+    <td><span class="pill partial">exists, unwired</span></td>
+    <td><strong>The single biggest head start.</strong> "Given a photographed contour, find the parameters that reproduce it" is already solved — but only ever run against 6 curated reference PNGs, never real camera photos, and not wired into the backend.</td>
+  </tr>
+  <tr>
+    <td><strong>Contour comparison toolkit</strong> — contour extraction from masks, arc-length resampling, IoU, mean contour distance, Hausdorff</td>
+    <td><code>network/docs/puzzle_shape_generation/scripts/shape_comparator.py</code></td>
+    <td><span class="pill have">have</span></td>
+    <td>Ready-made metrics for every evaluation milestone below.</td>
+  </tr>
+  <tr>
+    <td><strong>Piece segmentation in photos</strong> — rembg background removal, largest-alpha-component contour, skin rejection, confidence scoring; already powers a live-preview endpoint (<code>/api/v1/piece/preview</code>)</td>
+    <td><code>backend/app/services/piece_detector.py</code>, <code>background_remover.py</code>, <code>piece_classifier.py</code></td>
+    <td><span class="pill partial">coarse</span></td>
+    <td>Finds the piece and a rough ≤60-point polygon for UI overlay. Needs upgrading to a precise, full-resolution closed contour — but the plumbing (frame in → detection out) exists and is production-tested.</td>
+  </tr>
+  <tr>
+    <td><strong>Real-photo evaluation dataset</strong> — north_star: 14 puzzles, 236 pieces, each photographed on 4 different backgrounds, with known grid position per piece</td>
+    <td><code>network/datasets/north_star/v1/</code> (local, regenerated via <code>ingest.py</code>)</td>
+    <td><span class="pill have">have</span></td>
+    <td>Perfect for this column: known grid positions mean <em>true neighbor pairs are known</em> (ground truth for edge matching), and the same piece on 4 backgrounds is a natural re-identification test set.</td>
+  </tr>
+  <tr>
+    <td><strong>iOS camera plumbing</strong> — persistent <code>AVCaptureSession</code>, live preview layer, photo capture, multipart upload to backend</td>
+    <td><code>ios/Pussel/Features/Solve/PieceCameraSession.swift</code>, <code>PieceCaptureView.swift</code>, <code>APIClient.swift</code></td>
+    <td><span class="pill partial">single-shot only</span></td>
+    <td>Live preview exists but no frame analysis or overlay — capture is one manual photo. Notably the web frontend already streams preview frames to the backend for live outline overlay; iOS never adopted that endpoint.</td>
+  </tr>
+  <tr>
+    <td><strong>On-device vision (iOS)</strong> — Vision framework, Core ML, per-frame processing</td>
+    <td>—</td>
+    <td><span class="pill missing">none</span></td>
+    <td>Greenfield. Apple's <code>VNDetectContoursRequest</code> is purpose-built for "find the outline" and is the obvious first thing to spike.</td>
+  </tr>
+  <tr>
+    <td><strong>Corner detection / edge splitting / tab-blank classification from photos</strong></td>
+    <td>—</td>
+    <td><span class="pill missing">none</span></td>
+    <td>The genuinely new algorithmic work of this column (§4, stages 4–5).</td>
+  </tr>
+  <tr>
+    <td><strong>Piece fingerprint / identity database</strong></td>
+    <td>—</td>
+    <td><span class="pill missing">none</span></td>
+    <td>All current matching is piece-vs-overview. There is no concept of "this specific piece, seen before" anywhere.</td>
+  </tr>
+</table>
+</div>
+
+<div class="callout insight">
+  <strong>Key realization</strong>
+  The project already contains both ends of the pipeline — segmentation of real photos (backend) and
+  fitting of the parametric shape model to a contour (shape-generation scripts). What's missing is the
+  middle: turning a raw photo contour into <em>four labeled, normalized edges</em>. That middle is
+  well-trodden ground in the literature (§3), not research risk.
+</div>
+
+<h2 id="field">3 · What the field says (research findings)</h2>
+
+<h3>The consistent recipe across every working real-photo solver</h3>
+<p>
+  Independent projects (Wolfson et&nbsp;al. 1988 — the 104-piece original; kellinwood/PuzzleSolver; Zolver;
+  byWulf/jigsawlutioner; several writeups) converge on essentially the same pipeline, which is strong
+  evidence it's the right default:
+</p>
+<ul class="compact">
+  <li><strong>Capture is everything.</strong> Every successful project controls the background — flatbed scanner with lid open, black mat, or a backlit lightbox. Segmentation is then trivial thresholding. The capture setup, not the algorithm, determines whether downstream steps work.</li>
+  <li><strong>Corner detection is the fragile step.</strong> Every project either documents failure modes or ships a manual-correction UI. Approaches: <code>approxPolyDP</code>, Harris corners + "most rectangular 4-subset" selection, Shi-Tomasi with distance constraints, curvature extrema along the boundary. Plan for occasional human-in-the-loop correction.</li>
+  <li><strong>Tab/blank/flat classification is considered solved.</strong> Draw the chord between adjacent corners; if the contour midpoint bulges away from the centroid → tab, toward it → blank, on the chord → flat. Multiple independent implementations, no reported trouble.</li>
+  <li><strong>Edge matching = arc-length resample + chamfer-style distance.</strong> Normalize each side (translate/rotate to axis-aligned), resample to N equidistant points (~100), compare a side against a <em>flipped</em> candidate side by summed closest-point distance. Some projects use ~6 hand-engineered scalars instead (protrusion width/depth/position) — cheaper, more interpretable, hashable.</li>
+</ul>
+
+<h3>Findings that shape our design</h3>
+<ul class="compact">
+  <li><strong>Shape alone is not a unique fingerprint on most puzzles.</strong> jigsawlutioner's operational finding: geometric matching works reliably only on Ravensburger; most manufacturers reuse near-identical die-cut tab shapes across many pieces. <em>Color/texture disambiguation is mandatory</em> for identity — geometry proposes, appearance confirms. This validates the vision's instinct to combine both.</li>
+  <li><strong>Perspective must be corrected in software.</strong> Hobby projects dodge it with scanners; Stuff Made Here dodged it with a telecentric lens. For a phone, a known mat (ArUco/ChArUco fiducials) gives both metric scale (px→mm) and a homography to rectify tilt. A few degrees of uncorrected tilt distorts tab geometry enough to break matching.</li>
+  <li><strong>ARKit/LiDAR depth is the wrong tool</strong> — ~1–3&nbsp;cm accuracy vs. sub-millimeter-relevant tab features. Use 2D + fiducial. ARKit is still useful as capture <em>guidance</em> (hold flat, hold steady).</li>
+  <li><strong>On-device contouring is available for free:</strong> Apple's <code>VNDetectContoursRequest</code> (iOS 14+) returns outline paths in real time and is explicitly tuned for high-contrast scenes — which our controlled-mat capture provides anyway. Deep segmentation (MobileSAM/FastSAM via Core ML) is the fallback for uncontrolled backgrounds, not the starting point.</li>
+  <li><strong>No prior art found for persistent cross-session piece fingerprinting</strong> — the closest analogue is person/vehicle re-identification (feature vector + nearest-neighbor with threshold, never exact hash equality). This part of the vision is a genuine gap/opportunity.</li>
+</ul>
+
+<div class="callout risk">
+  <strong>The one hard constraint to internalize</strong>
+  Everything downstream of capture degrades together: shadows read as contour, tilt warps tabs, motion
+  blur kills corners. The cheapest, highest-leverage "algorithm" in this whole column is a
+  <em>defined capture protocol</em> — a plain mat (possibly printed with fiducials), near-overhead
+  phone, diffuse light. Milestone 1 exists to establish exactly this before any clever code.
+</div>
+
+<h2 id="pipeline">4 · The proposed pipeline</h2>
+<p>One frame (or photo) in, one structured piece record out:</p>
+
+<div class="pipeline">
+  <div class="stage"><div class="num">1</div><div class="name">Capture</div><div class="detail">Controlled mat, near-overhead. Optional ArUco corners for scale + tilt.</div></div>
+  <div class="stage"><div class="num">2</div><div class="name">Rectify</div><div class="detail">Homography from fiducials (or skip in v1: assume flat overhead).</div></div>
+  <div class="stage"><div class="num">3</div><div class="name">Segment + contour</div><div class="detail">rembg / threshold / VNDetectContours → one closed, full-res contour.</div></div>
+  <div class="stage"><div class="num">4</div><div class="name">Find 4 corners</div><div class="detail">Curvature extrema / Harris + rectangular-subset. The fragile step.</div></div>
+  <div class="stage"><div class="num">5</div><div class="name">Split + classify</div><div class="detail">4 edge segments; chord-midpoint test → tab / blank / flat.</div></div>
+  <div class="stage"><div class="num">6</div><div class="name">Describe</div><div class="detail">Per edge: resampled polyline + fitted TabParameters (our 11-param model).</div></div>
+  <div class="stage"><div class="num">7</div><div class="name">Fingerprint</div><div class="detail">Rotation-invariant shape descriptor + color histogram / patch embedding.</div></div>
+  <div class="stage"><div class="num">8</div><div class="name">Match</div><div class="detail">Identity: nearest-neighbor vs. seen pieces. Fit: edge vs. inverted candidate edges.</div></div>
+</div>
+
+<h3>The piece record (sketch)</h3>
+<p>
+  Each scanned piece becomes a small JSON document — this is what gets stored, deduplicated against,
+  and matched:
+</p>
+<ul class="compact">
+  <li><code>contour</code>: full-res closed polygon (px), plus mm scale if fiducials present</li>
+  <li><code>corners</code>: 4 indices into the contour + confidence</li>
+  <li><code>edges[4]</code>: type (tab/blank/flat), normalized 100-point polyline, fitted <code>TabParameters</code>, fit residual</li>
+  <li><code>appearance</code>: color histogram (LAB) + small patch embedding of the piece face</li>
+  <li><code>fingerprint</code>: rotation-invariant combination of the above (canonical edge ordering, e.g. start from lexicographically smallest edge descriptor)</li>
+  <li><code>quality</code>: sharpness, contour smoothness, corner confidence — gates "locked" status in the live UX</li>
+</ul>
+
+<div class="callout">
+  <strong>Why fit TabParameters at all, when a resampled polyline suffices for matching?</strong>
+  Three reasons: (1) it's a 11-number semantic compression — cheap to store, index, and hash;
+  (2) the fit residual is a built-in <em>quality score</em> ("this contour doesn't look like a puzzle
+  edge" → bad scan, don't lock); (3) it closes the loop with the synthetic training pipeline — real
+  fitted parameter distributions can drive more realistic synthetic data (feeding back into the
+  first column). The polyline stays alongside as ground truth; the parameters are the summary.
+</div>
+
+<h2 id="decisions">5 · Key design decisions (and recommendations)</h2>
+<div class="tablewrap">
+<table>
+  <tr><th>Decision</th><th>Options</th><th>Recommendation</th></tr>
+  <tr>
+    <td>Where does extraction run?</td>
+    <td>Backend (Python/OpenCV, reuse everything) vs. on-device (Vision/Core ML, low latency)</td>
+    <td><strong>Backend first.</strong> The iOS preview-streaming pattern already exists (web frontend uses it). Move on-device only for the frame-rate-critical part (stage 3 rough outline for the live overlay) once the algorithm is settled. Don't fight two problems (algorithm + Swift port) at once.</td>
+  </tr>
+  <tr>
+    <td>Metric scale?</td>
+    <td>Fiducial mat (ArUco) vs. relative-only (normalize by piece size)</td>
+    <td><strong>Relative-only in v1.</strong> Edge <em>matching</em> only needs consistent relative geometry between pieces from the same session/puzzle. Add the printable fiducial mat when cross-session metric identity or tilt correction proves necessary (M2 will tell us).</td>
+  </tr>
+  <tr>
+    <td>Edge representation for matching?</td>
+    <td>Resampled polyline + chamfer vs. fitted parameters vs. hand-engineered scalars</td>
+    <td><strong>Polyline + chamfer as ground truth</strong>, parameters as compression/quality-gate. Benchmark both in M4 — if parameter-space distance ranks neighbors nearly as well, it wins on speed and storage.</td>
+  </tr>
+  <tr>
+    <td>Live scanning UX granularity?</td>
+    <td>Continuous auto-scan of whatever's in frame vs. one-piece-at-a-time with explicit lock</td>
+    <td><strong>One piece at a time with visible lock state</strong> (matches the stated vision). Simpler tracking, natural quality gating, satisfying UX. Multi-piece-in-frame is a later enhancement.</td>
+  </tr>
+  <tr>
+    <td>Identity threshold?</td>
+    <td>Fixed similarity cutoff vs. calibrated per-puzzle</td>
+    <td>Defer — M6/M7 produce the data (impostor vs. genuine similarity distributions on north_star) to choose empirically.</td>
+  </tr>
+</table>
+</div>
+
+<h2 id="milestones">6 · Milestones</h2>
+<p>
+  Ordered so each one is small, independently valuable, and produces a <em>number</em> or a
+  <em>demo</em> — never "infrastructure only". Phases A–B are pure Python against existing photos
+  (no new hardware, no iOS work); the camera experience comes last, once the algorithm is proven.
+</p>
+
+<p class="phasehead a">Phase A · Offline geometry extraction (Python, north_star photos)</p>
+<p class="phasedesc">Prove we can turn an existing real photo into four labeled edges. Everything runs as scripts in <code>network/experiments/</code>, evaluated with contact sheets like exp25.</p>
+
+<div class="milestone">
+  <h4><span class="mtag a">M1</span> High-fidelity contour extraction</h4>
+  <div class="meta">~2–4 sessions · builds on <code>piece_detector.py</code> + <code>background_remover.py</code></div>
+  <ul>
+    <li>Upgrade the existing rembg pipeline from "≤60-point UI polygon" to a full-resolution, smoothed, closed contour (mask → morphological cleanup → <code>findContours</code> → light smoothing).</li>
+    <li>Run over all 236 north_star pieces × 4 backgrounds; render overlay contact sheets for eyeball review.</li>
+    <li>Note which backgrounds fail (the red carpet will be the stress test) — this <em>defines the capture protocol</em> for the eventual scanning mat.</li>
+  </ul>
+  <div class="success">≥95% of pieces yield a single clean closed contour on at least the 2 friendly backgrounds; failure modes are catalogued.</div>
+</div>
+
+<div class="milestone">
+  <h4><span class="mtag a">M2</span> Corner detection bake-off</h4>
+  <div class="meta">~3–5 sessions · the known-fragile step, so measure it properly</div>
+  <ul>
+    <li>Hand-label 4 corners on a ~60-piece subset (tiny matplotlib click tool — an afternoon).</li>
+    <li>Implement 2–3 candidates: curvature extrema along the contour; Harris/Shi-Tomasi + "most rectangular 4-subset"; <code>approxPolyDP</code> baseline.</li>
+    <li>Benchmark corner error (as % of piece size) per method per background.</li>
+  </ul>
+  <div class="success">Best method places all 4 corners within 3% of piece size on ≥90% of the subset; we know its failure modes well enough to design the manual-nudge fallback.</div>
+</div>
+
+<div class="milestone">
+  <h4><span class="mtag a">M3</span> Edge splitting + tab/blank/flat classification</h4>
+  <div class="meta">~1–2 sessions · literature says this is the easy part</div>
+  <ul>
+    <li>Split contour at corners into 4 arcs; chord-midpoint-vs-centroid test per arc.</li>
+    <li>Ground truth is nearly free: north_star grid positions tell us which edges are flat (border pieces), and interlocking neighbors constrain tab/blank parity — hand-verify the remainder on contact sheets.</li>
+  </ul>
+  <div class="success">≥98% edge-type accuracy across all cleanly-contoured pieces. Output: every north_star piece stored as a draft piece record (contour + corners + 4 typed edges).</div>
+</div>
+
+<div class="milestone">
+  <h4><span class="mtag a">M4</span> Edge complementarity matching — the first payoff</h4>
+  <div class="meta">~3–4 sessions · the milestone that proves the column's core value</div>
+  <ul>
+    <li>Normalize each edge (rotate to axis, arc-length resample to 100 points); match edge A against flipped edge B via chamfer distance. Also try the ~6-scalar descriptor variant.</li>
+    <li>Evaluation is beautiful here: north_star grid positions give every true neighbor pair. For each interior edge, rank all candidate mating edges in the same puzzle — where does the true neighbor rank?</li>
+  </ul>
+  <div class="success">Report: true mating edge ranked #1 for X% of edges, top-5 for Y% — per puzzle brand. This number tells us how strong the geometry signal is on our actual puzzles (the jigsawlutioner brand-dependence question, answered with our data).</div>
+</div>
+
+<div class="milestone">
+  <h4><span class="mtag a">M5</span> Fit TabParameters to real edges (optional, parallel)</h4>
+  <div class="meta">~2–3 sessions · reuses <code>optimize_torch.py</code> nearly as-is</div>
+  <ul>
+    <li>Wire M3's edge arcs into the existing chamfer/Hausdorff parameter fitter; record fit residuals.</li>
+    <li>Compare real fitted parameter distributions against the synthetic generator's <code>TabParameters.random()</code> ranges — a free realism audit of the synthetic pipeline.</li>
+  </ul>
+  <div class="success">Median fit residual below an agreed IoU/chamfer threshold on tab/blank edges; a plot of real vs. synthetic parameter distributions (feeds back into the CNN column).</div>
+</div>
+
+<p class="phasehead b">Phase B · Piece identity</p>
+<p class="phasedesc">From "an edge matches an edge" to "I recognize this specific piece" — the prerequisite for the scan-and-lock UX.</p>
+
+<div class="milestone">
+  <h4><span class="mtag b">M6</span> Piece fingerprint + re-identification benchmark</h4>
+  <div class="meta">~3–4 sessions · north_star's 4-backgrounds-per-piece design was made for this</div>
+  <ul>
+    <li>Fingerprint = rotation-invariant shape descriptor (canonically ordered 4-edge descriptors) + LAB color histogram (+ optionally a small patch embedding).</li>
+    <li>Re-ID protocol: enroll each piece from background 1, query with backgrounds 2–4 (different lighting/surface), nearest-neighbor over all 236 pieces.</li>
+    <li>Ablate: shape only vs. color only vs. combined.</li>
+  </ul>
+  <div class="success">Top-1 re-ID ≥95% combined, with the ablation quantifying how much each signal contributes.</div>
+</div>
+
+<div class="milestone">
+  <h4><span class="mtag b">M7</span> Uniqueness / collision study</h4>
+  <div class="meta">~1–2 sessions · mostly analysis on M6's data</div>
+  <ul>
+    <li>Genuine-vs-impostor similarity distributions; per-brand shape collision rates (do our kids' puzzles reuse die-cut shapes like jigsawlutioner warns?).</li>
+    <li>Choose the "locked" confidence threshold for the live UX from these curves.</li>
+  </ul>
+  <div class="success">A documented threshold with expected false-match / false-new-piece rates.</div>
+</div>
+
+<p class="phasehead c">Phase C · Backend service</p>
+<p class="phasedesc">Package Phase A+B as an API — one focused milestone, since the service plumbing pattern already exists.</p>
+
+<div class="milestone">
+  <h4><span class="mtag c">M8</span> <code>/api/v1/piece/geometry</code> endpoint + session piece store</h4>
+  <div class="meta">~2–3 sessions · mirrors the existing preview/process endpoints</div>
+  <ul>
+    <li>Photo in → piece record out (contour, corners, edge types, descriptors, fingerprint, quality score).</li>
+    <li>Per-puzzle piece store with dedupe: posting a piece answers "new piece" vs. "seen before (id=…)" using the M7 threshold.</li>
+    <li>Extend the existing <code>/piece/preview</code> response with contour quality + a "lockable" flag, so a live client can drive the scan UX without a new streaming protocol.</li>
+  </ul>
+  <div class="success">curl a north_star photo → correct structured record; posting the same piece on two backgrounds returns the same piece id.</div>
+</div>
+
+<p class="phasehead d">Phase D · iOS live scanning experience</p>
+<p class="phasedesc">Only now touch Swift — with a proven algorithm behind a stable API. Split into three small steps so each is demoable on-device.</p>
+
+<div class="milestone">
+  <h4><span class="mtag d">M9</span> Live outline overlay in the iOS preview</h4>
+  <div class="meta">~2–3 sessions · iOS catches up to what the web frontend already does</div>
+  <ul>
+    <li>Add an <code>AVCaptureVideoDataOutput</code> frame tap to the existing <code>PieceCameraSession</code>; throttle-stream downscaled frames to the (extended) preview endpoint; draw the returned polygon over the preview layer.</li>
+    <li>Optional spike alongside: on-device <code>VNDetectContoursRequest</code> for the rough outline at full frame rate, with the backend doing the precise work — decide based on felt latency.</li>
+  </ul>
+  <div class="success">Point phone at a piece → its outline appears live within ~300ms and tracks as the piece/phone moves.</div>
+</div>
+
+<div class="milestone">
+  <h4><span class="mtag d">M10</span> Scan-and-lock: the "mark it green" moment</h4>
+  <div class="meta">~3–4 sessions · the heart of the vision</div>
+  <ul>
+    <li>Stability tracking across frames (contour IoU between consecutive detections); when stable + quality-gated (sharpness, size, corner confidence), auto-capture a full-res frame, run full geometry extraction, and flip the overlay to a locked/green state with haptic feedback.</li>
+    <li>Scanned pieces accumulate in a session gallery (thumbnail + edge-type glyph, e.g. <code>T·B·F·T</code>).</li>
+  </ul>
+  <div class="success">Scan 10 physical pieces in under 2 minutes, each locking automatically without pressing a shutter; re-pointing at an already-scanned piece shows "already scanned" instead of duplicating.</div>
+</div>
+
+<div class="milestone">
+  <h4><span class="mtag d">M11</span> Neighbor suggestions — the two columns meet</h4>
+  <div class="meta">~3–5 sessions · first user-visible fusion of geometry + texture</div>
+  <ul>
+    <li>For any scanned piece, rank other scanned pieces by edge complementarity (M4 matcher), confirmed by color continuity across the seam; show "likely neighbors" in the gallery.</li>
+    <li>Fuse with the existing texture matcher's position prediction: geometry proposes local fits, texture anchors global position — flag disagreements.</li>
+  </ul>
+  <div class="success">On a scanned 24-piece kids' puzzle, the true neighbor appears in the top-3 suggestions for ≥80% of edges.</div>
+</div>
+
+<h2 id="risks">7 · Risks &amp; mitigations</h2>
+<div class="tablewrap">
+<table>
+  <tr><th>Risk</th><th>Likelihood</th><th>Mitigation</th></tr>
+  <tr>
+    <td>Corner detection unreliable on real photos (the field's universal pain point)</td>
+    <td>High</td>
+    <td>M2 measures it before anything depends on it; design the piece record to carry corner confidence; plan a one-tap manual nudge in the app as the escape hatch.</td>
+  </tr>
+  <tr>
+    <td>Shape collisions — our puzzle brands reuse die-cut tab shapes, weakening geometry-only matching</td>
+    <td>Medium–high (kids' puzzles are rarely Ravensburger-grade)</td>
+    <td>Exactly why the fingerprint is shape <em>+ color</em> from day one; M4/M7 quantify the problem per brand instead of discovering it in production.</td>
+  </tr>
+  <tr>
+    <td>Perspective tilt distorts tab geometry from handheld capture</td>
+    <td>Medium</td>
+    <td>v1 relies on capture guidance (level indicator via device gyro, "hold overhead" UI); printable ArUco mat as the upgrade path if M4 numbers degrade on handheld vs. tripod shots.</td>
+  </tr>
+  <tr>
+    <td>Latency of the stream-to-backend loop makes live scanning feel sluggish</td>
+    <td>Medium</td>
+    <td>Hybrid path is designed in: cheap on-device VNDetectContours for the live overlay, backend for the precise lock-time extraction. Decide with real numbers in M9.</td>
+  </tr>
+  <tr>
+    <td>north_star photos (upright, arrow marker, curated) are easier than live handheld frames</td>
+    <td>Certain, by design</td>
+    <td>Fine for algorithm development; M10's success criterion is on live physical pieces, and a small "handheld capture" photo set can be added to north_star once the protocol from M1 is settled.</td>
+  </tr>
+  <tr>
+    <td>rembg (u2net) too slow or imprecise for full-res contour work</td>
+    <td>Low–medium</td>
+    <td>On a controlled mat, classical thresholding may beat it — M1 compares both. rembg stays the fallback for messy backgrounds.</td>
+  </tr>
+</table>
+</div>
+
+<h2 id="next">8 · Suggested first step</h2>
+<p>
+  <strong>Start with M1 + M2 together as a single experiment</strong> (e.g.
+  <code>network/experiments/exp28_piece_geometry/</code>): full-res contours over north_star, corner
+  bake-off with a small hand-labeled set, contact sheets for review. It needs no new photos, no iOS
+  work, no new dependencies, and it retires the two biggest unknowns — contour fidelity and corner
+  reliability — before anything is built on top of them. M4 (neighbor-edge ranking) is then the first
+  moment the whole column proves its worth with one number.
+</p>
+<p>
+  A parallel cheap spike, if appetite allows: a ~1-hour Xcode playground pointing
+  <code>VNDetectContoursRequest</code> at a piece on the gray mat, just to see on-device outline
+  quality and frame rate first-hand. It doesn't block anything, and it informs the M9 build-vs-stream
+  decision early.
+</p>
+
+<footer>
+  Prepared 2026-07-16 · Sources: repo survey of <code>shared/puzzle_shapes</code>, <code>backend/app/services</code>, <code>ios/Pussel</code>, <code>network/experiments</code>; literature &amp; project survey incl. Wolfson et&nbsp;al. 1988, Goldberg et&nbsp;al. 2004, kellinwood/PuzzleSolver, byWulf/jigsawlutioner, Zolver, Apple Vision docs (VNDetectContoursRequest), ArUco/ChArUco calibration references, MobileSAM/EdgeSAM mobile-segmentation reports.
+</footer>
+
+</div>
+</body>
+</html>

--- a/docs/piece-geometry-scanning.html
+++ b/docs/piece-geometry-scanning.html
@@ -176,13 +176,14 @@
   <span class="kicker">Pussel · brainstorm &amp; living results log · 2026-07-16</span>
   <h1>The Second Column: Scanning Exact Piece Geometry</h1>
   <p class="subtitle" style="margin-top:0.5rem">
-    <strong>Status: Phase A + Phase B complete</strong> (M1–M4, M6, M7 in
-    <code>network/experiments/exp28_piece_geometry/</code>; detailed log: <code>HANDOFF.md</code> there;
-    M5 deferred, optional). Result blocks (◆) below record what each milestone actually found.
-    The production scoring stack is settled: rembg contour → polydp corners → typed edges +
-    canonical polylines → shape+spatial-color fingerprint → one z-sum score for both ranking
-    (95.2% top-1 cross-background) and thresholding (M7 recipe). Next: Phase C (M8, backend
-    endpoint).
+    <strong>Status: Phases A, B, and C complete</strong> (M1–M4, M6, M7 researched in
+    <code>network/experiments/exp28_piece_geometry/</code> — detailed log: <code>HANDOFF.md</code> there;
+    M5 deferred, optional; M8 shipped the stack as production backend code in
+    <code>backend/app/services/piece_geometry/</code> with E2E verification on real photos).
+    Result blocks (◆) below record what each milestone actually found. The scoring stack:
+    rembg contour → polydp corners → typed edges + canonical polylines → shape+spatial-color
+    fingerprint → one z-sum score for ranking (95.2% top-1 cross-background) and thresholding
+    (M7 recipe). Next: Phase D (M9, iOS live overlay).
   </p>
   <p class="subtitle">
     Today Pussel answers <em>"where in the picture does this piece go?"</em> by matching surface
@@ -586,7 +587,7 @@
 <p class="phasedesc">Package Phase A+B as an API — one focused milestone, since the service plumbing pattern already exists.</p>
 
 <div class="milestone">
-  <h4><span class="mtag c">M8</span> <code>/api/v1/piece/geometry</code> endpoint + session piece store <span class="badge next">NEXT ▶</span></h4>
+  <h4><span class="mtag c">M8</span> <code>/api/v1/piece/geometry</code> endpoint + session piece store <span class="badge done">DONE ✓</span></h4>
   <div class="meta">~2–3 sessions · mirrors the existing preview/process endpoints</div>
   <ul>
     <li>Photo in → piece record out (contour, corners, edge types, descriptors, fingerprint, quality score).</li>
@@ -594,13 +595,28 @@
     <li>Extend the existing <code>/piece/preview</code> response with contour quality + a "lockable" flag, so a live client can drive the scan UX without a new streaming protocol.</li>
   </ul>
   <div class="success">curl a north_star photo → correct structured record; posting the same piece on two backgrounds returns the same piece id.</div>
+  <div class="outcome">
+    <strong>Criterion met, verified end-to-end with real photos against a running backend.</strong> The
+    exp28 stack now lives in <code>backend/app/services/piece_geometry/</code> (scipy-free port with
+    equivalence tests; edges contour-ordered since production orientation is unknown). The acceptance
+    sequence: piece → <code>new p001</code> (lockable, correct edge types); same physical piece on a
+    different background → <code>matched p001</code> at z=−5.77; a different piece → <code>uncertain</code>
+    (z=−2.0, correctly conservative per M7); resolved via the new <code>on_uncertain=enroll</code> param →
+    <code>p002</code>; that piece on a third background → <code>matched p002</code> at z=−4.90. Both
+    cross-background matches cleared the strict threshold — same-mat production scans have more margin.
+    Two gaps that only real-photo E2E caught (synthetic tests all passed): the service had to crop to
+    the largest alpha component before the calibrated pipeline (exp28's frame of reference), and the
+    gray zone needed an explicit client-resolvable enroll path — M7's "97.9% of new pieces land in the
+    gray zone" finding, now baked into the API contract. The preview endpoint gained an opt-in
+    <code>lockable</code> flag for M9/M10. 212 backend tests pass.
+  </div>
 </div>
 
 <p class="phasehead d">Phase D · iOS live scanning experience</p>
 <p class="phasedesc">Only now touch Swift — with a proven algorithm behind a stable API. Split into three small steps so each is demoable on-device.</p>
 
 <div class="milestone">
-  <h4><span class="mtag d">M9</span> Live outline overlay in the iOS preview</h4>
+  <h4><span class="mtag d">M9</span> Live outline overlay in the iOS preview <span class="badge next">NEXT ▶</span></h4>
   <div class="meta">~2–3 sessions · iOS catches up to what the web frontend already does</div>
   <ul>
     <li>Add an <code>AVCaptureVideoDataOutput</code> frame tap to the existing <code>PieceCameraSession</code>; throttle-stream downscaled frames to the (extended) preview endpoint; draw the returned polygon over the preview layer.</li>

--- a/docs/piece-geometry-scanning.html
+++ b/docs/piece-geometry-scanning.html
@@ -176,11 +176,13 @@
   <span class="kicker">Pussel · brainstorm &amp; living results log · 2026-07-16</span>
   <h1>The Second Column: Scanning Exact Piece Geometry</h1>
   <p class="subtitle" style="margin-top:0.5rem">
-    <strong>Status:</strong> M1–M4 and M6 completed in <code>network/experiments/exp28_piece_geometry/</code>
-    (detailed log: <code>HANDOFF.md</code> there). Result blocks (◆) below record what each milestone
-    actually found. M5 deferred (optional). M6's ≥95% criterion was not met on the harsh
-    cross-background benchmark (91.5%) but the gap is isolated to wood-query capture quality.
-    M7 is next.
+    <strong>Status: Phase A + Phase B complete</strong> (M1–M4, M6, M7 in
+    <code>network/experiments/exp28_piece_geometry/</code>; detailed log: <code>HANDOFF.md</code> there;
+    M5 deferred, optional). Result blocks (◆) below record what each milestone actually found.
+    The production scoring stack is settled: rembg contour → polydp corners → typed edges +
+    canonical polylines → shape+spatial-color fingerprint → one z-sum score for both ranking
+    (95.2% top-1 cross-background) and thresholding (M7 recipe). Next: Phase C (M8, backend
+    endpoint).
   </p>
   <p class="subtitle">
     Today Pussel answers <em>"where in the picture does this piece go?"</em> by matching surface
@@ -523,7 +525,7 @@
 <p class="phasedesc">From "an edge matches an edge" to "I recognize this specific piece" — the prerequisite for the scan-and-lock UX.</p>
 
 <div class="milestone">
-  <h4><span class="mtag b">M6</span> Piece fingerprint + re-identification benchmark <span class="badge done">DONE — CRITERION NOT MET</span></h4>
+  <h4><span class="mtag b">M6</span> Piece fingerprint + re-identification benchmark <span class="badge done">DONE — MET VIA M7 SCORER</span></h4>
   <div class="meta">~3–4 sessions · north_star's 4-backgrounds-per-piece design was made for this</div>
   <ul>
     <li>Fingerprint = rotation-invariant shape descriptor (canonically ordered 4-edge descriptors) + LAB color histogram (+ optionally a small patch embedding).</li>
@@ -546,25 +548,45 @@
     up to 96.2% top-1 / 99.6% top-5. Production outlook: the app's same-mat, same-session scenario
     is strictly easier than every benchmarked cell — ≥95% looks realistic on the gray mat, but
     proving it needs a same-background repeat-capture set. Fix path: capture-time exposure/WB
-    control, not more descriptor engineering.
+    control, not more descriptor engineering. <strong>Addendum from M7:</strong> the distance-space
+    z-sum scorer built for thresholding turned out to also be the best retriever —
+    <strong>95.2% top-1 on the same leakage-free cells (independently verified), retroactively
+    meeting the ≥95% criterion</strong>; non-wood queries run 96.3–96.9%.
   </div>
 </div>
 
 <div class="milestone">
-  <h4><span class="mtag b">M7</span> Uniqueness / collision study <span class="badge next">NEXT ▶</span></h4>
+  <h4><span class="mtag b">M7</span> Uniqueness / collision study <span class="badge done">DONE ✓</span></h4>
   <div class="meta">~1–2 sessions · mostly analysis on M6's data</div>
   <ul>
     <li>Genuine-vs-impostor similarity distributions; per-brand shape collision rates (do our kids' puzzles reuse die-cut shapes like jigsawlutioner warns?).</li>
     <li>Choose the "locked" confidence threshold for the live UX from these curves.</li>
   </ul>
   <div class="success">A documented threshold with expected false-match / false-new-piece rates.</div>
+  <div class="outcome">
+    <strong>Criterion met — a documented two-threshold recipe with measured error rates</strong>, plus
+    two findings that reshape the column. The recipe: score z = z_shape + z_spatial (each z-normalized
+    by the enroll gallery's own impostor statistics, which proved nearly identical across galleries —
+    so one threshold transfers). Frozen on validation cells, measured on the 9 leakage-free cells:
+    <strong>auto-lock at z &lt; −4.78 (0.19% wrong-lock, 1.08% false-merge of new pieces),
+    declare-new at z &gt; −0.80 (0.89% false-new)</strong>, gray zone in between (~26–30% of genuine
+    re-scans at strict settings; relaxing to the FMR=1% point cuts that to ~8% — a product decision,
+    both points on the shipped ROC; EER 2.29%). Note for the UX: 97.9% of genuinely-new pieces land
+    in the gray zone, so "not accepted" is the practical new-piece signal. Finding #1:
+    <strong>zero full-piece die-cut collisions</strong> across all 1,695 distinct within-puzzle pairs —
+    every nearest pair sits 1.1–3.4× above the "same piece re-photographed" bar. Single edges collide
+    (M4); all four edges together never did on these 14 puzzles — piece uniqueness is not the
+    bottleneck. Finding #2: <strong>the z-sum is also the best retriever (95.2% top-1 on the
+    leakage-free cells, independently verified)</strong> — one score serves both ranking and
+    thresholding, retiring M6's rank-fusion machinery and retroactively meeting M6's ≥95% criterion.
+  </div>
 </div>
 
 <p class="phasehead c">Phase C · Backend service</p>
 <p class="phasedesc">Package Phase A+B as an API — one focused milestone, since the service plumbing pattern already exists.</p>
 
 <div class="milestone">
-  <h4><span class="mtag c">M8</span> <code>/api/v1/piece/geometry</code> endpoint + session piece store</h4>
+  <h4><span class="mtag c">M8</span> <code>/api/v1/piece/geometry</code> endpoint + session piece store <span class="badge next">NEXT ▶</span></h4>
   <div class="meta">~2–3 sessions · mirrors the existing preview/process endpoints</div>
   <ul>
     <li>Photo in → piece record out (contour, corners, edge types, descriptors, fingerprint, quality score).</li>

--- a/ios/Pussel/App/AppFlow.swift
+++ b/ios/Pussel/App/AppFlow.swift
@@ -73,6 +73,12 @@ final class SolveSession {
   var isProcessing = false
   var puzzleExpired = false
   var errorMessage: String?
+  #if DEBUG
+    /// Forces `PieceQueueView`'s camera cover open even when
+    /// `PieceCameraSession.isCameraAvailable` is false (the Simulator),
+    /// so `pusseldebug://camera` can demo M9's live preview overlay there.
+    var debugCameraOpen = false
+  #endif
 
   @ObservationIgnored private let store: PuzzleStore?
 

--- a/ios/Pussel/App/AppFlow.swift
+++ b/ios/Pussel/App/AppFlow.swift
@@ -123,6 +123,22 @@ final class SolveSession {
     processNext(api: api)
   }
 
+  /// Queues a piece captured by the M10 scan-and-lock flow. Same pipeline as
+  /// `enqueue` (position prediction, persistence, overlay marker), plus the
+  /// geometry-store piece id so the scan gallery can find this entry's image
+  /// again on later scanner visits. The scan flow only calls this for `new`
+  /// verdicts, so the dedupe keeps the piece list duplicate-free too.
+  func enqueueScanned(jpeg: Data, scanPieceId: String, api: APIClient) {
+    entries.append(CaptureEntry(jpeg: jpeg, scanPieceId: scanPieceId))
+    persist()
+    processNext(api: api)
+  }
+
+  /// The entry photographed for a geometry-store piece id, if any.
+  func entry(forScanPieceId pieceId: String) -> CaptureEntry? {
+    entries.first { $0.scanPieceId == pieceId }
+  }
+
   /// Resumes any pieces left `.queued` from a reloaded session.
   func resume(api: APIClient) {
     processNext(api: api)
@@ -184,6 +200,12 @@ final class SolveSession {
       puzzleExpired = false
       for index in entries.indices where entries[index].status == .expired {
         entries[index].status = .queued
+      }
+      // The old backend's geometry store died with the old puzzle id, and the
+      // fresh store will mint p001, p002, … again for different physical
+      // pieces — stale links would attach old thumbnails to the wrong pieces.
+      for index in entries.indices {
+        entries[index].scanPieceId = nil
       }
       persist()
       processNext(api: api)

--- a/ios/Pussel/App/AppFlow.swift
+++ b/ios/Pussel/App/AppFlow.swift
@@ -78,6 +78,10 @@ final class SolveSession {
     /// `PieceCameraSession.isCameraAvailable` is false (the Simulator),
     /// so `pusseldebug://camera` can demo M9's live preview overlay there.
     var debugCameraOpen = false
+    /// Forces `PieceQueueView`'s scan cover open even when
+    /// `PieceCameraSession.isCameraAvailable` is false (the Simulator),
+    /// so `pusseldebug://scan` can demo the scan-and-lock flow there.
+    var debugScanOpen = false
   #endif
 
   @ObservationIgnored private let store: PuzzleStore?

--- a/ios/Pussel/Features/Solve/PieceCameraSession.swift
+++ b/ios/Pussel/Features/Solve/PieceCameraSession.swift
@@ -1,9 +1,13 @@
 import AVFoundation
+import CoreImage
 import UIKit
 
 /// Persistent camera session for capturing pieces one after another with a
-/// manual shutter. Device-only — on the Simulator `isCameraAvailable` is false
-/// and the UI falls back to PhotosPicker.
+/// manual shutter, plus a live low-res frame stream that feeds
+/// `PiecePreviewStreamer` for the M9 outline overlay. Device-only for the
+/// photo/streaming path — on the Simulator `isCameraAvailable` is false and
+/// the UI falls back to PhotosPicker (the DEBUG preview loop below is the
+/// Simulator's stand-in for live frames; see `startDebugPreviewLoop`).
 final class PieceCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
   static var isCameraAvailable: Bool {
     AVCaptureDevice.default(for: .video) != nil
@@ -20,29 +24,91 @@ final class PieceCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
   /// intent decides — not how far along the awaits happen to be.
   private var wantsRunning = false
 
+  // MARK: - Live preview streaming (M9)
+
+  private let videoOutput = AVCaptureVideoDataOutput()
+  /// Dedicated queue for both receiving frames and mutating the streaming
+  /// state below, so the capture delegate never races the main-actor calls
+  /// that enable/disable it — matches `sessionQueue`'s role for
+  /// start/stop.
+  private let videoQueue = DispatchQueue(label: "dk.delectosoft.pussel.piece-camera.video")
+  /// videoQueue-confined.
+  private var isStreamingPreview = false
+  /// videoQueue-confined. `PiecePreviewStreamer` itself is thread-safe for
+  /// the calls made here (see its doc comment).
+  private weak var previewStreamer: PiecePreviewStreamer?
+  private static let ciContext = CIContext()
+
+  /// Long side, in pixels, live-preview frames are downscaled to before
+  /// JPEG-encoding and sending — small enough to keep the ~4Hz stream
+  /// cheap, large enough for the backend's region detector to work with.
+  private static let previewFrameMaxLongSide: CGFloat = 480
+  private static let previewFrameJPEGQuality: CGFloat = 0.6
+
+  /// Wires the streamer this session forwards frames to. Call once after
+  /// creating the session (before `start()`), from the main actor.
+  func attachPreviewStreamer(_ streamer: PiecePreviewStreamer) {
+    videoQueue.async { [weak self] in
+      self?.previewStreamer = streamer
+    }
+  }
+
+  /// Starts/stops forwarding camera frames to the preview streamer. The
+  /// capture view pauses this during photo capture (see `capturePhoto()`)
+  /// and while it isn't visible.
+  func setPreviewStreamingEnabled(_ enabled: Bool) {
+    videoQueue.async { [weak self] in
+      self?.isStreamingPreview = enabled
+    }
+  }
+
+  // MARK: - Lifecycle
+
   /// Returns false when the camera cannot run — access denied, or no usable
   /// device — so the caller can report it rather than show a dead preview.
   func start() async -> Bool {
     wantsRunning = true
-    guard await AVCaptureDevice.requestAccess(for: .video) else { return false }
-    configureIfNeeded()
-    guard isConfigured else { return false }
-    // The screen was dismissed while the permission prompt was up: stop() has
-    // already run, and starting now would strand the camera with no one left
-    // to stop it. Not a failure — nothing to report, nothing to run.
-    guard wantsRunning else { return true }
-    let session = self.session
-    // startRunning/stopRunning both block, so they run off the main thread —
-    // through one serial queue so a stop queued behind a start runs after it.
-    sessionQueue.async {
-      guard !session.isRunning else { return }
-      session.startRunning()
-    }
-    return true
+    #if DEBUG
+      // Registered even when the real camera can't configure (e.g. the
+      // Simulator has no device below) so `pusseldebug://previewloop` can
+      // still reach this session and demo the overlay over a black preview.
+      Self.debugActive = self
+    #endif
+    #if targetEnvironment(simulator)
+      // The Simulator has no camera. Touching AVCaptureDevice's authorization
+      // (requestAccess) pops an iOS 26 permission dialog that can't be
+      // dismissed in a headless CI/agent session, and there's no device to
+      // configure anyway — so skip the real capture path entirely. The view
+      // presents its normal chrome over a black preview, and the DEBUG
+      // `previewloop` command feeds fake frames straight into the streamer
+      // (see feedDebugFrame). Real-device builds are unaffected: the #else
+      // branch below is byte-identical to the original.
+      return true
+    #else
+      guard await AVCaptureDevice.requestAccess(for: .video) else { return false }
+      configureIfNeeded()
+      guard isConfigured else { return false }
+      // The screen was dismissed while the permission prompt was up: stop() has
+      // already run, and starting now would strand the camera with no one left
+      // to stop it. Not a failure — nothing to report, nothing to run.
+      guard wantsRunning else { return true }
+      let session = self.session
+      // startRunning/stopRunning both block, so they run off the main thread —
+      // through one serial queue so a stop queued behind a start runs after it.
+      sessionQueue.async {
+        guard !session.isRunning else { return }
+        session.startRunning()
+      }
+      return true
+    #endif
   }
 
   func stop() {
     wantsRunning = false
+    #if DEBUG
+      stopDebugPreviewLoop()
+      if Self.debugActive === self { Self.debugActive = nil }
+    #endif
     let session = self.session
     sessionQueue.async {
       guard session.isRunning else { return }
@@ -54,6 +120,10 @@ final class PieceCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
     // Ignore shutter taps while a capture is in flight — overwriting the
     // stored continuation would leak it and hang the first caller.
     guard isConfigured, captureContinuation == nil else { return nil }
+    // Pause the preview stream so it doesn't race the shutter for the
+    // photo output's bandwidth; resumes once the shot is developed.
+    setPreviewStreamingEnabled(false)
+    defer { setPreviewStreamingEnabled(true) }
     return await withCheckedContinuation { continuation in
       captureContinuation = continuation
       photoOutput.capturePhoto(with: AVCapturePhotoSettings(), delegate: self)
@@ -82,7 +152,121 @@ final class PieceCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
       return
     }
     session.addOutput(photoOutput)
+    if session.canAddOutput(videoOutput) {
+      videoOutput.alwaysDiscardsLateVideoFrames = true
+      videoOutput.setSampleBufferDelegate(self, queue: videoQueue)
+      session.addOutput(videoOutput)
+      // Rotate the delivered buffers to portrait at the connection level, so
+      // the downscaled JPEG sent to the backend is visually upright —
+      // exactly what the user sees in the portrait preview layer. 90° is
+      // the portrait rotation for a back camera (its sensor is mounted
+      // landscape; AVCaptureDevice.RotationCoordinator reports 90 for
+      // portrait on the back camera, and 90 is the angle equivalent of the
+      // legacy `.portrait` videoOrientation). With the frame and the
+      // preview showing the same upright image, the overlay needs no
+      // orientation guess — just the shared aspect-fill bounds mapping
+      // (PiecePreviewGeometry.viewPolygon).
+      if let connection = videoOutput.connection(with: .video),
+        connection.isVideoRotationAngleSupported(90)
+      {
+        connection.videoRotationAngle = 90
+      }
+    }
     session.commitConfiguration()
     isConfigured = true
+  }
+
+  /// Downscales a captured frame to ~`previewFrameMaxLongSide` on its long
+  /// side and JPEG-encodes it for the preview endpoint. Pure/CPU-only, so
+  /// it's shared by both the real camera path (below) and the DEBUG
+  /// preview loop.
+  private static func downscaledJPEG(ciImage: CIImage) -> (data: Data, size: CGSize)? {
+    let extent = ciImage.extent
+    guard extent.width > 0, extent.height > 0 else { return nil }
+    let scale = min(1, previewFrameMaxLongSide / max(extent.width, extent.height))
+    let scaled =
+      scale < 1 ? ciImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale)) : ciImage
+    guard let cgImage = ciContext.createCGImage(scaled, from: scaled.extent) else { return nil }
+    let size = CGSize(width: cgImage.width, height: cgImage.height)
+    guard let data = UIImage(cgImage: cgImage).jpegData(compressionQuality: previewFrameJPEGQuality)
+    else { return nil }
+    return (data, size)
+  }
+
+  #if DEBUG
+    /// The currently active session, so `pusseldebug://previewloop` can
+    /// reach the piece-capture screen's camera without `AppModel` knowing
+    /// about view-local camera state (mirrors how the debug command file
+    /// reaches `AppModel` itself; see `DebugDriver`). Registered by
+    /// `start()`, cleared by `stop()`.
+    static weak var debugActive: PieceCameraSession?
+
+    private var debugPreviewTimer: Timer?
+
+    /// Feeds `image` through the same downscale → stream → overlay path as
+    /// a real camera frame, on a ~3Hz repeating timer — the Simulator has
+    /// no camera, so this is how `pusseldebug://previewloop?path=<host
+    /// image path>` demos M9 there. `pusseldebug://previewloop?stop=1`
+    /// stops it (`stopDebugPreviewLoop`).
+    func startDebugPreviewLoop(image: UIImage) {
+      stopDebugPreviewLoop()
+      // Bake any EXIF orientation into the pixels first: `cgImage` alone
+      // drops UIImage's orientation metadata, which would feed a rotated
+      // frame for a phone-shot fixture. Real camera frames don't need this
+      // — their buffers arrive already upright (videoRotationAngle = 90).
+      let upright: UIImage
+      if image.imageOrientation == .up, image.cgImage != nil {
+        upright = image
+      } else {
+        upright = UIGraphicsImageRenderer(size: image.size).image { _ in
+          image.draw(in: CGRect(origin: .zero, size: image.size))
+        }
+      }
+      guard let cgImage = upright.cgImage else { return }
+      let ciImage = CIImage(cgImage: cgImage)
+      feedDebugFrame(ciImage)
+      let interval: TimeInterval = 1.0 / 3.0
+      let timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+        self?.feedDebugFrame(ciImage)
+      }
+      RunLoop.main.add(timer, forMode: .common)
+      debugPreviewTimer = timer
+    }
+
+    func stopDebugPreviewLoop() {
+      debugPreviewTimer?.invalidate()
+      debugPreviewTimer = nil
+    }
+
+    private func feedDebugFrame(_ ciImage: CIImage) {
+      videoQueue.async { [weak self] in
+        guard let self, self.isStreamingPreview, let previewStreamer = self.previewStreamer else {
+          return
+        }
+        let now = Date()
+        guard previewStreamer.shouldAcceptFrame(now: now) else { return }
+        guard let frame = Self.downscaledJPEG(ciImage: ciImage) else { return }
+        previewStreamer.submit(jpegData: frame.data, frameSize: frame.size, now: now)
+      }
+    }
+  #endif
+}
+
+extension PieceCameraSession: AVCaptureVideoDataOutputSampleBufferDelegate {
+  /// Runs on `videoQueue`. Checks the throttle *before* downscaling so a
+  /// frame that would just be dropped never pays for the JPEG encode.
+  func captureOutput(
+    _ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer,
+    from connection: AVCaptureConnection
+  ) {
+    guard isStreamingPreview, let previewStreamer,
+      let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
+    else { return }
+    let now = Date()
+    guard previewStreamer.shouldAcceptFrame(now: now) else { return }
+    guard let frame = Self.downscaledJPEG(ciImage: CIImage(cvPixelBuffer: pixelBuffer)) else {
+      return
+    }
+    previewStreamer.submit(jpegData: frame.data, frameSize: frame.size, now: now)
   }
 }

--- a/ios/Pussel/Features/Solve/PieceCameraSession.swift
+++ b/ios/Pussel/Features/Solve/PieceCameraSession.swift
@@ -117,6 +117,16 @@ final class PieceCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
   }
 
   func capturePhoto() async -> UIImage? {
+    #if targetEnvironment(simulator)
+      // The Simulator has no real camera, so `capturePhoto` would hang
+      // waiting for a photo output that never fires. When the DEBUG preview
+      // loop is running (i.e. a host image was fed via `startDebugPreviewLoop`)
+      // we use the upright image it stored so the scan-and-lock flow can
+      // complete an end-to-end cycle on the Simulator without a real device.
+      if let debugCaptureImage {
+        return debugCaptureImage
+      }
+    #endif
     // Ignore shutter taps while a capture is in flight — overwriting the
     // stored continuation would leak it and hang the first caller.
     guard isConfigured, captureContinuation == nil else { return nil }
@@ -203,11 +213,19 @@ final class PieceCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
 
     private var debugPreviewTimer: Timer?
 
+    /// The upright host image last fed by `startDebugPreviewLoop`. Stored so
+    /// `capturePhoto()` can return it on the Simulator, giving the scan-and-
+    /// lock flow a real JPEG to POST without a physical camera.
+    private(set) var debugCaptureImage: UIImage?
+
     /// Feeds `image` through the same downscale → stream → overlay path as
     /// a real camera frame, on a ~3Hz repeating timer — the Simulator has
     /// no camera, so this is how `pusseldebug://previewloop?path=<host
     /// image path>` demos M9 there. `pusseldebug://previewloop?stop=1`
     /// stops it (`stopDebugPreviewLoop`).
+    /// Also stores the upright image in `debugCaptureImage` so the M10
+    /// scan-and-lock flow can complete an end-to-end POST cycle on the
+    /// Simulator via the `capturePhoto()` override above.
     func startDebugPreviewLoop(image: UIImage) {
       stopDebugPreviewLoop()
       // Bake any EXIF orientation into the pixels first: `cgImage` alone
@@ -224,6 +242,7 @@ final class PieceCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
       }
       guard let cgImage = upright.cgImage else { return }
       let ciImage = CIImage(cgImage: cgImage)
+      debugCaptureImage = upright
       feedDebugFrame(ciImage)
       let interval: TimeInterval = 1.0 / 3.0
       let timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
@@ -236,6 +255,7 @@ final class PieceCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
     func stopDebugPreviewLoop() {
       debugPreviewTimer?.invalidate()
       debugPreviewTimer = nil
+      debugCaptureImage = nil
     }
 
     private func feedDebugFrame(_ ciImage: CIImage) {

--- a/ios/Pussel/Features/Solve/PieceCaptureView.swift
+++ b/ios/Pussel/Features/Solve/PieceCaptureView.swift
@@ -1,6 +1,8 @@
 import AVFoundation
 import PhotosUI
+import QuartzCore
 import SwiftUI
+import UIKit
 
 /// Full-screen piece capture, presented when the "+" tile in the piece list is
 /// tapped. The camera only runs while this is on screen. Device-only — on the
@@ -10,14 +12,20 @@ struct PieceCaptureView: View {
   @Environment(AppModel.self) private var model
   @Environment(\.dismiss) private var dismiss
   @State private var camera = PieceCameraSession()
+  @State private var previewStreamer: PiecePreviewStreamer?
   @State private var photoItem: PhotosPickerItem?
   @State private var isCapturing = false
 
   var body: some View {
     ZStack {
       Color.black.ignoresSafeArea()
-      CameraPreview(session: camera.session)
-        .ignoresSafeArea()
+      CameraPreview(
+        session: camera.session,
+        previewState: previewStreamer?.state ?? .none,
+        updatedAt: previewStreamer?.updatedAt ?? .distantPast,
+        frameSize: previewStreamer?.frameSize ?? .zero
+      )
+      .ignoresSafeArea()
     }
     .overlay(alignment: .top) {
       Button("Cancel") { dismiss() }
@@ -36,18 +44,34 @@ struct PieceCaptureView: View {
         .padding(.bottom, 40)
     }
     .task {
+      let streamer = previewStreamer ?? PiecePreviewStreamer(api: model.api)
+      previewStreamer = streamer
+      camera.attachPreviewStreamer(streamer)
       let started = await camera.start()
       // Dismissed while the permission prompt was up — the user left on
       // purpose, so there is nothing to complain about.
       guard !Task.isCancelled else { return }
       guard started else {
+        #if DEBUG
+          // The Simulator has no camera; stay on screen over the black
+          // background so `pusseldebug://previewloop` can still demo the
+          // overlay instead of bouncing straight back out. A real device
+          // failure (permission denied, etc.) still reports and dismisses.
+          if !PieceCameraSession.isCameraAvailable {
+            camera.setPreviewStreamingEnabled(true)
+            return
+          }
+        #endif
         model.reportPieceError("Pussel cannot use the camera. Check camera access in Settings.")
         dismiss()
         return
       }
+      camera.setPreviewStreamingEnabled(true)
     }
     .onDisappear {
+      camera.setPreviewStreamingEnabled(false)
       camera.stop()
+      previewStreamer?.reset()
     }
     .keepsScreenAwake()
     .onChange(of: photoItem) { _, item in
@@ -98,8 +122,28 @@ struct PieceCaptureView: View {
   }
 }
 
+/// Camera preview with the M9 live piece-outline overlay: a `CAShapeLayer`
+/// drawn on top of the `AVCaptureVideoPreviewLayer`, mapped from
+/// `PiecePreviewStreamer`'s normalized polygon via
+/// `PiecePreviewGeometry.viewPolygon` (aspect-fill onto the overlay bounds,
+/// mirroring the preview layer's `.resizeAspectFill` of the same upright
+/// portrait feed).
 struct CameraPreview: UIViewRepresentable {
   let session: AVCaptureSession
+  let previewState: PiecePreviewState
+  let updatedAt: Date
+  /// Pixel size of the frame the current polygon was measured against —
+  /// the upright-portrait downscaled JPEG that was sent to the backend. Its
+  /// aspect ratio drives the aspect-fill mapping onto the overlay bounds.
+  let frameSize: CGSize
+
+  /// The overlay hides once `updatedAt` is older than this — a stalled
+  /// request stream (e.g. persistent network errors) shouldn't leave a
+  /// stale outline glued to the screen.
+  static let staleInterval: TimeInterval = 1.5
+  /// Implicit-transaction duration for path/color changes, so the outline
+  /// glides between detections rather than snapping.
+  private static let pathAnimationDuration: TimeInterval = 0.12
 
   final class PreviewView: UIView {
     // Overrides UIView's class property, so `static` isn't an option (it can't
@@ -110,6 +154,30 @@ struct CameraPreview: UIViewRepresentable {
     // AVCaptureVideoPreviewLayer, so this cast can never fail.
     // swiftlint:disable:next force_cast
     var previewLayer: AVCaptureVideoPreviewLayer { layer as! AVCaptureVideoPreviewLayer }
+
+    let outlineLayer = CAShapeLayer()
+
+    override init(frame: CGRect) {
+      super.init(frame: frame)
+      outlineLayer.fillColor = UIColor.clear.cgColor
+      outlineLayer.lineWidth = 3
+      outlineLayer.shadowColor = UIColor.black.cgColor
+      outlineLayer.shadowOpacity = 0.6
+      outlineLayer.shadowRadius = 3
+      outlineLayer.shadowOffset = .zero
+      outlineLayer.isHidden = true
+      layer.addSublayer(outlineLayer)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+      super.layoutSubviews()
+      outlineLayer.frame = bounds
+    }
   }
 
   func makeUIView(context: Context) -> PreviewView {
@@ -119,5 +187,37 @@ struct CameraPreview: UIViewRepresentable {
     return view
   }
 
-  func updateUIView(_ uiView: PreviewView, context: Context) {}
+  func updateUIView(_ uiView: PreviewView, context: Context) {
+    guard let polygon = previewState.polygon, polygon.count >= 3,
+      Date().timeIntervalSince(updatedAt) < Self.staleInterval
+    else {
+      uiView.outlineLayer.isHidden = true
+      return
+    }
+
+    // One mapping path for device and Simulator: the streamed frame is
+    // rotated to upright portrait at the connection level (see
+    // PieceCameraSession.configureIfNeeded), so it shows exactly what the
+    // `.resizeAspectFill` preview layer shows — same image, same aspect.
+    // Aspect-filling the frame-normalized polygon onto the overlay's bounds
+    // therefore reproduces the preview layer's geometry with no
+    // orientation guesswork (and on the Simulator there is no live preview
+    // layer to convert through anyway; the backdrop is just black).
+    let viewPoints = PiecePreviewGeometry.viewPolygon(
+      fromFramePolygon: polygon, frameSize: frameSize, viewBounds: uiView.bounds.size)
+    let path = UIBezierPath()
+    path.move(to: viewPoints[0])
+    for point in viewPoints.dropFirst() {
+      path.addLine(to: point)
+    }
+    path.close()
+
+    CATransaction.begin()
+    CATransaction.setAnimationDuration(Self.pathAnimationDuration)
+    uiView.outlineLayer.path = path.cgPath
+    uiView.outlineLayer.strokeColor =
+      (previewState.isLockable ? UIColor.systemGreen : UIColor.systemYellow).cgColor
+    uiView.outlineLayer.isHidden = false
+    CATransaction.commit()
+  }
 }

--- a/ios/Pussel/Features/Solve/PieceCaptureView.swift
+++ b/ios/Pussel/Features/Solve/PieceCaptureView.swift
@@ -139,7 +139,10 @@ struct CameraPreview: UIViewRepresentable {
 
   /// The overlay hides once `updatedAt` is older than this — a stalled
   /// request stream (e.g. persistent network errors) shouldn't leave a
-  /// stale outline glued to the screen.
+  /// stale outline glued to the screen. Enforced both here (on every
+  /// `updateUIView`) and by `PreviewView`'s independent tick, because a
+  /// stalled stream stops changing observable state and so stops calling
+  /// `updateUIView` — the very case this guard exists for.
   static let staleInterval: TimeInterval = 1.5
   /// Implicit-transaction duration for path/color changes, so the outline
   /// glides between detections rather than snapping.
@@ -157,6 +160,13 @@ struct CameraPreview: UIViewRepresentable {
 
     let outlineLayer = CAShapeLayer()
 
+    /// The instant the currently-shown outline becomes stale (the last
+    /// `updatedAt` + `staleInterval`). The tick below hides the outline once
+    /// `Date()` passes this, so a stalled stream that stops driving
+    /// `updateUIView` can't leave the outline frozen on screen.
+    private var staleDeadline: Date = .distantPast
+    private var staleTimer: Timer?
+
     override init(frame: CGRect) {
       super.init(frame: frame)
       outlineLayer.fillColor = UIColor.clear.cgColor
@@ -167,11 +177,45 @@ struct CameraPreview: UIViewRepresentable {
       outlineLayer.shadowOffset = .zero
       outlineLayer.isHidden = true
       layer.addSublayer(outlineLayer)
+      // ~3 Hz backstop, independent of SwiftUI re-renders: hides the outline
+      // within ~0.35 s of the stream stalling, well under staleInterval, at
+      // negligible cost. Weak self so it never keeps the view alive; the
+      // RunLoop holds the timer until deinit invalidates it.
+      let timer = Timer(timeInterval: 0.35, repeats: true) { [weak self] _ in
+        self?.hideOutlineIfStale()
+      }
+      RunLoop.main.add(timer, forMode: .common)
+      staleTimer = timer
+    }
+
+    deinit {
+      staleTimer?.invalidate()
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
       fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Shows the outline and marks it fresh until `deadline`. Called by
+    /// `updateUIView` when a live detection arrives.
+    func showOutline(freshUntil deadline: Date) {
+      staleDeadline = deadline
+      outlineLayer.isHidden = false
+    }
+
+    /// Hides the outline now and stops the tick from re-showing it. Called by
+    /// `updateUIView` when there is nothing valid to draw.
+    func hideOutline() {
+      staleDeadline = .distantPast
+      outlineLayer.isHidden = true
+    }
+
+    /// Tick target: hides the outline once its freshness window has elapsed.
+    private func hideOutlineIfStale() {
+      if !outlineLayer.isHidden, Date() >= staleDeadline {
+        outlineLayer.isHidden = true
+      }
     }
 
     override func layoutSubviews() {
@@ -191,7 +235,7 @@ struct CameraPreview: UIViewRepresentable {
     guard let polygon = previewState.polygon, polygon.count >= 3,
       Date().timeIntervalSince(updatedAt) < Self.staleInterval
     else {
-      uiView.outlineLayer.isHidden = true
+      uiView.hideOutline()
       return
     }
 
@@ -217,7 +261,7 @@ struct CameraPreview: UIViewRepresentable {
     uiView.outlineLayer.path = path.cgPath
     uiView.outlineLayer.strokeColor =
       (previewState.isLockable ? UIColor.systemGreen : UIColor.systemYellow).cgColor
-    uiView.outlineLayer.isHidden = false
+    uiView.showOutline(freshUntil: updatedAt.addingTimeInterval(Self.staleInterval))
     CATransaction.commit()
   }
 }

--- a/ios/Pussel/Features/Solve/PiecePreviewGeometry.swift
+++ b/ios/Pussel/Features/Solve/PiecePreviewGeometry.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Pure math for mapping the backend's frame-normalized piece outline onto
+/// the camera-preview overlay's bounds.
+///
+/// The frames `PieceCameraSession` streams are rotated to upright portrait
+/// at the connection level (`videoRotationAngle = 90` on the video data
+/// output — see `configureIfNeeded`), so the downscaled JPEG the backend
+/// measured is visually identical to what the portrait
+/// `AVCaptureVideoPreviewLayer` shows: same image, same aspect ratio, no
+/// orientation difference to correct for. That makes the overlay mapping a
+/// single aspect-fill: the preview layer displays the feed with
+/// `.resizeAspectFill`, and `viewPoint` applies the same centered fill to
+/// the polygon, reproducing the layer's geometry without going through
+/// `layerPointConverted(fromCaptureDevicePoint:)` — which also lets the
+/// identical path serve the Simulator, where no capture session runs and no
+/// preview-layer connection exists (the DEBUG `previewloop` feeds host
+/// images whose axes are likewise display axes).
+enum PiecePreviewGeometry {
+  /// Maps one frame-normalized point onto the overlay view's bounds with
+  /// centered **aspect-fill** — the same fit the `.resizeAspectFill`
+  /// preview layer applies to the (same-aspect) live feed, cropping the
+  /// overflowing axis equally on both sides.
+  ///
+  /// - Parameters:
+  ///   - point: a polygon point as returned by the backend, normalized to
+  ///     the upright frame it received.
+  ///   - frameSize: pixel size of that frame (the downscaled JPEG's size);
+  ///     only its aspect ratio matters. A zero/degenerate size falls back
+  ///     to a plain stretch onto the bounds.
+  ///   - viewBounds: the overlay view's bounds size, in points.
+  /// - Returns: the point in the overlay view's coordinate space.
+  static func viewPoint(
+    fromFramePoint point: NormalizedPoint, frameSize: CGSize, viewBounds: CGSize
+  ) -> CGPoint {
+    guard frameSize.width > 0, frameSize.height > 0 else {
+      return CGPoint(x: point.x * viewBounds.width, y: point.y * viewBounds.height)
+    }
+    let scale = max(viewBounds.width / frameSize.width, viewBounds.height / frameSize.height)
+    let scaledWidth = frameSize.width * scale
+    let scaledHeight = frameSize.height * scale
+    // Centered aspect-fill: the scaled frame overflows on one axis, so its
+    // origin is pushed negative there to keep it centered.
+    let originX = (viewBounds.width - scaledWidth) / 2
+    let originY = (viewBounds.height - scaledHeight) / 2
+    return CGPoint(x: originX + point.x * scaledWidth, y: originY + point.y * scaledHeight)
+  }
+
+  /// Maps a full polygon through `viewPoint(fromFramePoint:frameSize:viewBounds:)`,
+  /// preserving point order.
+  static func viewPolygon(
+    fromFramePolygon polygon: [NormalizedPoint], frameSize: CGSize, viewBounds: CGSize
+  ) -> [CGPoint] {
+    polygon.map { viewPoint(fromFramePoint: $0, frameSize: frameSize, viewBounds: viewBounds) }
+  }
+}

--- a/ios/Pussel/Features/Solve/PiecePreviewGeometry.swift
+++ b/ios/Pussel/Features/Solve/PiecePreviewGeometry.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 
 /// Pure math for mapping the backend's frame-normalized piece outline onto

--- a/ios/Pussel/Features/Solve/PiecePreviewStreamer.swift
+++ b/ios/Pussel/Features/Solve/PiecePreviewStreamer.swift
@@ -1,0 +1,116 @@
+import CoreGraphics
+import Foundation
+import Observation
+
+/// The latest live-preview detection, published by `PiecePreviewStreamer`.
+/// Mirrors the backend's quality flags: a plain `detected` region (yellow
+/// outline) versus one the backend judged `lockable` (green outline, per
+/// `include_quality=true`'s `lockable` flag).
+enum PiecePreviewState: Equatable {
+  case none
+  case detected(polygon: [NormalizedPoint], confidence: Double)
+  case lockable(polygon: [NormalizedPoint], confidence: Double)
+
+  var polygon: [NormalizedPoint]? {
+    switch self {
+    case .none: return nil
+    case .detected(let polygon, _), .lockable(let polygon, _): return polygon
+    }
+  }
+
+  var isLockable: Bool {
+    if case .lockable = self { return true }
+    return false
+  }
+}
+
+/// Owns the throttle/in-flight state machine for streaming live camera
+/// frames to `POST /api/v1/piece/preview`, and publishes the latest
+/// detection so `PieceCaptureView` can draw it. One instance per piece
+/// capture screen, created alongside its `PieceCameraSession`.
+///
+/// Split isolation by design: `shouldAcceptFrame`/`submit` are safe to call
+/// from any thread (lock-guarded, matching `StubURLProtocol`'s precedent
+/// for cross-thread state in this codebase — see PusselTests/APIClientTests.swift)
+/// — `PieceCameraSession` calls them from its dedicated video-capture
+/// queue, before doing any downscale work, so a throttled/in-flight frame
+/// is dropped cheaply. The UI-facing `state`/`frameSize`/`updatedAt` are
+/// main-actor-isolated, since SwiftUI only ever reads them from
+/// `PieceCaptureView`'s body.
+@Observable
+final class PiecePreviewStreamer: @unchecked Sendable {
+  private let api: APIClient
+  private let lock = NSLock()
+  private var throttle = PiecePreviewThrottle()
+
+  @MainActor private(set) var state: PiecePreviewState = .none
+  /// Pixel size of the frame `state`'s polygon was measured against — the
+  /// upright-portrait downscaled JPEG `PieceCameraSession` sent. Its aspect
+  /// ratio drives the overlay's aspect-fill mapping
+  /// (`PiecePreviewGeometry.viewPolygon`).
+  @MainActor private(set) var frameSize: CGSize = .zero
+  /// When `state` was last updated. `PieceCaptureView` hides the overlay
+  /// once this gets too old, so a stalled request stream (e.g. persistent
+  /// network errors) doesn't leave a stale outline glued to the screen.
+  @MainActor private(set) var updatedAt: Date = .distantPast
+
+  init(api: APIClient) {
+    self.api = api
+  }
+
+  /// Whether a frame arriving now is worth downscaling and sending. Call
+  /// this before doing that work — safe from any thread.
+  func shouldAcceptFrame(now: Date = Date()) -> Bool {
+    lock.withLock { throttle.shouldSend(now: now) }
+  }
+
+  /// Sends an already-downscaled JPEG frame and publishes the result. Safe
+  /// to call from any thread (typically the video-capture queue); the
+  /// network call and state publication both hop to the main actor
+  /// internally. A no-op if the throttle would reject the frame (e.g. it
+  /// raced another accepted frame between `shouldAcceptFrame` and here).
+  func submit(jpegData: Data, frameSize: CGSize, now: Date = Date()) {
+    let accepted = lock.withLock { () -> Bool in
+      guard throttle.shouldSend(now: now) else { return false }
+      throttle.markSent(at: now)
+      return true
+    }
+    guard accepted else { return }
+    Task { @MainActor in
+      defer { self.lock.withLock { self.throttle.markCompleted() } }
+      do {
+        let response = try await self.api.previewPiece(imageData: jpegData)
+        self.apply(response, frameSize: frameSize, now: Date())
+      } catch {
+        // Leave the last-known state on a transient error — a single
+        // dropped frame shouldn't blank the outline mid-track. The
+        // staleness check in PieceCaptureView hides it if errors persist.
+      }
+    }
+  }
+
+  /// Resets to no detection and clears the throttle — called when
+  /// streaming pauses (photo capture, view disappearing) so a stale
+  /// outline doesn't linger, and so streaming resumes cleanly afterward.
+  @MainActor
+  func reset() {
+    lock.withLock { throttle = PiecePreviewThrottle() }
+    state = .none
+    frameSize = .zero
+    updatedAt = .distantPast
+  }
+
+  @MainActor
+  private func apply(_ response: PiecePreviewResponse, frameSize: CGSize, now: Date) {
+    self.frameSize = frameSize
+    updatedAt = now
+    guard response.found, response.polygon.count >= 3 else {
+      state = .none
+      return
+    }
+    state =
+      response.lockable == true
+      ? .lockable(polygon: response.polygon, confidence: response.confidence)
+      : .detected(polygon: response.polygon, confidence: response.confidence)
+  }
+}

--- a/ios/Pussel/Features/Solve/PiecePreviewThrottle.swift
+++ b/ios/Pussel/Features/Solve/PiecePreviewThrottle.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Pure decision logic for whether a new live-preview frame should be sent
+/// to the backend, given the current throttle state. No I/O, no timers, no
+/// actor isolation — a plain value type, so it's directly unit-testable
+/// without mocking the network or a clock.
+///
+/// `PiecePreviewStreamer` is the sole owner of a live instance and is
+/// responsible for calling `markSent`/`markCompleted` around each request;
+/// this type only computes the yes/no answer and the state transitions.
+struct PiecePreviewThrottle: Equatable {
+  /// Minimum time between requests — the ~4Hz cadence M9 targets for
+  /// tracking responsiveness without hammering the backend.
+  static let minInterval: TimeInterval = 0.25
+
+  private(set) var lastSend: Date?
+  private(set) var isInFlight = false
+
+  init() {}
+
+  /// Whether a frame arriving at `now` should be sent: never while a
+  /// request is already in flight, and never sooner than `minInterval`
+  /// after the last send.
+  func shouldSend(now: Date) -> Bool {
+    guard !isInFlight else { return false }
+    guard let lastSend else { return true }
+    return now.timeIntervalSince(lastSend) >= Self.minInterval
+  }
+
+  /// Marks a send as started; `shouldSend` returns false until a matching
+  /// `markCompleted()`.
+  mutating func markSent(at now: Date) {
+    lastSend = now
+    isInFlight = true
+  }
+
+  /// Marks the in-flight request as finished, successfully or not, so the
+  /// next frame past `minInterval` can send again.
+  mutating func markCompleted() {
+    isInFlight = false
+  }
+}

--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -38,12 +38,13 @@ struct PieceQueueView: View {
       // rather than centering against their taller status labels.
       LazyVGrid(columns: Self.columns, alignment: .leading, spacing: 12) {
         AddPieceTile(action: addPiece)
-        ScanPiecesTile(action: openScan)
-          #if !DEBUG
-            // On a non-debug, non-camera device (shouldn't exist in practice)
-            // the tile would open a dead view — hide it to be safe.
-            .opacity(PieceCameraSession.isCameraAvailable ? 1 : 0)
-          #endif
+        // Omit the tile entirely when it can't be used, rather than rendering
+        // it invisible — an .opacity(0) tile still takes taps and is announced
+        // by VoiceOver. Always present in DEBUG (the Simulator scan demo opens
+        // it over a black preview); in release only when there's a camera.
+        if showScanTile {
+          ScanPiecesTile(action: openScan)
+        }
         // Newest first, so a piece appears next to the plus that captured it
         // and the grid ages away from there. The stored order stays oldest
         // first — the prediction queue works through it front to back.
@@ -89,6 +90,18 @@ struct PieceQueueView: View {
     } else {
       showLibrary = true
     }
+  }
+
+  /// Whether the scan-and-lock tile is shown. Always in DEBUG so the
+  /// Simulator scan demo (`pusseldebug://scan`) has an entry point over its
+  /// black preview; in release only when a camera exists to drive it, so it
+  /// is never a dead, VoiceOver-discoverable control.
+  private var showScanTile: Bool {
+    #if DEBUG
+      return true
+    #else
+      return PieceCameraSession.isCameraAvailable
+    #endif
   }
 
   private func openScan() {

--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -59,7 +59,7 @@ struct PieceQueueView: View {
     .onChange(of: session.entries.isEmpty) { _, isEmpty in
       if isEmpty { isDeleteMode = false }
     }
-    .fullScreenCover(isPresented: $showCamera) {
+    .fullScreenCover(isPresented: cameraCoverIsPresented) {
       PieceCaptureView()
     }
     // Simulator path: no camera, so the tile picks from the library directly.
@@ -80,6 +80,24 @@ struct PieceQueueView: View {
       showLibrary = true
     }
   }
+
+  #if DEBUG
+    /// Also presented when `pusseldebug://camera` sets
+    /// `session.debugCameraOpen`, so M9's overlay is demoable on the
+    /// Simulator (which has no camera, so `showCamera` alone never becomes
+    /// reachable there).
+    private var cameraCoverIsPresented: Binding<Bool> {
+      Binding(
+        get: { showCamera || session.debugCameraOpen },
+        set: { newValue in
+          showCamera = newValue
+          session.debugCameraOpen = newValue
+        }
+      )
+    }
+  #else
+    private var cameraCoverIsPresented: Binding<Bool> { $showCamera }
+  #endif
 }
 
 /// Leading tile in the grid: a big plus that starts a new piece capture.

--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -10,6 +10,7 @@ struct PieceQueueView: View {
   let session: SolveSession
   @State private var isDeleteMode = false
   @State private var showCamera = false
+  @State private var showScan = false
   @State private var showLibrary = false
   @State private var photoItem: PhotosPickerItem?
 
@@ -37,6 +38,12 @@ struct PieceQueueView: View {
       // rather than centering against their taller status labels.
       LazyVGrid(columns: Self.columns, alignment: .leading, spacing: 12) {
         AddPieceTile(action: addPiece)
+        ScanPiecesTile(action: openScan)
+          #if !DEBUG
+            // On a non-debug, non-camera device (shouldn't exist in practice)
+            // the tile would open a dead view — hide it to be safe.
+            .opacity(PieceCameraSession.isCameraAvailable ? 1 : 0)
+          #endif
         // Newest first, so a piece appears next to the plus that captured it
         // and the grid ages away from there. The stored order stays oldest
         // first — the prediction queue works through it front to back.
@@ -62,6 +69,9 @@ struct PieceQueueView: View {
     .fullScreenCover(isPresented: cameraCoverIsPresented) {
       PieceCaptureView()
     }
+    .fullScreenCover(isPresented: scanCoverIsPresented) {
+      PieceScanView(session: session)
+    }
     // Simulator path: no camera, so the tile picks from the library directly.
     .photosPicker(isPresented: $showLibrary, selection: $photoItem, matching: .images)
     .onChange(of: photoItem) { _, item in
@@ -81,6 +91,19 @@ struct PieceQueueView: View {
     }
   }
 
+  private func openScan() {
+    // On a real device the camera is available; on the Simulator it's not,
+    // but the DEBUG build still opens the scan view (over a black preview)
+    // so `pusseldebug://scan` can demo the scan-and-lock flow there.
+    #if DEBUG
+      showScan = true
+    #else
+      if PieceCameraSession.isCameraAvailable {
+        showScan = true
+      }
+    #endif
+  }
+
   #if DEBUG
     /// Also presented when `pusseldebug://camera` sets
     /// `session.debugCameraOpen`, so M9's overlay is demoable on the
@@ -95,9 +118,42 @@ struct PieceQueueView: View {
         }
       )
     }
+
+    /// Also presented when `pusseldebug://scan` sets
+    /// `session.debugScanOpen`, mirroring `cameraCoverIsPresented` above.
+    private var scanCoverIsPresented: Binding<Bool> {
+      Binding(
+        get: { showScan || session.debugScanOpen },
+        set: { newValue in
+          showScan = newValue
+          session.debugScanOpen = newValue
+        }
+      )
+    }
   #else
     private var cameraCoverIsPresented: Binding<Bool> { $showCamera }
+    private var scanCoverIsPresented: Binding<Bool> { $showScan }
   #endif
+}
+
+/// Second tile in the grid: opens the hands-free scan-and-lock flow.
+private struct ScanPiecesTile: View {
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      RoundedRectangle(cornerRadius: 10)
+        .strokeBorder(.tint, style: StrokeStyle(lineWidth: 2, dash: [6, 4]))
+        .aspectRatio(1, contentMode: .fit)
+        .overlay {
+          Image(systemName: "dot.viewfinder")
+            .font(.system(size: 28, weight: .light))
+            .foregroundStyle(.tint)
+        }
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel("Scan pieces")
+  }
 }
 
 /// Leading tile in the grid: a big plus that starts a new piece capture.

--- a/ios/Pussel/Features/Solve/PieceScanController.swift
+++ b/ios/Pussel/Features/Solve/PieceScanController.swift
@@ -121,13 +121,24 @@ final class PieceScanController {
 
   // MARK: - Dependencies
 
-  private let puzzleId: String
+  /// Read fresh for every request rather than captured once: the backend's
+  /// puzzle store is in-memory, so a backend restart invalidates the id
+  /// mid-session and `recoverPuzzle` (re-upload) mints a new one — the
+  /// retry must see it.
+  private let puzzleId: () -> String
   private let geometryClient: any PieceGeometryScanning
   /// Returns the full-res JPEG for the current frame, already downscaled and
   /// encoded. Nil means the capture failed (e.g. no camera in the Simulator
   /// when the DEBUG capture-image isn't set).
   private let capture: () async -> Data?
   private let haptic: (ScanHaptic) -> Void
+  /// Called when a geometry POST 404s (the backend forgot this puzzle — its
+  /// store is in-memory and a restart wipes it mid-session). Should obtain a
+  /// fresh puzzle id (`SolveSession.reupload`) and return whether it
+  /// succeeded; the POST is then retried once against `puzzleId()`. Without
+  /// this, every auto-lock on a stale session dead-ends in a red
+  /// "Puzzle not found" banner — found by the user on the first device run.
+  private let recoverPuzzle: (() async -> Bool)?
   /// Injected sleep so tests can override with a no-op instant function and
   /// avoid any real `Task.sleep` pauses.
   private let sleep: (TimeInterval) async -> Void
@@ -148,10 +159,11 @@ final class PieceScanController {
   // MARK: - Init
 
   init(
-    puzzleId: String,
+    puzzleId: @escaping () -> String,
     geometryClient: any PieceGeometryScanning,
     capture: @escaping () async -> Data?,
     haptic: @escaping (ScanHaptic) -> Void = pieceScanDefaultHaptic,
+    recoverPuzzle: (() async -> Bool)? = nil,
     sleep: @escaping (TimeInterval) async -> Void = pieceScanDefaultSleep,
     tracker: PieceScanStabilityTracker = PieceScanStabilityTracker()
   ) {
@@ -159,6 +171,7 @@ final class PieceScanController {
     self.geometryClient = geometryClient
     self.capture = capture
     self.haptic = haptic
+    self.recoverPuzzle = recoverPuzzle
     self.sleep = sleep
     self.tracker = tracker
   }
@@ -192,11 +205,23 @@ final class PieceScanController {
   /// Shared POST path used by both the auto-capture and the uncertain-confirm
   /// flows. Caller is responsible for clearing `pendingUncertainJPEG` before
   /// entering here (to close the race window for a double-tap confirm).
-  private func post(jpeg: Data, enrollUncertain: Bool) async {
+  ///
+  /// A 404 means the backend forgot this puzzle (in-memory store, restart) —
+  /// recover a fresh puzzle id and retry once, so a stale saved session heals
+  /// itself on the first lock instead of red-bannering every scan.
+  private func post(jpeg: Data, enrollUncertain: Bool, isRetry: Bool = false) async {
     do {
       let response = try await geometryClient.uploadPieceGeometry(
-        puzzleId: puzzleId, jpegData: jpeg, enrollUncertain: enrollUncertain)
+        puzzleId: puzzleId(), jpegData: jpeg, enrollUncertain: enrollUncertain)
       applyResponse(response, jpeg: jpeg)
+    } catch let error as APIError where error.status == 404 && !isRetry {
+      if let recoverPuzzle, await recoverPuzzle() {
+        await post(jpeg: jpeg, enrollUncertain: enrollUncertain, isRetry: true)
+        return
+      }
+      setVerdict(.failure("Puzzle session expired. Close the scanner and re-add the puzzle."))
+      haptic(.failure)
+      scheduleRearm(delay: Self.rearmDelayFailure)
     } catch {
       setVerdict(.failure(error.localizedDescription))
       haptic(.failure)
@@ -282,7 +307,7 @@ final class PieceScanController {
   /// strip on open is cosmetic, and the next POST will surface any real backend
   /// problem.
   func loadEnrolled() async {
-    guard let response = try? await geometryClient.listPieceGeometry(puzzleId: puzzleId)
+    guard let response = try? await geometryClient.listPieceGeometry(puzzleId: puzzleId())
     else { return }
     let knownIds = Set(gallery.map(\.pieceId))
     for piece in response.pieces where !knownIds.contains(piece.pieceId) {

--- a/ios/Pussel/Features/Solve/PieceScanController.swift
+++ b/ios/Pussel/Features/Solve/PieceScanController.swift
@@ -1,0 +1,340 @@
+import Foundation
+import UIKit
+
+// MARK: - Geometry scanning protocol
+
+/// The subset of `APIClient`'s geometry API surface needed by
+/// `PieceScanController`. Defined here (not in `APIClient.swift`) so the
+/// controller file is self-contained, and so fakes in tests can conform to it
+/// without touching the real network client.
+///
+/// The `enrollUncertain` parameter on `uploadPieceGeometry` has a default on
+/// `APIClient` itself (= false); the protocol declares it without a default so
+/// the concrete call site always makes the intent explicit and tests can
+/// intercept both paths without default-argument ambiguity.
+@MainActor
+protocol PieceGeometryScanning {
+  func uploadPieceGeometry(
+    puzzleId: String, jpegData: Data, enrollUncertain: Bool
+  ) async throws -> PieceGeometryUploadResponse
+  func listPieceGeometry(puzzleId: String) async throws -> PieceGeometryListResponse
+}
+
+// Conform `APIClient` to the protocol. The existing method already carries the
+// same signature with a default argument, so the protocol witness resolves to
+// it directly — the extension only names the conformance, nothing else.
+extension APIClient: PieceGeometryScanning {}
+
+// MARK: - Haptic
+
+/// Distinct scan outcomes mapped to distinct feedback patterns. Having an enum
+/// rather than a raw `UINotificationFeedbackGenerator.FeedbackType` lets the
+/// scanner's protocol express intent — not just "what kind of buzz" but "which
+/// scan event" — and lets the test fake record the semantic outcome without
+/// importing UIKit.
+enum ScanHaptic {
+  case success
+  case warning
+  case failure
+}
+
+// MARK: - State types
+
+/// The scan-and-lock state machine has four coarse phases matching the main
+/// actor's responsibility lifecycle: watching → capturing → showing the result
+/// → back to watching.
+enum ScanPhase: Equatable {
+  case scanning
+  case capturing
+  case verdict(ScanVerdict)
+}
+
+/// Terminal outcome of one capture–upload cycle. Each case is shown to the
+/// user with a distinct colour / message, and the re-arm duration is keyed to
+/// it.
+enum ScanVerdict: Equatable {
+  /// First time this piece was seen: enrolled and added to the gallery.
+  case locked(pieceId: String, edgeTypes: [GeometryEdgeType])
+  /// This piece was already in the store — show which one it matched.
+  case alreadyScanned(pieceId: String)
+  /// The upload succeeded but the store isn't sure whether this is a new or
+  /// duplicate piece. The user can confirm ("Add as new") via
+  /// `confirmUncertainAsNew()`.
+  case uncertain
+  /// The photo itself couldn't be measured (contour quality gate failed —
+  /// e.g. clutter merged into the silhouette), so there is no fingerprint to
+  /// compare or enroll. Distinct from `.uncertain`: offering "add as new"
+  /// here would be a dead end, because `on_uncertain=enroll` has nothing to
+  /// enroll — the only way forward is a better capture.
+  case unreadable
+  /// Network/server error or a nil capture.
+  case failure(String)
+}
+
+// MARK: - Gallery item
+
+/// One enrolled piece in the local gallery, kept between scan-and-lock cycles
+/// so the bottom strip is always up to date.
+struct ScannedPiece: Identifiable, Equatable {
+  let pieceId: String
+  let edgeTypes: [GeometryEdgeType]
+  /// The full-res JPEG captured at lock time. `nil` for pieces loaded from the
+  /// server list (`loadEnrolled`), where no local capture happened.
+  let thumbnailJPEG: Data?
+
+  /// `Identifiable` conformance — the backend's stable piece id.
+  var id: String { pieceId }
+}
+
+// MARK: - Controller
+
+/// Scan-and-lock state machine. Drives the camera's stability tracker and
+/// maps the geometry API's responses to the verdict UI.
+///
+/// Dependencies are injected at init so unit tests can run deterministically
+/// without a real camera, network, or clock:
+/// - `geometryClient` — real `APIClient` in production, a recording fake in tests.
+/// - `capture` — `async` closure that returns a full-res JPEG; tests can return
+///   fixture bytes without touching any camera.
+/// - `haptic` — test recorder instead of UIKit's feedback generator.
+/// - `sleep` — `Task.sleep` by default; tests inject an instant no-op so the
+///   re-arm delay doesn't pause the test suite.
+/// - `tracker` — the stability detector; default-init is fine for production,
+///   and tests can call `ingest` directly rather than faking it.
+@MainActor
+@Observable
+final class PieceScanController {
+
+  // MARK: - Re-arm delays
+
+  /// How long the verdict banner stays visible before the scanner re-arms.
+  /// `internal` so tests can reference them without magic numbers.
+  static let rearmDelayLocked: TimeInterval = 1.5
+  static let rearmDelayAlreadyScanned: TimeInterval = 2.0
+  static let rearmDelayFailure: TimeInterval = 2.0
+  /// Uncertain returns to scanning almost immediately — the "Add as new" chip
+  /// below provides the user's second opinion independently of the re-arm.
+  static let rearmDelayUncertain: TimeInterval = 0.6
+  /// Long enough to read "couldn't read the piece" and reposition, short
+  /// enough that scanning feels continuous.
+  static let rearmDelayUnreadable: TimeInterval = 1.2
+
+  // MARK: - Dependencies
+
+  private let puzzleId: String
+  private let geometryClient: any PieceGeometryScanning
+  /// Returns the full-res JPEG for the current frame, already downscaled and
+  /// encoded. Nil means the capture failed (e.g. no camera in the Simulator
+  /// when the DEBUG capture-image isn't set).
+  private let capture: () async -> Data?
+  private let haptic: (ScanHaptic) -> Void
+  /// Injected sleep so tests can override with a no-op instant function and
+  /// avoid any real `Task.sleep` pauses.
+  private let sleep: (TimeInterval) async -> Void
+  private var tracker: PieceScanStabilityTracker
+
+  // MARK: - Observable state
+
+  private(set) var phase: ScanPhase = .scanning
+  private(set) var gallery: [ScannedPiece] = []
+  /// Non-nil while the user can still confirm an uncertain verdict as a new
+  /// piece. Cleared either by `confirmUncertainAsNew()` or
+  /// `dismissUncertainChip()`.
+  private(set) var pendingUncertainJPEG: Data?
+  /// Set to the matching piece's id on an `.alreadyScanned` verdict so the
+  /// gallery strip can briefly highlight it. Cleared when the scanner re-arms.
+  private(set) var lastMatchedPieceId: String?
+
+  // MARK: - Init
+
+  init(
+    puzzleId: String,
+    geometryClient: any PieceGeometryScanning,
+    capture: @escaping () async -> Data?,
+    haptic: @escaping (ScanHaptic) -> Void = pieceScanDefaultHaptic,
+    sleep: @escaping (TimeInterval) async -> Void = pieceScanDefaultSleep,
+    tracker: PieceScanStabilityTracker = PieceScanStabilityTracker()
+  ) {
+    self.puzzleId = puzzleId
+    self.geometryClient = geometryClient
+    self.capture = capture
+    self.haptic = haptic
+    self.sleep = sleep
+    self.tracker = tracker
+  }
+
+  // MARK: - Streaming feed
+
+  /// Called for every preview update. Guards on `.scanning` so mid-capture or
+  /// mid-verdict calls are silently dropped — the tracker's own latch (once
+  /// fired, ignores further lockable detections until `reset()`) is a second
+  /// line of defence, but the phase guard is cheaper.
+  func ingest(_ state: PiecePreviewState, at date: Date) {
+    guard phase == .scanning else { return }
+    if tracker.ingest(state, at: date) {
+      Task { await lockAndPost() }
+    }
+  }
+
+  // MARK: - Core capture + upload flow
+
+  private func lockAndPost() async {
+    phase = .capturing
+    guard let jpeg = await capture() else {
+      setVerdict(.failure("Could not capture the piece."))
+      haptic(.failure)
+      scheduleRearm(delay: Self.rearmDelayFailure)
+      return
+    }
+    await post(jpeg: jpeg, enrollUncertain: false)
+  }
+
+  /// Shared POST path used by both the auto-capture and the uncertain-confirm
+  /// flows. Caller is responsible for clearing `pendingUncertainJPEG` before
+  /// entering here (to close the race window for a double-tap confirm).
+  private func post(jpeg: Data, enrollUncertain: Bool) async {
+    do {
+      let response = try await geometryClient.uploadPieceGeometry(
+        puzzleId: puzzleId, jpegData: jpeg, enrollUncertain: enrollUncertain)
+      applyResponse(response, jpeg: jpeg)
+    } catch {
+      setVerdict(.failure(error.localizedDescription))
+      haptic(.failure)
+      scheduleRearm(delay: Self.rearmDelayFailure)
+    }
+  }
+
+  private func applyResponse(_ response: PieceGeometryUploadResponse, jpeg: Data) {
+    switch response.status {
+    case .new:
+      let pieceId = response.pieceId ?? UUID().uuidString
+      let edgeTypes = response.edgeTypes
+      gallery.append(ScannedPiece(pieceId: pieceId, edgeTypes: edgeTypes, thumbnailJPEG: jpeg))
+      pendingUncertainJPEG = nil
+      setVerdict(.locked(pieceId: pieceId, edgeTypes: edgeTypes))
+      haptic(.success)
+      scheduleRearm(delay: Self.rearmDelayLocked)
+
+    case .matched:
+      let matchId = response.matchPieceId ?? response.pieceId ?? "?"
+      pendingUncertainJPEG = nil
+      lastMatchedPieceId = matchId
+      setVerdict(.alreadyScanned(pieceId: matchId))
+      haptic(.warning)
+      scheduleRearm(delay: Self.rearmDelayAlreadyScanned)
+
+    case .uncertain:
+      // Two flavors share the wire status. A genuine gray-zone verdict
+      // always carries the closest match's z-score (a comparison was made);
+      // a nil z-score means the pipeline failed on this photo (no clean
+      // contour → no fingerprint), and re-posting the same bytes with
+      // on_uncertain=enroll would loop forever — found the hard way in the
+      // M10 E2E, where a cluttered photo kept the confirm chip alive with
+      // nothing behind it.
+      guard response.zScore != nil else {
+        setVerdict(.unreadable)
+        scheduleRearm(delay: Self.rearmDelayUnreadable)
+        return
+      }
+      // Keep the JPEG so the user can confirm it as a new piece.
+      // No haptic — an alarming buzz would be counter-productive here.
+      pendingUncertainJPEG = jpeg
+      setVerdict(.uncertain)
+      scheduleRearm(delay: Self.rearmDelayUncertain)
+    }
+  }
+
+  // MARK: - Uncertain confirm
+
+  /// Enrolls the pending uncertain piece as a new piece. A no-op if
+  /// `pendingUncertainJPEG` is already nil (double-tap protection: the first
+  /// call clears it before awaiting the network, so a second call finds nil
+  /// and returns immediately).
+  func confirmUncertainAsNew() async {
+    guard let jpeg = pendingUncertainJPEG else { return }
+    // Clear immediately — before the await — so a second tap while the
+    // request is in flight is a clean no-op.
+    pendingUncertainJPEG = nil
+    phase = .capturing
+    await post(jpeg: jpeg, enrollUncertain: true)
+  }
+
+  /// Removes the uncertain chip without enrolling the piece.
+  func dismissUncertainChip() {
+    pendingUncertainJPEG = nil
+  }
+
+  #if DEBUG
+    /// The currently presented controller, so `pusseldebug://scanconfirm` can
+    /// drive the uncertain-confirm chip without a synthetic tap (Simulator
+    /// windows are often untappable in headless sessions — see
+    /// `PieceCameraSession.debugActive` for the precedent). Registered by
+    /// `PieceScanView.task`, cleared on disappear.
+    static weak var debugActive: PieceScanController?
+  #endif
+
+  // MARK: - Gallery pre-fill
+
+  /// Fetches the already-enrolled pieces from the server and merges them into
+  /// the gallery. Pieces already present (matched by `pieceId`) keep their
+  /// local thumbnails; pieces known only to the server are appended with
+  /// `thumbnailJPEG: nil`. Errors are silently swallowed — an empty gallery
+  /// strip on open is cosmetic, and the next POST will surface any real backend
+  /// problem.
+  func loadEnrolled() async {
+    guard let response = try? await geometryClient.listPieceGeometry(puzzleId: puzzleId)
+    else { return }
+    let knownIds = Set(gallery.map(\.pieceId))
+    for piece in response.pieces where !knownIds.contains(piece.pieceId) {
+      gallery.append(
+        ScannedPiece(pieceId: piece.pieceId, edgeTypes: piece.edgeTypes, thumbnailJPEG: nil))
+    }
+  }
+
+  // MARK: - Private helpers
+
+  private func setVerdict(_ verdict: ScanVerdict) {
+    phase = .verdict(verdict)
+  }
+
+  /// Schedules re-arm after the verdict display duration. Uses the injected
+  /// `sleep` closure so tests can override with an instant function and avoid
+  /// real pauses. Guards that `phase` is still in the verdict that scheduled
+  /// this rearm before resetting — a `confirmUncertainAsNew()` call that
+  /// arrives during the uncertain window will already have moved the phase to
+  /// `.capturing`, so we must not then stomp it back to `.scanning`.
+  private func scheduleRearm(delay: TimeInterval) {
+    let verdictAtSchedule = phase
+    Task {
+      await self.sleep(delay)
+      // Only reset if the phase hasn't been advanced by another action (e.g.
+      // confirmUncertainAsNew changed .uncertain → .capturing before we woke).
+      guard self.phase == verdictAtSchedule else { return }
+      self.lastMatchedPieceId = nil
+      self.tracker.reset()
+      self.phase = .scanning
+    }
+  }
+
+}
+
+// MARK: - Default injectable dependencies
+
+/// Default haptic handler used by `PieceScanController`. Defined at module
+/// scope rather than as a static method so it can be passed as a default
+/// argument without the "covariant Self in default expression" restriction.
+private func pieceScanDefaultHaptic(_ kind: ScanHaptic) {
+  let type: UINotificationFeedbackGenerator.FeedbackType
+  switch kind {
+  case .success: type = .success
+  case .warning: type = .warning
+  case .failure: type = .error
+  }
+  UINotificationFeedbackGenerator().notificationOccurred(type)
+}
+
+/// Default sleep closure: wraps `Task.sleep` in a non-throwing shell so it
+/// can serve as a plain `(TimeInterval) async -> Void` default argument.
+private func pieceScanDefaultSleep(_ seconds: TimeInterval) async {
+  try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+}

--- a/ios/Pussel/Features/Solve/PieceScanController.swift
+++ b/ios/Pussel/Features/Solve/PieceScanController.swift
@@ -214,7 +214,15 @@ final class PieceScanController {
       scheduleRearm(delay: Self.rearmDelayFailure)
       return
     }
-    await post(jpeg: jpeg, enrollUncertain: false)
+    // Hands-free enrollment: gray-zone verdicts enroll immediately instead of
+    // waiting for a confirm tap. The M10 device runs showed the confirm-chip
+    // flow costs one tap per new piece (M7: ~98% of new pieces land in the
+    // gray zone), which defeats the scan-10-pieces-hands-free goal. The
+    // matching risk is carried by the relaxed backend t_accept (M7's FMR=1%
+    // point): ~8% of genuine re-scans may now enroll as duplicates, deletable
+    // from the piece list. The chip UX below remains for the response shapes
+    // that still report uncertain (e.g. a server with enrollment disabled).
+    await post(jpeg: jpeg, enrollUncertain: true)
   }
 
   /// Shared POST path used by both the auto-capture and the uncertain-confirm

--- a/ios/Pussel/Features/Solve/PieceScanController.swift
+++ b/ios/Pussel/Features/Solve/PieceScanController.swift
@@ -255,7 +255,17 @@ final class PieceScanController {
   private func applyResponse(_ response: PieceGeometryUploadResponse, jpeg: Data) {
     switch response.status {
     case .new:
-      let pieceId = response.pieceId ?? UUID().uuidString
+      // A `new` verdict must carry the backend's piece id — it's the key the
+      // gallery/persistence link (onEnrolled → scanPieceId → thumbnail
+      // restore, "already scanned" highlighting) is built on. Inventing a
+      // UUID would persist an id the backend never issued and silently break
+      // all of that, so a missing id is treated as an invalid response.
+      guard let pieceId = response.pieceId else {
+        setVerdict(.failure("The server enrolled the piece without an id. Try again."))
+        haptic(.failure)
+        scheduleRearm(delay: Self.rearmDelayFailure)
+        return
+      }
       let edgeTypes = response.edgeTypes
       gallery.append(ScannedPiece(pieceId: pieceId, edgeTypes: edgeTypes, thumbnailJPEG: jpeg))
       pendingUncertainJPEG = nil

--- a/ios/Pussel/Features/Solve/PieceScanController.swift
+++ b/ios/Pussel/Features/Solve/PieceScanController.swift
@@ -139,6 +139,17 @@ final class PieceScanController {
   /// this, every auto-lock on a stale session dead-ends in a red
   /// "Puzzle not found" banner — found by the user on the first device run.
   private let recoverPuzzle: (() async -> Bool)?
+  /// Called once per enrolled piece (a `new` verdict, auto or via the
+  /// uncertain-confirm) with the geometry piece id and the captured JPEG.
+  /// The view wires this to `SolveSession.enqueueScanned`, which is what
+  /// puts scanned pieces into the puzzle page's piece list and persists
+  /// their photos — the scan gallery restores its thumbnails from those
+  /// entries via `thumbnailForPiece`.
+  private let onEnrolled: ((String, Data) -> Void)?
+  /// Locally stored photo for a geometry piece id, for gallery items whose
+  /// piece was scanned in an earlier scanner visit (the server list carries
+  /// no images). Nil (absent or no match) falls back to the placeholder tile.
+  private let thumbnailForPiece: ((String) -> Data?)?
   /// Injected sleep so tests can override with a no-op instant function and
   /// avoid any real `Task.sleep` pauses.
   private let sleep: (TimeInterval) async -> Void
@@ -164,6 +175,8 @@ final class PieceScanController {
     capture: @escaping () async -> Data?,
     haptic: @escaping (ScanHaptic) -> Void = pieceScanDefaultHaptic,
     recoverPuzzle: (() async -> Bool)? = nil,
+    onEnrolled: ((String, Data) -> Void)? = nil,
+    thumbnailForPiece: ((String) -> Data?)? = nil,
     sleep: @escaping (TimeInterval) async -> Void = pieceScanDefaultSleep,
     tracker: PieceScanStabilityTracker = PieceScanStabilityTracker()
   ) {
@@ -172,6 +185,8 @@ final class PieceScanController {
     self.capture = capture
     self.haptic = haptic
     self.recoverPuzzle = recoverPuzzle
+    self.onEnrolled = onEnrolled
+    self.thumbnailForPiece = thumbnailForPiece
     self.sleep = sleep
     self.tracker = tracker
   }
@@ -236,6 +251,7 @@ final class PieceScanController {
       let edgeTypes = response.edgeTypes
       gallery.append(ScannedPiece(pieceId: pieceId, edgeTypes: edgeTypes, thumbnailJPEG: jpeg))
       pendingUncertainJPEG = nil
+      onEnrolled?(pieceId, jpeg)
       setVerdict(.locked(pieceId: pieceId, edgeTypes: edgeTypes))
       haptic(.success)
       scheduleRearm(delay: Self.rearmDelayLocked)
@@ -312,7 +328,13 @@ final class PieceScanController {
     let knownIds = Set(gallery.map(\.pieceId))
     for piece in response.pieces where !knownIds.contains(piece.pieceId) {
       gallery.append(
-        ScannedPiece(pieceId: piece.pieceId, edgeTypes: piece.edgeTypes, thumbnailJPEG: nil))
+        ScannedPiece(
+          pieceId: piece.pieceId,
+          edgeTypes: piece.edgeTypes,
+          // Pieces enrolled in an earlier scanner visit were enqueued into
+          // the session's piece list at lock time — recover their photos
+          // from there rather than showing a placeholder.
+          thumbnailJPEG: thumbnailForPiece?(piece.pieceId)))
     }
   }
 

--- a/ios/Pussel/Features/Solve/PieceScanStability.swift
+++ b/ios/Pussel/Features/Solve/PieceScanStability.swift
@@ -69,8 +69,13 @@ struct PieceScanStabilityTracker {
     }
 
     let bbox = boundingBox(of: polygon)
-    guard isValidBbox(bbox) else {
-      // Degenerate polygon (< 3 points or zero-area bbox) — treat as noise.
+    guard polygon.count >= 3, isValidBbox(bbox) else {
+      // Degenerate polygon (< 3 points, or a line/point whose bbox has zero
+      // area) — treat as noise. The real pipeline already guards count >= 3
+      // in PiecePreviewStreamer.apply, but this value type documents the same
+      // contract, so it enforces it independently rather than trusting the
+      // caller (a 2-point diagonal has a positive-area bbox and would slip
+      // past the area check alone).
       resetStreak()
       return false
     }
@@ -139,9 +144,10 @@ struct PieceScanStabilityTracker {
     return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
   }
 
-  /// A bbox is considered valid (non-degenerate) when the polygon has ≥ 3
-  /// points AND the box has positive area. A 1- or 2-point polygon collapses
-  /// to a line or point, which would produce an IoU of 0 against everything.
+  /// A bbox is non-degenerate when it has positive area. The polygon
+  /// point-count check (≥ 3) lives in `ingest`, where the polygon is still in
+  /// hand; together they reject lines and points, which would produce an IoU
+  /// of 0 against everything.
   private func isValidBbox(_ rect: CGRect) -> Bool {
     rect.width > 0 && rect.height > 0
   }

--- a/ios/Pussel/Features/Solve/PieceScanStability.swift
+++ b/ios/Pussel/Features/Solve/PieceScanStability.swift
@@ -1,0 +1,160 @@
+import CoreGraphics
+import Foundation
+
+/// Pure decision logic for when a live piece detection has been stable-and-
+/// lockable long enough to trigger an auto-capture. No I/O, no timers, no
+/// actor isolation — a plain value type, directly unit-testable without
+/// mocking the network or a clock.
+///
+/// Stability is measured as axis-aligned bounding-box IoU between consecutive
+/// lockable detections. Full polygon IoU would be more precise but requires a
+/// clipping algorithm (O(n²)) and is fragile on non-convex shapes; bbox IoU
+/// is O(1), unit-testable with pencil arithmetic, and sufficient here because
+/// the piece camera is held close — when the piece isn't moving, its bbox
+/// barely drifts, and the minIoU threshold already ignores tiny jitter.
+///
+/// `PieceCaptureView` / its controller is responsible for calling `reset()`
+/// after acting on a fire so the tracker is ready for the next piece.
+struct PieceScanStabilityTracker {
+  // MARK: - Configuration
+
+  /// Minimum wall-clock duration a consecutive lockable streak must span
+  /// before the tracker fires. Default 1.0 s matches M10's "hold for ~1 s"
+  /// brief.
+  let minDuration: TimeInterval
+  /// Minimum number of lockable samples within the streak. Guards against a
+  /// long but very sparsely sampled streak (e.g. one frame per 0.9 s).
+  let minSamples: Int
+  /// Minimum IoU between consecutive lockable bbox pairs to extend a streak;
+  /// below this the piece has drifted and the streak resets.
+  let minIoU: Double
+
+  // MARK: - Private streak state
+
+  private var streakStart: Date?
+  private var streakSampleCount: Int = 0
+  private var lastPolygon: [NormalizedPoint]?
+  /// Once the tracker fires it latches here and ignores further lockable
+  /// detections until `reset()` is called. This prevents the controller
+  /// from seeing multiple fires for the same held pose.
+  private var hasFired: Bool = false
+
+  // MARK: - Init
+
+  init(minDuration: TimeInterval = 1.0, minSamples: Int = 3, minIoU: Double = 0.8) {
+    self.minDuration = minDuration
+    self.minSamples = minSamples
+    self.minIoU = minIoU
+  }
+
+  // MARK: - Public API
+
+  /// Feed every preview update. Returns `true` exactly once per stable
+  /// streak — on the ingest where the stability criterion first fires. The
+  /// tracker latches after firing; call `reset()` to arm it for the next
+  /// piece.
+  ///
+  /// Only `.lockable` states extend a streak; `.detected` and `.none` reset
+  /// it. A detected-but-not-lockable frame means the backend's quality gate
+  /// didn't pass (unclean contour, corner disagreement), so counting it would
+  /// give a false sense of stability.
+  @discardableResult
+  mutating func ingest(_ state: PiecePreviewState, at date: Date) -> Bool {
+    guard !hasFired else { return false }
+
+    guard case .lockable(let polygon, _) = state else {
+      // Any non-lockable state breaks the streak.
+      resetStreak()
+      return false
+    }
+
+    let bbox = boundingBox(of: polygon)
+    guard isValidBbox(bbox) else {
+      // Degenerate polygon (< 3 points or zero-area bbox) — treat as noise.
+      resetStreak()
+      return false
+    }
+
+    if let last = lastPolygon {
+      let lastBbox = boundingBox(of: last)
+      guard isValidBbox(lastBbox), iou(bbox, lastBbox) >= minIoU else {
+        // The piece jumped or rotated — restart counting from this frame.
+        resetStreak(firstPolygon: polygon, at: date)
+        return false
+      }
+    } else {
+      // First lockable frame in this streak.
+      streakStart = date
+      streakSampleCount = 0
+    }
+
+    lastPolygon = polygon
+    streakSampleCount += 1
+
+    guard let start = streakStart else { return false }
+    let elapsed = date.timeIntervalSince(start)
+    guard elapsed >= minDuration, streakSampleCount >= minSamples else { return false }
+
+    hasFired = true
+    return true
+  }
+
+  /// Resets all streak state so the tracker is ready for a new piece.
+  /// Call this after acting on a fire (e.g. after the verdict UX completes).
+  mutating func reset() {
+    resetStreak()
+    hasFired = false
+  }
+
+  // MARK: - Private helpers
+
+  private mutating func resetStreak(firstPolygon: [NormalizedPoint]? = nil, at date: Date? = nil) {
+    if let firstPolygon, let date {
+      // Seed the new streak with the frame that caused the reset so the
+      // detection that broke the old streak isn't lost — it's the first
+      // sample of the next one.
+      lastPolygon = firstPolygon
+      streakStart = date
+      streakSampleCount = 1
+    } else {
+      lastPolygon = nil
+      streakStart = nil
+      streakSampleCount = 0
+    }
+  }
+
+  /// Axis-aligned bounding box of a polygon, in [0,1] normalized coordinates.
+  private func boundingBox(of polygon: [NormalizedPoint]) -> CGRect {
+    guard !polygon.isEmpty else { return .zero }
+    var minX = polygon[0].x
+    var maxX = polygon[0].x
+    var minY = polygon[0].y
+    var maxY = polygon[0].y
+    for pt in polygon.dropFirst() {
+      minX = min(minX, pt.x)
+      maxX = max(maxX, pt.x)
+      minY = min(minY, pt.y)
+      maxY = max(maxY, pt.y)
+    }
+    return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+  }
+
+  /// A bbox is considered valid (non-degenerate) when the polygon has ≥ 3
+  /// points AND the box has positive area. A 1- or 2-point polygon collapses
+  /// to a line or point, which would produce an IoU of 0 against everything.
+  private func isValidBbox(_ rect: CGRect) -> Bool {
+    rect.width > 0 && rect.height > 0
+  }
+
+  /// Intersection-over-union of two axis-aligned rectangles. Returns 0 when
+  /// the rectangles don't overlap.
+  private func iou(_ rectA: CGRect, _ rectB: CGRect) -> Double {
+    let intersection = rectA.intersection(rectB)
+    guard !intersection.isNull else { return 0 }
+    let intersectionArea = Double(intersection.width * intersection.height)
+    let unionArea =
+      Double(rectA.width * rectA.height) + Double(rectB.width * rectB.height) - intersectionArea
+    guard unionArea > 0 else { return 0 }
+    return intersectionArea / unionArea
+  }
+}

--- a/ios/Pussel/Features/Solve/PieceScanView.swift
+++ b/ios/Pussel/Features/Solve/PieceScanView.swift
@@ -72,13 +72,22 @@ struct PieceScanView: View {
       camera.attachPreviewStreamer(streamer)
 
       let ctrl = PieceScanController(
-        puzzleId: session.puzzleId,
+        puzzleId: { [weak session] in session?.puzzleId ?? "" },
         geometryClient: model.api,
         capture: { [weak camera] in
           guard let camera else { return nil }
           let image = await camera.capturePhoto()
           guard let image else { return nil }
           return ImageUtilities.normalizedJPEG(from: image, maxDimension: 1600, quality: 0.9)
+        },
+        // The backend's puzzle store is in-memory: a stored session's id can
+        // 404 after a backend restart. Recover the same way the piece queue
+        // does — re-upload the kept trimmed image for a fresh id — so the
+        // first auto-lock heals the session instead of red-bannering.
+        recoverPuzzle: { [weak session] in
+          guard let session else { return false }
+          await session.reupload(api: model.api)
+          return session.errorMessage == nil
         }
       )
       controller = ctrl

--- a/ios/Pussel/Features/Solve/PieceScanView.swift
+++ b/ios/Pussel/Features/Solve/PieceScanView.swift
@@ -1,0 +1,309 @@
+import AVFoundation
+import SwiftUI
+import UIKit
+
+/// Full-screen hands-free scan mode: holds the camera over a piece, waits for
+/// the stability tracker to fire, and posts the geometry. No shutter — the
+/// lock triggers automatically after the piece holds still for ≥1 s.
+///
+/// Camera lifecycle mirrors `PieceCaptureView` exactly: started in `.task`,
+/// stopped in `.onDisappear`, with the same DEBUG Simulator no-camera fallback
+/// so `pusseldebug://previewloop` can demo the overlay over a black background.
+struct PieceScanView: View {
+  @Environment(AppModel.self) private var model
+  @Environment(\.dismiss) private var dismiss
+
+  let session: SolveSession
+
+  @State private var camera = PieceCameraSession()
+  @State private var previewStreamer: PiecePreviewStreamer?
+  @State private var controller: PieceScanController?
+
+  /// Drives the brief green flash that acknowledges a successful lock.
+  @State private var showLockFlash = false
+
+  var body: some View {
+    ZStack {
+      Color.black.ignoresSafeArea()
+      CameraPreview(
+        session: camera.session,
+        previewState: previewStreamer?.state ?? .none,
+        updatedAt: previewStreamer?.updatedAt ?? .distantPast,
+        frameSize: previewStreamer?.frameSize ?? .zero
+      )
+      .ignoresSafeArea()
+
+      // Green flash on successful lock: a translucent overlay that appears
+      // instantly and fades out, giving the user tactile feedback that the
+      // capture fired without any button tap.
+      if showLockFlash {
+        Color.green.opacity(0.25)
+          .ignoresSafeArea()
+          .allowsHitTesting(false)
+          .transition(.opacity)
+      }
+    }
+    // Top bar: Done + hint label.
+    .overlay(alignment: .top) {
+      HStack {
+        Button("Done") { dismiss() }
+          .foregroundStyle(.white)
+        Spacer()
+        Text(hintText)
+          .font(.subheadline.weight(.medium))
+          .foregroundStyle(.white)
+          .padding(.trailing, 4)
+      }
+      .padding(.horizontal)
+      .padding(.vertical, 12)
+    }
+    // Verdict banner + bottom controls.
+    .overlay(alignment: .bottom) {
+      VStack(spacing: 12) {
+        verdictBanner
+        uncertainChip
+        galleryStrip
+      }
+      .padding(.bottom, 24)
+    }
+    .task {
+      let streamer = previewStreamer ?? PiecePreviewStreamer(api: model.api)
+      previewStreamer = streamer
+      camera.attachPreviewStreamer(streamer)
+
+      let ctrl = PieceScanController(
+        puzzleId: session.puzzleId,
+        geometryClient: model.api,
+        capture: { [weak camera] in
+          guard let camera else { return nil }
+          let image = await camera.capturePhoto()
+          guard let image else { return nil }
+          return ImageUtilities.normalizedJPEG(from: image, maxDimension: 1600, quality: 0.9)
+        }
+      )
+      controller = ctrl
+      #if DEBUG
+        PieceScanController.debugActive = ctrl
+      #endif
+      // Pre-fill the gallery concurrently — the camera shouldn't wait behind
+      // a network round-trip, and the strip appearing a beat later is fine.
+      Task { await ctrl.loadEnrolled() }
+
+      let started = await camera.start()
+      guard !Task.isCancelled else { return }
+      guard started else {
+        #if DEBUG
+          if !PieceCameraSession.isCameraAvailable {
+            camera.setPreviewStreamingEnabled(true)
+            return
+          }
+        #endif
+        // Real device failure (permission denied, no device): report and close.
+        model.reportPieceError("Pussel cannot use the camera. Check camera access in Settings.")
+        dismiss()
+        return
+      }
+      camera.setPreviewStreamingEnabled(true)
+    }
+    .onDisappear {
+      camera.setPreviewStreamingEnabled(false)
+      camera.stop()
+      previewStreamer?.reset()
+      #if DEBUG
+        if PieceScanController.debugActive === controller {
+          PieceScanController.debugActive = nil
+        }
+      #endif
+    }
+    .keepsScreenAwake()
+    // Drive the controller from the preview stream.
+    .onChange(of: previewStreamer?.updatedAt) { _, _ in
+      guard let streamer = previewStreamer, let ctrl = controller else { return }
+      ctrl.ingest(streamer.state, at: streamer.updatedAt)
+    }
+    // React to phase changes that need view-level side effects.
+    .onChange(of: controller?.phase) { _, newPhase in
+      guard case .verdict(let verdict) = newPhase else { return }
+      if case .locked = verdict {
+        triggerLockFlash()
+      }
+    }
+  }
+
+  // MARK: - Sub-views
+
+  /// Hint shown in the top bar while the camera is live.
+  private var hintText: String {
+    switch controller?.phase {
+    case .capturing: return "Locking…"
+    default: return "Hold steady over a piece"
+    }
+  }
+
+  /// Coloured capsule banner shown over the preview when a verdict arrives.
+  @ViewBuilder
+  private var verdictBanner: some View {
+    if let phase = controller?.phase, case .verdict(let verdict) = phase {
+      Group {
+        switch verdict {
+        case .locked(_, let edgeTypes):
+          verdictCapsule(
+            text: "Piece locked ✓ \(edgeGlyphs(edgeTypes))",
+            background: .green
+          )
+        case .alreadyScanned:
+          verdictCapsule(text: "Already scanned", background: .orange)
+        case .unreadable:
+          verdictCapsule(
+            text: "Couldn't read the piece — adjust and hold steady", background: .gray)
+        case .failure(let msg):
+          verdictCapsule(text: msg, background: .red)
+        case .uncertain:
+          EmptyView()
+        }
+      }
+      .transition(.scale(scale: 0.85).combined(with: .opacity))
+    }
+  }
+
+  private func verdictCapsule(text: String, background: Color) -> some View {
+    Text(text)
+      .font(.subheadline.weight(.semibold))
+      .foregroundStyle(.white)
+      .padding(.horizontal, 20)
+      .padding(.vertical, 10)
+      .background(Capsule().fill(background))
+      .shadow(radius: 4)
+  }
+
+  /// "Not sure — tap to add as new piece" chip, shown when the server returned
+  /// an uncertain verdict and the user hasn't dismissed it yet.
+  @ViewBuilder
+  private var uncertainChip: some View {
+    if controller?.pendingUncertainJPEG != nil {
+      HStack(spacing: 8) {
+        Button {
+          Task { await controller?.confirmUncertainAsNew() }
+        } label: {
+          Text("Not sure — tap to add as new piece")
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(.white)
+        }
+        Button {
+          controller?.dismissUncertainChip()
+        } label: {
+          Image(systemName: "xmark")
+            .font(.caption.weight(.bold))
+            .foregroundStyle(.white.opacity(0.8))
+        }
+        .accessibilityLabel("Dismiss")
+      }
+      .padding(.horizontal, 16)
+      .padding(.vertical, 10)
+      .background(
+        Capsule().fill(.ultraThinMaterial.opacity(0.9))
+          .background(Capsule().fill(Color.secondary.opacity(0.5)))
+      )
+      .transition(.scale(scale: 0.9).combined(with: .opacity))
+    }
+  }
+
+  /// Horizontal scrolling row of scanned pieces with edge-type badges.
+  @ViewBuilder
+  private var galleryStrip: some View {
+    let pieces = controller?.gallery ?? []
+    let matchedId = controller?.lastMatchedPieceId
+    let isAlreadyScanned: Bool = {
+      if case .verdict(.alreadyScanned) = controller?.phase { return true }
+      return false
+    }()
+
+    VStack(alignment: .leading, spacing: 6) {
+      if !pieces.isEmpty {
+        Text("Scanned: \(pieces.count)")
+          .font(.caption)
+          .foregroundStyle(.white.opacity(0.7))
+          .padding(.leading, 16)
+        ScrollView(.horizontal, showsIndicators: false) {
+          HStack(spacing: 10) {
+            ForEach(pieces) { piece in
+              GalleryItemView(
+                piece: piece,
+                isHighlighted: isAlreadyScanned && piece.pieceId == matchedId
+              )
+            }
+          }
+          .padding(.horizontal, 16)
+          .padding(.vertical, 4)
+        }
+      }
+    }
+    .animation(.easeInOut(duration: 0.25), value: pieces.count)
+  }
+
+  // MARK: - Helpers
+
+  /// Joins edge glyphs with the middle-dot separator used throughout the UI.
+  private func edgeGlyphs(_ types: [GeometryEdgeType]) -> String {
+    types.map(\.glyph).joined(separator: "·")
+  }
+
+  /// Shows the green lock-flash overlay for ~0.4 s.
+  private func triggerLockFlash() {
+    withAnimation(.easeIn(duration: 0.05)) { showLockFlash = true }
+    Task {
+      try? await Task.sleep(nanoseconds: 400_000_000)
+      withAnimation(.easeOut(duration: 0.35)) { showLockFlash = false }
+    }
+  }
+}
+
+// MARK: - Gallery item view
+
+/// 56 pt rounded square for one scanned piece: thumbnail or puzzle-piece
+/// placeholder, with the edge-type glyphs underneath.
+private struct GalleryItemView: View {
+  let piece: ScannedPiece
+  let isHighlighted: Bool
+
+  private static let size: CGFloat = 56
+  private static let cornerRadius: CGFloat = 10
+
+  var body: some View {
+    VStack(spacing: 4) {
+      ZStack {
+        RoundedRectangle(cornerRadius: Self.cornerRadius)
+          .fill(Color.white.opacity(0.12))
+          .frame(width: Self.size, height: Self.size)
+
+        if let data = piece.thumbnailJPEG, let uiImage = UIImage(data: data) {
+          Image(uiImage: uiImage)
+            .resizable()
+            .scaledToFill()
+            .frame(width: Self.size, height: Self.size)
+            .clipShape(RoundedRectangle(cornerRadius: Self.cornerRadius))
+        } else {
+          Image(systemName: "puzzlepiece")
+            .font(.system(size: 24))
+            .foregroundStyle(.white.opacity(0.5))
+        }
+      }
+      .overlay {
+        if isHighlighted {
+          RoundedRectangle(cornerRadius: Self.cornerRadius)
+            .strokeBorder(.orange, lineWidth: 2.5)
+        }
+      }
+      // Pulse the orange border when highlighted: a brief scale animation
+      // draws the eye to the matched piece without permanent styling.
+      .scaleEffect(isHighlighted ? 1.06 : 1.0)
+      .animation(.easeInOut(duration: 0.25), value: isHighlighted)
+
+      if !piece.edgeTypes.isEmpty {
+        Text(piece.edgeTypes.map(\.glyph).joined(separator: "·"))
+          .font(.caption2.monospaced())
+          .foregroundStyle(.white.opacity(0.7))
+      }
+    }
+  }
+}

--- a/ios/Pussel/Features/Solve/PieceScanView.swift
+++ b/ios/Pussel/Features/Solve/PieceScanView.swift
@@ -104,12 +104,19 @@ struct PieceScanView: View {
       #if DEBUG
         PieceScanController.debugActive = ctrl
       #endif
-      // Pre-fill the gallery concurrently — the camera shouldn't wait behind
-      // a network round-trip, and the strip appearing a beat later is fine.
-      Task { await ctrl.loadEnrolled() }
+      // Pre-fill the gallery concurrently with camera startup (which can block
+      // on the permission prompt), but as a STRUCTURED child of this `.task`
+      // rather than a detached `Task {}`: if the view disappears mid-request
+      // it's cancelled with the `.task`, so loadEnrolled's await unwinds
+      // instead of mutating `gallery` after the UI is gone. Awaited on every
+      // exit path (early returns cancel-and-await it implicitly).
+      async let galleryPrefill: Void = ctrl.loadEnrolled()
 
       let started = await camera.start()
-      guard !Task.isCancelled else { return }
+      guard !Task.isCancelled else {
+        await galleryPrefill
+        return
+      }
       guard started else {
         #if DEBUG
           if !PieceCameraSession.isCameraAvailable {
@@ -123,6 +130,7 @@ struct PieceScanView: View {
         return
       }
       camera.setPreviewStreamingEnabled(true)
+      await galleryPrefill
     }
     .onDisappear {
       camera.setPreviewStreamingEnabled(false)

--- a/ios/Pussel/Features/Solve/PieceScanView.swift
+++ b/ios/Pussel/Features/Solve/PieceScanView.swift
@@ -88,6 +88,16 @@ struct PieceScanView: View {
           guard let session else { return false }
           await session.reupload(api: model.api)
           return session.errorMessage == nil
+        },
+        // Every enrolled piece also joins the puzzle page's piece list —
+        // predicted, persisted, and drawn on the overlay like any shutter
+        // capture. That persistence is also where the gallery's thumbnails
+        // come back from on later scanner visits (thumbnailForPiece).
+        onEnrolled: { [weak session] pieceId, jpeg in
+          session?.enqueueScanned(jpeg: jpeg, scanPieceId: pieceId, api: model.api)
+        },
+        thumbnailForPiece: { [weak session] pieceId in
+          session?.entry(forScanPieceId: pieceId)?.displayImage
         }
       )
       controller = ctrl

--- a/ios/Pussel/Models/PieceGeometryModels.swift
+++ b/ios/Pussel/Models/PieceGeometryModels.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+// Models for POST .../piece/geometry and GET .../piece/geometry, mirroring
+// backend/app/models/piece_geometry_model.py. The shared decoder uses
+// .convertFromSnakeCase, so snake_case JSON keys map automatically to
+// camelCase Swift properties. Extra JSON keys (dominant_dev, polyline,
+// corners, corner_confidences, contour, n_large_components, border_touching,
+// area_ratio, solidity, …) are silently ignored — we only decode what the
+// iOS scan-lock UI needs.
+
+// MARK: - Edge type
+
+/// Puzzle-edge profile: a tab protrudes into the neighbour, a blank receives
+/// one, and a flat side sits on the puzzle border.
+enum GeometryEdgeType: String, Codable, Equatable {
+  case tab
+  case blank
+  case flat
+
+  /// Single-character glyph used in the gallery's edge-type summary line
+  /// (e.g. "T·B·F·T"). Compact and language-independent.
+  var glyph: String {
+    switch self {
+    case .tab: return "T"
+    case .blank: return "B"
+    case .flat: return "F"
+    }
+  }
+}
+
+// MARK: - Quality
+
+/// Quality verdict for a piece contour. Only the two boolean flags matter to
+/// the scan-lock flow; the numeric metrics (area_ratio, solidity, …) are left
+/// on the backend and not decoded here.
+struct GeometryQuality: Codable, Equatable {
+  /// The contour passed all quality gates (component count, area, solidity).
+  let isClean: Bool
+  /// Whether the polydp and curvature corner detectors disagreed beyond the
+  /// allowed tolerance; nil when corner detection did not run (the backend
+  /// only sets this when a clean contour was found).
+  let cornerDisagreement: Bool?
+}
+
+// MARK: - Edge summary (list-only; no polyline)
+
+/// Condensed form of one classified edge, sufficient for the gallery badge.
+/// `dominant_dev` and `polyline` are intentionally omitted — the app only
+/// needs the type label, not the shape detail.
+struct GeometryEdgeSummary: Codable, Equatable {
+  let type: GeometryEdgeType
+}
+
+// MARK: - Record summary (upload response)
+
+/// The subset of `PieceGeometryRecordResponse` the app consumes: the four
+/// classified edges in contour-traversal order. Corners, polylines, and the
+/// optional full contour are not decoded.
+struct PieceGeometryRecordSummary: Codable, Equatable {
+  let edges: [GeometryEdgeSummary]
+}
+
+// MARK: - Upload response
+
+/// Match status returned by the dedupe store for each uploaded geometry.
+enum PieceGeometryStatus: String, Codable, Equatable {
+  /// First time this shape has been seen for the puzzle.
+  case new
+  /// Shape matched an already-enrolled piece within the lock threshold.
+  case matched
+  /// Shape is within the scan-lock z-score band but below the hard match
+  /// threshold — may be the same piece in worse lighting.
+  case uncertain
+}
+
+/// Response of POST .../piece/geometry.
+struct PieceGeometryUploadResponse: Codable, Equatable {
+  /// Stable id for this piece (matched or newly enrolled), or nil when the
+  /// status is `uncertain` and the backend chose not to enroll.
+  let pieceId: String?
+  let status: PieceGeometryStatus
+  /// Id of the closest already-enrolled piece when a comparison was made
+  /// (present for `matched` and `uncertain`; nil for `new`).
+  let matchPieceId: String?
+  /// Combined shape+colour z-score of the closest match; nil when no
+  /// comparison was made (first piece ever, status `new`).
+  let zScore: Double?
+  /// True when the contour is clean, corner detectors agree, and all four
+  /// edges were classified — the minimum bar for scan-lock auto-capture.
+  let lockable: Bool
+  let quality: GeometryQuality
+  let record: PieceGeometryRecordSummary
+
+  /// Flat array of edge types in contour-traversal order, for quick display.
+  var edgeTypes: [GeometryEdgeType] { record.edges.map(\.type) }
+}
+
+// MARK: - List response
+
+/// One enrolled piece's summary, returned by GET .../piece/geometry.
+struct PieceGeometrySummary: Codable, Equatable, Identifiable {
+  let pieceId: String
+  let edgeTypes: [GeometryEdgeType]
+  let isClean: Bool
+  /// Always present in list responses (backend always stores a resolved
+  /// boolean after enrollment, unlike the nullable upload response field).
+  let cornerDisagreement: Bool
+
+  /// `Identifiable` conformance — pieceId is the durable backend key.
+  var id: String { pieceId }
+}
+
+/// Response of GET .../piece/geometry for a puzzle.
+struct PieceGeometryListResponse: Codable, Equatable {
+  let puzzleId: String
+  let pieces: [PieceGeometrySummary]
+}

--- a/ios/Pussel/Models/PieceModels.swift
+++ b/ios/Pussel/Models/PieceModels.swift
@@ -89,21 +89,33 @@ struct CaptureEntry: Identifiable, Equatable {
   var trimmedDisplayImage: Data
   var status: Status = .queued
   var result: PieceResponse?
+  /// The geometry store's piece id when this entry was captured by the M10
+  /// scan-and-lock flow (nil for shutter/library captures). Links the entry
+  /// to the scan gallery, which uses it to restore thumbnails for pieces
+  /// enrolled in an earlier scanner visit. Cleared on `reupload` — the
+  /// backend's geometry store died with the old puzzle id, so the ids it
+  /// minted no longer name anything.
+  var scanPieceId: String?
 
-  init(jpeg: Data) {
+  init(jpeg: Data, scanPieceId: String? = nil) {
     self.id = UUID()
     self.uploadJPEG = jpeg
     self.displayImage = jpeg
     self.trimmedDisplayImage = ImageUtilities.alphaTrimmedPNG(from: jpeg)
+    self.scanPieceId = scanPieceId
   }
 
   /// Rehydrates an entry loaded from disk (see PuzzleStore.loadSession).
-  init(id: UUID, uploadJPEG: Data, displayImage: Data, status: Status, result: PieceResponse?) {
+  init(
+    id: UUID, uploadJPEG: Data, displayImage: Data, status: Status, result: PieceResponse?,
+    scanPieceId: String? = nil
+  ) {
     self.id = id
     self.uploadJPEG = uploadJPEG
     self.displayImage = displayImage
     self.trimmedDisplayImage = ImageUtilities.alphaTrimmedPNG(from: displayImage)
     self.status = status
     self.result = result
+    self.scanPieceId = scanPieceId
   }
 }

--- a/ios/Pussel/Models/PieceModels.swift
+++ b/ios/Pussel/Models/PieceModels.swift
@@ -25,6 +25,33 @@ struct PieceResponse: Codable, Equatable {
   let pieceSpan: PieceSpan?
 }
 
+/// Bounding box normalized to [0,1] image coordinates, mirroring the
+/// backend's `BoundingBox` model.
+struct NormalizedBoundingBox: Codable, Equatable {
+  let x: Double
+  let y: Double
+  let width: Double
+  let height: Double
+}
+
+/// Response of POST /api/v1/piece/preview — live piece-region detection in
+/// a downscaled camera frame, streamed from `PiecePreviewStreamer`.
+struct PiecePreviewResponse: Codable, Equatable {
+  let found: Bool
+  /// Outline of the detected region, normalized to the frame that was
+  /// submitted. Empty when `found` is false.
+  let polygon: [NormalizedPoint]
+  let bbox: NormalizedBoundingBox?
+  let confidence: Double
+  /// Best-effort piece-geometry quality flag from a quick corner-detection
+  /// pass; only populated when the request opted in with
+  /// `include_quality=true` (see `APIClient.previewPiece`).
+  let lockable: Bool?
+  /// Whether the quick corner cross-check disagreed; only populated with
+  /// `include_quality=true`.
+  let cornerDisagreement: Bool?
+}
+
 /// A captured piece moving through the prediction queue.
 struct CaptureEntry: Identifiable, Equatable {
   enum Status: Equatable {

--- a/ios/Pussel/Networking/APIClient.swift
+++ b/ios/Pussel/Networking/APIClient.swift
@@ -68,6 +68,20 @@ final class APIClient {
     return try await sendDecoding(request)
   }
 
+  /// Streams one downscaled live-preview frame to the piece-region
+  /// detector. Stateless and lightweight — `PiecePreviewStreamer` calls
+  /// this in a throttled loop while the piece camera is open.
+  /// `include_quality=true` adds the `lockable`/`corner_disagreement` flags.
+  func previewPiece(imageData: Data) async throws -> PiecePreviewResponse {
+    let request = makeMultipartRequest(
+      path: "api/v1/piece/preview",
+      queryItems: [URLQueryItem(name: "include_quality", value: "true")],
+      jpegData: imageData,
+      filename: "frame.jpg"
+    )
+    return try await sendDecoding(request)
+  }
+
   // MARK: - Request building & sending
 
   func makeMultipartRequest(

--- a/ios/Pussel/Networking/APIClient.swift
+++ b/ios/Pussel/Networking/APIClient.swift
@@ -68,6 +68,39 @@ final class APIClient {
     return try await sendDecoding(request)
   }
 
+  /// Uploads a piece JPEG to the geometry endpoint, which extracts its
+  /// contour, classifies edges, and runs the dedupe fingerprint store.
+  /// `enrollUncertain=true` opts in to storing pieces whose z-score falls
+  /// in the uncertain band (default server behaviour is to report but not
+  /// enroll them — the param is omitted entirely when false so the server's
+  /// own default applies without the client needing to track it).
+  func uploadPieceGeometry(
+    puzzleId: String, jpegData: Data, enrollUncertain: Bool = false
+  ) async throws -> PieceGeometryUploadResponse {
+    var queryItems: [URLQueryItem] = []
+    if enrollUncertain {
+      queryItems.append(URLQueryItem(name: "on_uncertain", value: "enroll"))
+    }
+    let request = makeMultipartRequest(
+      path: "api/v1/puzzle/\(puzzleId)/piece/geometry",
+      queryItems: queryItems,
+      jpegData: jpegData,
+      filename: "piece.jpg"
+    )
+    return try await sendDecoding(request)
+  }
+
+  /// Fetches the geometry summary for every enrolled piece of a puzzle.
+  /// Used by the gallery to show edge-type badges and clean/dirty indicators
+  /// without re-uploading any images.
+  func listPieceGeometry(puzzleId: String) async throws -> PieceGeometryListResponse {
+    let url = baseURL.appending(path: "api/v1/puzzle/\(puzzleId)/piece/geometry")
+    let request = URLRequest(url: url)
+    // Reuse the authenticated send+decode path — no body, plain GET.
+    let data = try await send(request, authenticated: true)
+    return try decoder.decode(PieceGeometryListResponse.self, from: data)
+  }
+
   /// Streams one downscaled live-preview frame to the piece-region
   /// detector. Stateless and lightweight — `PiecePreviewStreamer` calls
   /// this in a throttled loop while the piece camera is open.

--- a/ios/Pussel/Persistence/PuzzleStore.swift
+++ b/ios/Pussel/Persistence/PuzzleStore.swift
@@ -40,6 +40,10 @@ private struct StoredPiece: Codable {
   let id: UUID
   /// nil while the piece is captured but not yet predicted.
   var result: StoredResult?
+  /// Geometry-store piece id for M10 scan-and-lock captures; nil for
+  /// shutter/library captures and for manifests written before this field
+  /// existed (optional Codable decodes missing keys as nil).
+  var scanPieceId: String?
 }
 
 private struct StoredResult: Codable {
@@ -153,7 +157,8 @@ final class PuzzleStore {
               rotationConfidence: $0.rotationConfidence,
               pieceSpan: $0.pieceSpan
             )
-          }
+          },
+          scanPieceId: entry.scanPieceId
         )
       },
       pieceCount: session.targetPieceCount,
@@ -255,7 +260,8 @@ final class PuzzleStore {
         uploadJPEG: upload,
         displayImage: display,
         status: result == nil ? .queued : .done,
-        result: result
+        result: result,
+        scanPieceId: piece.scanPieceId
       )
     }
     return session

--- a/ios/Pussel/Support/DebugNavigation.swift
+++ b/ios/Pussel/Support/DebugNavigation.swift
@@ -8,7 +8,9 @@
   ///   echo "pusseldebug://trim?puzzle=/host/path.jpg" > /tmp/pussel-debug-command
   ///   xcrun simctl spawn booted notifyutil -p dk.delectosoft.pussel.debug
   /// Commands: trim?puzzle=, accept[?pieces=], piece?path=, reupload, reset,
-  ///   open?index=, delete?index= (index into the saved-puzzles list).
+  ///   open?index=, delete?index= (index into the saved-puzzles list),
+  ///   camera[?open=0], previewloop?path=<host image path>[&stop=1] (M9 live
+  ///   preview overlay demo — see PieceCameraSession.startDebugPreviewLoop).
   /// Simulator apps can read host file paths directly. Compiled out of
   /// Release builds; the handler runs the same actions as the real UI.
   @MainActor
@@ -81,6 +83,10 @@
         debugOpen(index: value("index"))
       case "delete":
         debugDelete(index: value("index"))
+      case "camera":
+        debugCamera(open: value("open"))
+      case "previewloop":
+        debugPreviewLoop(path: value("path"), stop: value("stop"))
       default:
         break
       }
@@ -125,6 +131,31 @@
         return
       }
       deletePuzzle(store.puzzles[index].id)
+    }
+
+    /// Forces the piece camera cover open (or closed with `?open=0`), even
+    /// on the Simulator where `PieceCameraSession.isCameraAvailable` is
+    /// false — see `PieceQueueView.cameraCoverIsPresented`. Must already be
+    /// in the solving phase (drive there first with `trim`/`accept`).
+    private func debugCamera(open: String?) {
+      guard case .solving(let session) = flow.phase else { return }
+      session.debugCameraOpen = (open.flatMap(Int.init) ?? 1) != 0
+    }
+
+    /// Starts (or, with `?stop=1`, stops) a repeating fake-frame loop on the
+    /// active piece camera session, feeding `path` through the same
+    /// downscale → stream → overlay pipeline a real camera frame takes —
+    /// the Simulator's stand-in for a live camera, so M9's outline overlay
+    /// is demoable there. Requires the piece camera to already be open
+    /// (`camera`, or the real shutter screen on a device).
+    private func debugPreviewLoop(path: String?, stop: String?) {
+      guard let camera = PieceCameraSession.debugActive else { return }
+      if (stop.flatMap(Int.init) ?? 0) != 0 {
+        camera.stopDebugPreviewLoop()
+        return
+      }
+      guard let image = Self.hostImage(path) else { return }
+      camera.startDebugPreviewLoop(image: image)
     }
 
     private static func hostImage(_ path: String?) -> UIImage? {

--- a/ios/Pussel/Support/DebugNavigation.swift
+++ b/ios/Pussel/Support/DebugNavigation.swift
@@ -10,7 +10,9 @@
   /// Commands: trim?puzzle=, accept[?pieces=], piece?path=, reupload, reset,
   ///   open?index=, delete?index= (index into the saved-puzzles list),
   ///   camera[?open=0], previewloop?path=<host image path>[&stop=1] (M9 live
-  ///   preview overlay demo — see PieceCameraSession.startDebugPreviewLoop).
+  ///   preview overlay demo — see PieceCameraSession.startDebugPreviewLoop),
+  ///   scan[?open=0] (M10 scan-and-lock demo — mirrors camera),
+  ///   scanconfirm (taps the M10 uncertain-confirm chip on the open scan view).
   /// Simulator apps can read host file paths directly. Compiled out of
   /// Release builds; the handler runs the same actions as the real UI.
   @MainActor
@@ -67,6 +69,7 @@
 
     // One thin case per command keeps this dispatcher's cyclomatic complexity
     // low; each command's own guards live in its helper below.
+    // swiftlint:disable:next cyclomatic_complexity
     private func runDebugCommand(_ host: String?, value: (String) -> String?) async {
       switch host {
       case "reset":
@@ -85,6 +88,10 @@
         debugDelete(index: value("index"))
       case "camera":
         debugCamera(open: value("open"))
+      case "scan":
+        debugScan(open: value("open"))
+      case "scanconfirm":
+        await PieceScanController.debugActive?.confirmUncertainAsNew()
       case "previewloop":
         debugPreviewLoop(path: value("path"), stop: value("stop"))
       default:
@@ -140,6 +147,13 @@
     private func debugCamera(open: String?) {
       guard case .solving(let session) = flow.phase else { return }
       session.debugCameraOpen = (open.flatMap(Int.init) ?? 1) != 0
+    }
+
+    /// Forces the scan-and-lock cover open (or closed with `?open=0`), even
+    /// on the Simulator — mirrors `debugCamera` for the M10 scan flow.
+    private func debugScan(open: String?) {
+      guard case .solving(let session) = flow.phase else { return }
+      session.debugScanOpen = (open.flatMap(Int.init) ?? 1) != 0
     }
 
     /// Starts (or, with `?stop=1`, stops) a repeating fake-frame loop on the

--- a/ios/PusselTests/APIClientTests.swift
+++ b/ios/PusselTests/APIClientTests.swift
@@ -163,4 +163,144 @@ final class APIClientTests: XCTestCase {
       XCTFail("Unexpected error type: \(error)")
     }
   }
+
+  // MARK: - uploadPieceGeometry
+
+  func testUploadPieceGeometryHitsCorrectPath() async throws {
+    authStore.backendToken = "tok"
+    StubURLProtocol.handler = { _ in (200, Self.geometryUploadJSON) }
+    _ = try await client.uploadPieceGeometry(
+      puzzleId: "puzz-1", jpegData: Data("JPEG".utf8))
+    let req = try XCTUnwrap(StubURLProtocol.receivedRequests.first)
+    XCTAssertEqual(req.url?.path, "/api/v1/puzzle/puzz-1/piece/geometry")
+    XCTAssertEqual(req.httpMethod, "POST")
+  }
+
+  func testUploadPieceGeometryDoesNotSendOnUncertainParamByDefault() async throws {
+    authStore.backendToken = "tok"
+    StubURLProtocol.handler = { _ in (200, Self.geometryUploadJSON) }
+    _ = try await client.uploadPieceGeometry(
+      puzzleId: "puzz-1", jpegData: Data("JPEG".utf8))
+    let req = try XCTUnwrap(StubURLProtocol.receivedRequests.first)
+    // Default enrollUncertain=false must NOT add the query param at all —
+    // the server applies its own default (report) without the client echoing it.
+    let query = req.url?.query ?? ""
+    XCTAssertFalse(query.contains("on_uncertain"), "on_uncertain must be absent by default")
+  }
+
+  func testUploadPieceGeometrySendsOnUncertainEnrollWhenRequested() async throws {
+    authStore.backendToken = "tok"
+    StubURLProtocol.handler = { _ in (200, Self.geometryUploadJSON) }
+    _ = try await client.uploadPieceGeometry(
+      puzzleId: "puzz-1", jpegData: Data("JPEG".utf8), enrollUncertain: true)
+    let req = try XCTUnwrap(StubURLProtocol.receivedRequests.first)
+    XCTAssertEqual(req.url?.query, "on_uncertain=enroll")
+  }
+
+  func testUploadPieceGeometrySendsMultipartWithAuthHeader() async throws {
+    authStore.backendToken = "mytoken"
+    StubURLProtocol.handler = { _ in (200, Self.geometryUploadJSON) }
+    _ = try await client.uploadPieceGeometry(
+      puzzleId: "puzz-2", jpegData: Data("IMGDATA".utf8))
+    let req = try XCTUnwrap(StubURLProtocol.receivedRequests.first)
+    XCTAssertEqual(req.value(forHTTPHeaderField: "Authorization"), "Bearer mytoken")
+    let ct = req.value(forHTTPHeaderField: "Content-Type") ?? ""
+    // Confirm the request is multipart (the request builder's responsibility;
+    // the body bytes aren't readable after URLSession converts httpBody to a
+    // stream, so we check the header rather than parsing the body here).
+    XCTAssertTrue(ct.hasPrefix("multipart/form-data; boundary="))
+  }
+
+  func testUploadPieceGeometryMultipartBodyContainsFile() throws {
+    // Use makeMultipartRequest directly (no URLSession hop) so httpBody is
+    // readable — matching the pattern used by testMultipartRequestBuilding.
+    let req = client.makeMultipartRequest(
+      path: "api/v1/puzzle/puzz-2/piece/geometry",
+      jpegData: Data("IMGDATA".utf8),
+      filename: "piece.jpg"
+    )
+    let body = try XCTUnwrap(String(bytes: req.httpBody ?? Data(), encoding: .utf8))
+    XCTAssertTrue(body.contains("name=\"file\"; filename=\"piece.jpg\""))
+  }
+
+  func testUploadPieceGeometryDecodesResponse() async throws {
+    authStore.backendToken = "tok"
+    StubURLProtocol.handler = { _ in (200, Self.geometryUploadJSON) }
+    let response = try await client.uploadPieceGeometry(
+      puzzleId: "puzz-1", jpegData: Data("J".utf8))
+    XCTAssertEqual(response.pieceId, "piece-abc")
+    XCTAssertEqual(response.status, .matched)
+    XCTAssertTrue(response.lockable)
+  }
+
+  // MARK: - listPieceGeometry
+
+  func testListPieceGeometryHitsCorrectPathWithAuthenticatedGet() async throws {
+    authStore.backendToken = "listtoken"
+    let listJSON = #"{"puzzle_id": "puzz-3", "pieces": []}"#
+    StubURLProtocol.handler = { _ in (200, Data(listJSON.utf8)) }
+    _ = try await client.listPieceGeometry(puzzleId: "puzz-3")
+    let req = try XCTUnwrap(StubURLProtocol.receivedRequests.first)
+    XCTAssertEqual(req.url?.path, "/api/v1/puzzle/puzz-3/piece/geometry")
+    // URLRequest.httpMethod is nil for GET (the default); "POST" is explicit.
+    // Either way it must not be "POST".
+    XCTAssertNotEqual(req.httpMethod, "POST")
+    XCTAssertEqual(req.value(forHTTPHeaderField: "Authorization"), "Bearer listtoken")
+  }
+
+  func testListPieceGeometryDecodesResponse() async throws {
+    authStore.backendToken = "tok"
+    StubURLProtocol.handler = { _ in (200, Self.geometryListJSON) }
+    let response = try await client.listPieceGeometry(puzzleId: "puzz-4")
+    XCTAssertEqual(response.puzzleId, "puzz-4")
+    XCTAssertEqual(response.pieces.count, 1)
+    XCTAssertEqual(response.pieces[0].edgeTypes, [.tab, .blank, .flat, .tab])
+  }
+
+  // MARK: - JSON fixtures
+
+  private static let geometryUploadJSON: Data = {
+    let json = """
+      {
+        "piece_id": "piece-abc",
+        "status": "matched",
+        "match_piece_id": "piece-xyz",
+        "z_score": 1.42,
+        "lockable": true,
+        "quality": {
+          "is_clean": true,
+          "corner_disagreement": false,
+          "n_large_components": 1,
+          "border_touching": false,
+          "area_ratio": 0.87,
+          "solidity": 0.94
+        },
+        "record": {
+          "corners": [],
+          "corner_confidences": [],
+          "edges": [
+            {"type": "tab",  "dominant_dev": 0.1,  "polyline": []},
+            {"type": "blank","dominant_dev": -0.1, "polyline": []},
+            {"type": "flat", "dominant_dev": 0.0,  "polyline": []},
+            {"type": "tab",  "dominant_dev": 0.09, "polyline": []}
+          ],
+          "contour": null
+        }
+      }
+      """
+    return Data(json.utf8)
+  }()
+
+  private static let geometryListJSON: Data = {
+    let json = """
+      {
+        "puzzle_id": "puzz-4",
+        "pieces": [
+          {"piece_id": "p1", "edge_types": ["tab","blank","flat","tab"],
+           "is_clean": true, "corner_disagreement": false}
+        ]
+      }
+      """
+    return Data(json.utf8)
+  }()
 }

--- a/ios/PusselTests/ModelDecodingTests.swift
+++ b/ios/PusselTests/ModelDecodingTests.swift
@@ -201,4 +201,188 @@ final class ModelDecodingTests: XCTestCase {
     XCTAssertEqual(ImageUtilities.decodeDataURL("aGVsbG8="), Data("hello".utf8))
     XCTAssertNil(ImageUtilities.decodeDataURL("data:image/png;base64,%%%invalid%%%"))
   }
+
+  // MARK: - PieceGeometryUploadResponse
+
+  func testDecodePieceGeometryUploadResponseMatchedStatus() throws {
+    // Realistic backend payload for a matched piece: includes fields the app
+    // ignores (dominant_dev, polyline, corners, corner_confidences, contour,
+    // n_large_components, border_touching, area_ratio, solidity) to confirm
+    // the decoder tolerates extra keys gracefully.
+    let json = """
+      {
+        "piece_id": "piece-abc",
+        "status": "matched",
+        "match_piece_id": "piece-xyz",
+        "z_score": 1.42,
+        "lockable": true,
+        "quality": {
+          "is_clean": true,
+          "corner_disagreement": false,
+          "n_large_components": 1,
+          "border_touching": false,
+          "area_ratio": 0.87,
+          "solidity": 0.94
+        },
+        "record": {
+          "corners": [
+            {"x": 0.1, "y": 0.1}, {"x": 0.9, "y": 0.1},
+            {"x": 0.9, "y": 0.9}, {"x": 0.1, "y": 0.9}
+          ],
+          "corner_confidences": [0.9, 0.85, 0.92, 0.88],
+          "edges": [
+            {"type": "tab",   "dominant_dev": 0.12, "polyline": []},
+            {"type": "blank", "dominant_dev": -0.11, "polyline": []},
+            {"type": "flat",  "dominant_dev": 0.0, "polyline": []},
+            {"type": "tab",   "dominant_dev": 0.09, "polyline": []}
+          ],
+          "contour": null
+        }
+      }
+      """
+    let response = try decoder.decode(PieceGeometryUploadResponse.self, from: Data(json.utf8))
+
+    XCTAssertEqual(response.pieceId, "piece-abc")
+    XCTAssertEqual(response.status, .matched)
+    XCTAssertEqual(response.matchPieceId, "piece-xyz")
+    XCTAssertEqual(response.zScore, 1.42)
+    XCTAssertTrue(response.lockable)
+    XCTAssertTrue(response.quality.isClean)
+    XCTAssertEqual(response.quality.cornerDisagreement, false)
+    XCTAssertEqual(
+      response.edgeTypes, [.tab, .blank, .flat, .tab],
+      "edgeTypes convenience var must mirror record.edges[].type in order")
+  }
+
+  func testDecodePieceGeometryUploadResponseNewPieceNilOptionals() throws {
+    // A brand-new piece: no match, no z_score, no piece_id yet for uncertain.
+    let json = """
+      {
+        "piece_id": "piece-001",
+        "status": "new",
+        "match_piece_id": null,
+        "z_score": null,
+        "lockable": true,
+        "quality": {
+          "is_clean": true,
+          "corner_disagreement": null,
+          "n_large_components": 1,
+          "border_touching": false,
+          "area_ratio": 0.91,
+          "solidity": 0.97
+        },
+        "record": {
+          "corners": [],
+          "corner_confidences": [],
+          "edges": [
+            {"type": "flat",  "dominant_dev": 0.0,  "polyline": []},
+            {"type": "tab",   "dominant_dev": 0.15, "polyline": []},
+            {"type": "flat",  "dominant_dev": 0.0,  "polyline": []},
+            {"type": "blank", "dominant_dev": -0.08, "polyline": []}
+          ],
+          "contour": null
+        }
+      }
+      """
+    let response = try decoder.decode(PieceGeometryUploadResponse.self, from: Data(json.utf8))
+
+    XCTAssertEqual(response.pieceId, "piece-001")
+    XCTAssertEqual(response.status, .new)
+    XCTAssertNil(response.matchPieceId)
+    XCTAssertNil(response.zScore)
+    XCTAssertNil(response.quality.cornerDisagreement)
+    XCTAssertEqual(response.edgeTypes, [.flat, .tab, .flat, .blank])
+  }
+
+  func testDecodePieceGeometryUploadResponseUncertainNilPieceId() throws {
+    // Uncertain with on_uncertain=report (default): piece_id stays nil.
+    let json = """
+      {
+        "piece_id": null,
+        "status": "uncertain",
+        "match_piece_id": "piece-xyz",
+        "z_score": 2.71,
+        "lockable": false,
+        "quality": {
+          "is_clean": false,
+          "corner_disagreement": true,
+          "n_large_components": 2,
+          "border_touching": true,
+          "area_ratio": 0.55,
+          "solidity": 0.72
+        },
+        "record": {
+          "corners": [],
+          "corner_confidences": [],
+          "edges": [],
+          "contour": null
+        }
+      }
+      """
+    let response = try decoder.decode(PieceGeometryUploadResponse.self, from: Data(json.utf8))
+
+    XCTAssertNil(response.pieceId)
+    XCTAssertEqual(response.status, .uncertain)
+    XCTAssertFalse(response.lockable)
+    XCTAssertFalse(response.quality.isClean)
+    XCTAssertEqual(response.quality.cornerDisagreement, true)
+    XCTAssertTrue(response.edgeTypes.isEmpty)
+  }
+
+  // MARK: - PieceGeometryListResponse
+
+  func testDecodePieceGeometryListResponse() throws {
+    let json = """
+      {
+        "puzzle_id": "puzzle-99",
+        "pieces": [
+          {
+            "piece_id": "piece-001",
+            "edge_types": ["tab", "blank", "flat", "tab"],
+            "is_clean": true,
+            "corner_disagreement": false
+          },
+          {
+            "piece_id": "piece-002",
+            "edge_types": ["flat", "flat", "tab", "blank"],
+            "is_clean": false,
+            "corner_disagreement": true
+          }
+        ]
+      }
+      """
+    let response = try decoder.decode(PieceGeometryListResponse.self, from: Data(json.utf8))
+
+    XCTAssertEqual(response.puzzleId, "puzzle-99")
+    XCTAssertEqual(response.pieces.count, 2)
+
+    let first = response.pieces[0]
+    XCTAssertEqual(first.id, "piece-001")
+    XCTAssertEqual(first.edgeTypes, [.tab, .blank, .flat, .tab])
+    XCTAssertTrue(first.isClean)
+    XCTAssertFalse(first.cornerDisagreement)
+
+    let second = response.pieces[1]
+    XCTAssertEqual(second.id, "piece-002")
+    XCTAssertEqual(second.edgeTypes, [.flat, .flat, .tab, .blank])
+    XCTAssertFalse(second.isClean)
+    XCTAssertTrue(second.cornerDisagreement)
+  }
+
+  func testDecodePieceGeometryListResponseEmptyPieces() throws {
+    let json = """
+      {"puzzle_id": "puzzle-empty", "pieces": []}
+      """
+    let response = try decoder.decode(PieceGeometryListResponse.self, from: Data(json.utf8))
+    XCTAssertEqual(response.puzzleId, "puzzle-empty")
+    XCTAssertTrue(response.pieces.isEmpty)
+  }
+
+  // MARK: - GeometryEdgeType.glyph
+
+  func testGeometryEdgeTypeGlyphs() {
+    XCTAssertEqual(GeometryEdgeType.tab.glyph, "T")
+    XCTAssertEqual(GeometryEdgeType.blank.glyph, "B")
+    XCTAssertEqual(GeometryEdgeType.flat.glyph, "F")
+  }
 }

--- a/ios/PusselTests/ModelDecodingTests.swift
+++ b/ios/PusselTests/ModelDecodingTests.swift
@@ -136,6 +136,67 @@ final class ModelDecodingTests: XCTestCase {
     XCTAssertNil(response.pieceSpan)
   }
 
+  func testDecodePiecePreviewResponseFound() throws {
+    let json = """
+      {
+        "found": true,
+        "polygon": [
+          {"x": 0.1, "y": 0.2},
+          {"x": 0.8, "y": 0.2},
+          {"x": 0.8, "y": 0.9},
+          {"x": 0.1, "y": 0.9}
+        ],
+        "bbox": {"x": 0.1, "y": 0.2, "width": 0.7, "height": 0.7},
+        "confidence": 0.82,
+        "lockable": true,
+        "corner_disagreement": false
+      }
+      """
+    let response = try decoder.decode(PiecePreviewResponse.self, from: Data(json.utf8))
+    XCTAssertTrue(response.found)
+    XCTAssertEqual(response.polygon.count, 4)
+    XCTAssertEqual(response.polygon.first, NormalizedPoint(x: 0.1, y: 0.2))
+    XCTAssertEqual(
+      response.bbox, NormalizedBoundingBox(x: 0.1, y: 0.2, width: 0.7, height: 0.7))
+    XCTAssertEqual(response.confidence, 0.82)
+    XCTAssertEqual(response.lockable, true)
+    XCTAssertEqual(response.cornerDisagreement, false)
+  }
+
+  func testDecodePiecePreviewResponseNotFound() throws {
+    // The backend's actual shape when found=false: an empty polygon, no
+    // bbox, confidence defaulted to 0.0.
+    let json = """
+      {"found": false, "polygon": [], "bbox": null, "confidence": 0.0}
+      """
+    let response = try decoder.decode(PiecePreviewResponse.self, from: Data(json.utf8))
+    XCTAssertFalse(response.found)
+    XCTAssertTrue(response.polygon.isEmpty)
+    XCTAssertNil(response.bbox)
+    XCTAssertEqual(response.confidence, 0.0)
+    XCTAssertNil(response.lockable)
+    XCTAssertNil(response.cornerDisagreement)
+  }
+
+  func testDecodePiecePreviewResponseWithoutQualityFields() throws {
+    // include_quality=false (or omitted): lockable/corner_disagreement are
+    // present but null, matching the backend's default response shape.
+    let json = """
+      {
+        "found": true,
+        "polygon": [{"x": 0.0, "y": 0.0}, {"x": 1.0, "y": 0.0}, {"x": 1.0, "y": 1.0}],
+        "bbox": {"x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0},
+        "confidence": 0.5,
+        "lockable": null,
+        "corner_disagreement": null
+      }
+      """
+    let response = try decoder.decode(PiecePreviewResponse.self, from: Data(json.utf8))
+    XCTAssertTrue(response.found)
+    XCTAssertNil(response.lockable)
+    XCTAssertNil(response.cornerDisagreement)
+  }
+
   func testDecodeBareBase64DataURL() {
     XCTAssertEqual(ImageUtilities.decodeDataURL("aGVsbG8="), Data("hello".utf8))
     XCTAssertNil(ImageUtilities.decodeDataURL("data:image/png;base64,%%%invalid%%%"))

--- a/ios/PusselTests/PiecePreviewGeometryTests.swift
+++ b/ios/PusselTests/PiecePreviewGeometryTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+
+@testable import Pussel
+
+/// The streamed frames are upright portrait (PieceCameraSession sets
+/// `videoRotationAngle = 90` on the video data output connection), so the
+/// backend's polygon is normalized against an image that looks exactly like
+/// the preview: no rotation step exists, and the overlay mapping is a single
+/// centered aspect-fill onto the view bounds — the same fit the
+/// `.resizeAspectFill` preview layer applies to the same-aspect feed.
+final class PiecePreviewGeometryTests: XCTestCase {
+  private func assertViewPoint(
+    _ actual: CGPoint, _ expected: CGPoint, accuracy: CGFloat = 0.0001,
+    file: StaticString = #filePath, line: UInt = #line
+  ) {
+    XCTAssertEqual(actual.x, expected.x, accuracy: accuracy, file: file, line: line)
+    XCTAssertEqual(actual.y, expected.y, accuracy: accuracy, file: file, line: line)
+  }
+
+  // MARK: aspect-fill crop direction
+
+  func testAspectFillWideFrameCropsHorizontally() {
+    // Frame 100x50 into a 100x100 view: fill scale = max(1, 2) = 2, so the
+    // 200x100 scaled frame overflows the width and is centered (originX =
+    // -50), while the height fills exactly (originY = 0).
+    let frameSize = CGSize(width: 100, height: 50)
+    let viewBounds = CGSize(width: 100, height: 100)
+    assertViewPoint(
+      PiecePreviewGeometry.viewPoint(
+        fromFramePoint: NormalizedPoint(x: 0, y: 0), frameSize: frameSize, viewBounds: viewBounds),
+      CGPoint(x: -50, y: 0))
+    assertViewPoint(
+      PiecePreviewGeometry.viewPoint(
+        fromFramePoint: NormalizedPoint(x: 1, y: 1), frameSize: frameSize, viewBounds: viewBounds),
+      CGPoint(x: 150, y: 100))
+    // The frame center always lands at the view center under aspect-fill.
+    assertViewPoint(
+      PiecePreviewGeometry.viewPoint(
+        fromFramePoint: NormalizedPoint(x: 0.5, y: 0.5), frameSize: frameSize,
+        viewBounds: viewBounds),
+      CGPoint(x: 50, y: 50))
+  }
+
+  func testAspectFillTallFrameCropsVertically() {
+    // Frame 50x100 into a 100x100 view: fill scale = max(2, 1) = 2, so the
+    // 100x200 scaled frame overflows the height and is centered (originY =
+    // -50), while the width fills exactly (originX = 0).
+    let frameSize = CGSize(width: 50, height: 100)
+    let viewBounds = CGSize(width: 100, height: 100)
+    assertViewPoint(
+      PiecePreviewGeometry.viewPoint(
+        fromFramePoint: NormalizedPoint(x: 0, y: 0), frameSize: frameSize, viewBounds: viewBounds),
+      CGPoint(x: 0, y: -50))
+    assertViewPoint(
+      PiecePreviewGeometry.viewPoint(
+        fromFramePoint: NormalizedPoint(x: 1, y: 1), frameSize: frameSize, viewBounds: viewBounds),
+      CGPoint(x: 100, y: 150))
+    assertViewPoint(
+      PiecePreviewGeometry.viewPoint(
+        fromFramePoint: NormalizedPoint(x: 0.5, y: 0.5), frameSize: frameSize,
+        viewBounds: viewBounds),
+      CGPoint(x: 50, y: 50))
+  }
+
+  func testAspectFillMatchingAspectRatioHasNoCrop() {
+    // A frame whose aspect ratio matches the view fills without cropping:
+    // both axes scale by the same factor and origin stays at (0, 0).
+    let frameSize = CGSize(width: 100, height: 100)
+    let viewBounds = CGSize(width: 200, height: 200)
+    assertViewPoint(
+      PiecePreviewGeometry.viewPoint(
+        fromFramePoint: NormalizedPoint(x: 0, y: 0), frameSize: frameSize, viewBounds: viewBounds),
+      CGPoint(x: 0, y: 0))
+    assertViewPoint(
+      PiecePreviewGeometry.viewPoint(
+        fromFramePoint: NormalizedPoint(x: 1, y: 1), frameSize: frameSize, viewBounds: viewBounds),
+      CGPoint(x: 200, y: 200))
+  }
+
+  // MARK: the device case — a portrait 3:4 frame in a taller full-screen view
+
+  func testPortraitFrameInTallerViewTopLeftStaysTopLeft() {
+    // The real shape of the problem on a phone: the streamed frame is
+    // upright portrait 3:4 (e.g. 360x480 after downscale) and the overlay
+    // view is a taller full-screen portrait (e.g. 390x844). Fill scale =
+    // max(390/360, 844/480) = 844/480, so the width overflows and is
+    // cropped equally left/right; the height fills exactly. A polygon
+    // point at the frame's visual top-left must land in the view's
+    // top-left region: x slightly negative (just inside the cropped
+    // margin), y exactly 0 — NOT rotated to another corner and NOT
+    // vertically offset.
+    let frameSize = CGSize(width: 360, height: 480)
+    let viewBounds = CGSize(width: 390, height: 844)
+    let scale = 844.0 / 480.0  // = max(390/360, 844/480) ≈ 1.7583
+    let scaledWidth = 360 * scale
+    let originX = (390 - scaledWidth) / 2
+
+    let topLeft = PiecePreviewGeometry.viewPoint(
+      fromFramePoint: NormalizedPoint(x: 0, y: 0), frameSize: frameSize, viewBounds: viewBounds)
+    assertViewPoint(topLeft, CGPoint(x: originX, y: 0), accuracy: 0.001)
+    // Top-left region: at or left of the view's left edge, exactly at its
+    // top — no rotation, no vertical offset.
+    XCTAssertLessThanOrEqual(topLeft.x, 0)
+    XCTAssertEqual(topLeft.y, 0, accuracy: 0.001)
+
+    // A point just inside the frame (10% in from its left, 10% down) must
+    // land in the view's upper-left quadrant.
+    let nearTopLeft = PiecePreviewGeometry.viewPoint(
+      fromFramePoint: NormalizedPoint(x: 0.1, y: 0.1), frameSize: frameSize,
+      viewBounds: viewBounds)
+    XCTAssertGreaterThan(nearTopLeft.x, topLeft.x)
+    XCTAssertLessThan(nearTopLeft.x, viewBounds.width / 2)
+    XCTAssertEqual(nearTopLeft.y, 84.4, accuracy: 0.001)
+    XCTAssertLessThan(nearTopLeft.y, viewBounds.height / 2)
+
+    // And the frame center still lands at the view center.
+    assertViewPoint(
+      PiecePreviewGeometry.viewPoint(
+        fromFramePoint: NormalizedPoint(x: 0.5, y: 0.5), frameSize: frameSize,
+        viewBounds: viewBounds),
+      CGPoint(x: 195, y: 422))
+  }
+
+  // MARK: degenerate input
+
+  func testAspectFillZeroFrameSizeStretchesOntoBounds() {
+    // A degenerate frame size can't drive a fill ratio, so the point is
+    // stretched directly onto the bounds rather than dividing by zero.
+    let viewBounds = CGSize(width: 100, height: 200)
+    assertViewPoint(
+      PiecePreviewGeometry.viewPoint(
+        fromFramePoint: NormalizedPoint(x: 0.5, y: 0.5), frameSize: .zero, viewBounds: viewBounds),
+      CGPoint(x: 50, y: 100))
+    assertViewPoint(
+      PiecePreviewGeometry.viewPoint(
+        fromFramePoint: NormalizedPoint(x: 1, y: 1), frameSize: .zero, viewBounds: viewBounds),
+      CGPoint(x: 100, y: 200))
+  }
+
+  // MARK: polygon mapping
+
+  func testViewPolygonMapsEachPointInOrder() {
+    let polygon = [
+      NormalizedPoint(x: 0, y: 0),
+      NormalizedPoint(x: 1, y: 0),
+      NormalizedPoint(x: 0.5, y: 0.5),
+    ]
+    let frameSize = CGSize(width: 100, height: 100)
+    let viewBounds = CGSize(width: 100, height: 100)
+    let result = PiecePreviewGeometry.viewPolygon(
+      fromFramePolygon: polygon, frameSize: frameSize, viewBounds: viewBounds)
+    XCTAssertEqual(result.count, 3)
+    assertViewPoint(result[0], CGPoint(x: 0, y: 0))
+    assertViewPoint(result[1], CGPoint(x: 100, y: 0))
+    assertViewPoint(result[2], CGPoint(x: 50, y: 50))
+  }
+
+  func testViewPolygonEmptyMapsToEmpty() {
+    XCTAssertEqual(
+      PiecePreviewGeometry.viewPolygon(
+        fromFramePolygon: [], frameSize: CGSize(width: 10, height: 10),
+        viewBounds: CGSize(width: 10, height: 10)),
+      [])
+  }
+}

--- a/ios/PusselTests/PiecePreviewThrottleTests.swift
+++ b/ios/PusselTests/PiecePreviewThrottleTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+
+@testable import Pussel
+
+final class PiecePreviewThrottleTests: XCTestCase {
+  func testFirstFrameAlwaysSends() {
+    let throttle = PiecePreviewThrottle()
+    XCTAssertTrue(throttle.shouldSend(now: Date()))
+  }
+
+  func testInFlightBlocksAdditionalSendsEvenPastMinInterval() {
+    var throttle = PiecePreviewThrottle()
+    let t0 = Date()
+    throttle.markSent(at: t0)
+    // Well past minInterval, but still in flight — must not send.
+    XCTAssertFalse(throttle.shouldSend(now: t0.addingTimeInterval(10)))
+  }
+
+  func testRespectsMinIntervalAfterCompletion() {
+    var throttle = PiecePreviewThrottle()
+    let t0 = Date()
+    throttle.markSent(at: t0)
+    throttle.markCompleted()
+    XCTAssertFalse(throttle.shouldSend(now: t0.addingTimeInterval(0.1)))
+  }
+
+  func testResumesOnceMinIntervalElapsesAfterCompletion() {
+    var throttle = PiecePreviewThrottle()
+    let t0 = Date()
+    throttle.markSent(at: t0)
+    throttle.markCompleted()
+    XCTAssertTrue(throttle.shouldSend(now: t0.addingTimeInterval(1)))
+  }
+
+  func testExactlyMinIntervalSends() {
+    var throttle = PiecePreviewThrottle()
+    let t0 = Date()
+    throttle.markSent(at: t0)
+    throttle.markCompleted()
+    XCTAssertTrue(
+      throttle.shouldSend(now: t0.addingTimeInterval(PiecePreviewThrottle.minInterval)))
+  }
+
+  func testJustUnderMinIntervalDoesNotSend() {
+    var throttle = PiecePreviewThrottle()
+    let t0 = Date()
+    throttle.markSent(at: t0)
+    throttle.markCompleted()
+    XCTAssertFalse(
+      throttle.shouldSend(now: t0.addingTimeInterval(PiecePreviewThrottle.minInterval - 0.01)))
+  }
+
+  func testMarkSentWithoutCompletionKeepsBlockingRegardlessOfElapsedTime() {
+    // Simulates a hung/never-completing request: no amount of elapsed time
+    // should let a second frame through without an explicit completion.
+    var throttle = PiecePreviewThrottle()
+    let t0 = Date()
+    throttle.markSent(at: t0)
+    XCTAssertFalse(throttle.shouldSend(now: t0.addingTimeInterval(60)))
+  }
+
+  func testCanSendAgainImmediatelyAfterErrorCompletionPastInterval() {
+    // markCompleted() doesn't distinguish success from failure — a failed
+    // request must free up the throttle exactly like a successful one.
+    var throttle = PiecePreviewThrottle()
+    let t0 = Date()
+    throttle.markSent(at: t0)
+    throttle.markCompleted()
+    let t1 = t0.addingTimeInterval(PiecePreviewThrottle.minInterval)
+    XCTAssertTrue(throttle.shouldSend(now: t1))
+    throttle.markSent(at: t1)
+    XCTAssertFalse(throttle.shouldSend(now: t1.addingTimeInterval(0.01)))
+  }
+}

--- a/ios/PusselTests/PieceScanControllerTests.swift
+++ b/ios/PusselTests/PieceScanControllerTests.swift
@@ -10,6 +10,7 @@ import XCTest
 final class FakeGeometryClient: PieceGeometryScanning {
   private(set) var uploadCallCount = 0
   private(set) var lastEnrollUncertain: Bool?
+  private(set) var receivedPuzzleIds: [String] = []
 
   /// Queue of upload responses. Each call to `uploadPieceGeometry` dequeues
   /// one; panics if the queue runs dry (indicates the test over-called).
@@ -22,6 +23,7 @@ final class FakeGeometryClient: PieceGeometryScanning {
   ) async throws -> PieceGeometryUploadResponse {
     uploadCallCount += 1
     lastEnrollUncertain = enrollUncertain
+    receivedPuzzleIds.append(puzzleId)
     guard !uploadResponses.isEmpty else {
       fatalError("FakeGeometryClient: no more scripted upload responses")
     }
@@ -110,7 +112,7 @@ final class PieceScanControllerTests: XCTestCase {
   ) -> (ctrl: PieceScanController, haptics: HapticBox) {
     let box = HapticBox()
     let ctrl = PieceScanController(
-      puzzleId: "test-puzzle",
+      puzzleId: { "test-puzzle" },
       geometryClient: client,
       capture: { captureReturnsNil ? nil : fixtureJPEG },
       haptic: { [weak box] kind in box?.record(kind) },
@@ -196,7 +198,7 @@ final class PieceScanControllerTests: XCTestCase {
     let box = HapticBox()
     // Non-resuming sleep so the rearm doesn't clear pendingUncertainJPEG.
     let ctrl = PieceScanController(
-      puzzleId: "test-puzzle",
+      puzzleId: { "test-puzzle" },
       geometryClient: client,
       capture: { fixtureJPEG },
       haptic: { [weak box] kind in box?.record(kind) },
@@ -228,7 +230,7 @@ final class PieceScanControllerTests: XCTestCase {
     ]
     let box = HapticBox()
     let ctrl = PieceScanController(
-      puzzleId: "test-puzzle",
+      puzzleId: { "test-puzzle" },
       geometryClient: client,
       capture: { fixtureJPEG },
       haptic: { [weak box] kind in box?.record(kind) },
@@ -262,7 +264,7 @@ final class PieceScanControllerTests: XCTestCase {
     let box = HapticBox()
     let pendingJPEGClearedAfterConfirm = LockBox(false)
     let ctrl = PieceScanController(
-      puzzleId: "test-puzzle",
+      puzzleId: { "test-puzzle" },
       geometryClient: client,
       capture: { fixtureJPEG },
       haptic: { [weak box] kind in box?.record(kind) },
@@ -301,7 +303,7 @@ final class PieceScanControllerTests: XCTestCase {
       .success(uploadResponse(status: .new, pieceId: "p-once")),
     ]
     let ctrl = PieceScanController(
-      puzzleId: "test-puzzle",
+      puzzleId: { "test-puzzle" },
       geometryClient: client,
       capture: { fixtureJPEG },
       haptic: { _ in },
@@ -352,6 +354,66 @@ final class PieceScanControllerTests: XCTestCase {
     XCTAssertTrue(haptics.contains(.failure))
     // Instant sleep re-arms back to .scanning.
     XCTAssertEqual(ctrl.phase, .scanning)
+  }
+
+  // MARK: - 5b. 404 → puzzle recovery → retried once with the fresh id
+
+  /// The backend's in-memory puzzle store forgets a saved session's id after
+  /// a restart. The first auto-lock's 404 must trigger the recovery hook
+  /// (session re-upload) and retry against the fresh id — the failure mode
+  /// the first physical-device run hit on every scan.
+  func testPuzzleNotFoundRecoversAndRetriesWithFreshId() async {
+    let client = FakeGeometryClient()
+    client.uploadResponses = [
+      .failure(APIError(message: "Puzzle not found", status: 404)),
+      .success(uploadResponse(status: .new, pieceId: "p-new")),
+    ]
+    let box = HapticBox()
+    var puzzleId = "stale-id"
+    let ctrl = PieceScanController(
+      puzzleId: { puzzleId },
+      geometryClient: client,
+      capture: { fixtureJPEG },
+      haptic: { [weak box] kind in box?.record(kind) },
+      recoverPuzzle: {
+        puzzleId = "fresh-id"
+        return true
+      },
+      sleep: { _ in }
+    )
+
+    driveToFire(ctrl)
+    await settle()
+
+    XCTAssertEqual(client.receivedPuzzleIds, ["stale-id", "fresh-id"])
+    XCTAssertEqual(ctrl.gallery.count, 1)
+    XCTAssertTrue(box.contains(.success))
+    XCTAssertFalse(box.contains(.failure))
+  }
+
+  /// When recovery itself fails, the verdict is an actionable failure and
+  /// there is no retry loop.
+  func testPuzzleNotFoundWithFailedRecoveryFailsOnce() async {
+    let client = FakeGeometryClient()
+    client.uploadResponses = [
+      .failure(APIError(message: "Puzzle not found", status: 404))
+    ]
+    let box = HapticBox()
+    let ctrl = PieceScanController(
+      puzzleId: { "stale-id" },
+      geometryClient: client,
+      capture: { fixtureJPEG },
+      haptic: { [weak box] kind in box?.record(kind) },
+      recoverPuzzle: { false },
+      sleep: { _ in }
+    )
+
+    driveToFire(ctrl)
+    await settle()
+
+    XCTAssertEqual(client.uploadCallCount, 1, "No retry without a recovered id")
+    XCTAssertTrue(box.contains(.failure))
+    XCTAssertEqual(ctrl.gallery.count, 0)
   }
 
   // MARK: - 6. loadEnrolled merges gallery

--- a/ios/PusselTests/PieceScanControllerTests.swift
+++ b/ios/PusselTests/PieceScanControllerTests.swift
@@ -416,6 +416,42 @@ final class PieceScanControllerTests: XCTestCase {
     XCTAssertEqual(ctrl.gallery.count, 0)
   }
 
+  // MARK: - 5c. onEnrolled fires for enrolled pieces only
+
+  /// Enrolled pieces (new verdicts, auto or confirmed) must reach the
+  /// session's piece list via onEnrolled; matched pieces must not — the
+  /// dedupe is what keeps the puzzle page's list duplicate-free.
+  func testOnEnrolledFiresForNewAndConfirmButNotMatched() async {
+    let client = FakeGeometryClient()
+    client.uploadResponses = [
+      .success(uploadResponse(status: .new, pieceId: "p-a")),
+      .success(uploadResponse(status: .matched, pieceId: "p-a", matchPieceId: "p-a")),
+      .success(uploadResponse(status: .uncertain, pieceId: nil, matchPieceId: "p-a")),
+      .success(uploadResponse(status: .new, pieceId: "p-b")),
+    ]
+    var enrolled: [(String, Data)] = []
+    let ctrl = PieceScanController(
+      puzzleId: { "test-puzzle" },
+      geometryClient: client,
+      capture: { fixtureJPEG },
+      haptic: { _ in },
+      onEnrolled: { enrolled.append(($0, $1)) },
+      sleep: { _ in }
+    )
+
+    driveToFire(ctrl)  // new p-a
+    await settle()
+    driveToFire(ctrl)  // matched
+    await settle()
+    driveToFire(ctrl)  // uncertain — chip pending
+    await settle()
+    await ctrl.confirmUncertainAsNew()  // enroll → new p-b
+    await settle()
+
+    XCTAssertEqual(enrolled.map(\.0), ["p-a", "p-b"])
+    XCTAssertEqual(enrolled.map(\.1), [fixtureJPEG, fixtureJPEG])
+  }
+
   // MARK: - 6. loadEnrolled merges gallery
 
   func testLoadEnrolledMergesServerPiecesWithLocalGallery() async {
@@ -454,6 +490,39 @@ final class PieceScanControllerTests: XCTestCase {
     let serverOnly = ctrl.gallery.first { $0.pieceId == "server-only" }
     XCTAssertNotNil(local?.thumbnailJPEG, "Existing thumbnail must be preserved")
     XCTAssertNil(serverOnly?.thumbnailJPEG, "Server-only piece has no local thumbnail")
+  }
+
+  /// Pieces enrolled in an earlier scanner visit come back from the server
+  /// list without images; the thumbnailForPiece hook (wired to the session's
+  /// persisted piece entries) restores them instead of a placeholder.
+  func testLoadEnrolledRestoresThumbnailsViaProvider() async {
+    let client = FakeGeometryClient()
+    client.listResponse = .success(
+      PieceGeometryListResponse(
+        puzzleId: "test-puzzle",
+        pieces: [
+          PieceGeometrySummary(
+            pieceId: "p-earlier", edgeTypes: [.tab, .tab, .tab, .tab],
+            isClean: true, cornerDisagreement: false),
+          PieceGeometrySummary(
+            pieceId: "p-unknown", edgeTypes: [.flat, .flat, .flat, .flat],
+            isClean: true, cornerDisagreement: false),
+        ]
+      ))
+    let storedPhoto = Data("STORED".utf8)
+    let ctrl = PieceScanController(
+      puzzleId: { "test-puzzle" },
+      geometryClient: client,
+      capture: { fixtureJPEG },
+      haptic: { _ in },
+      thumbnailForPiece: { id in id == "p-earlier" ? storedPhoto : nil },
+      sleep: { _ in }
+    )
+
+    await ctrl.loadEnrolled()
+
+    XCTAssertEqual(ctrl.gallery.first { $0.pieceId == "p-earlier" }?.thumbnailJPEG, storedPhoto)
+    XCTAssertNil(ctrl.gallery.first { $0.pieceId == "p-unknown" }?.thumbnailJPEG)
   }
 
   // MARK: - 7. ingest during non-scanning phase is ignored

--- a/ios/PusselTests/PieceScanControllerTests.swift
+++ b/ios/PusselTests/PieceScanControllerTests.swift
@@ -168,6 +168,32 @@ final class PieceScanControllerTests: XCTestCase {
     XCTAssertEqual(ctrl.gallery.count, 2)
   }
 
+  func testNewVerdictWithoutPieceIdFailsAndDoesNotEnroll() async {
+    // A `new` verdict must carry a backend piece id — the gallery/persistence
+    // link is keyed on it. A missing id is an invalid response, not a reason
+    // to invent a UUID the backend never issued.
+    let client = FakeGeometryClient()
+    client.uploadResponses = [.success(uploadResponse(status: .new, pieceId: nil))]
+    var enrolled: [(String, Data)] = []
+    let box = HapticBox()
+    let ctrl = PieceScanController(
+      puzzleId: { "test-puzzle" },
+      geometryClient: client,
+      capture: { fixtureJPEG },
+      haptic: { [weak box] kind in box?.record(kind) },
+      onEnrolled: { enrolled.append(($0, $1)) },
+      sleep: { _ in }
+    )
+
+    driveToFire(ctrl)
+    await settle()
+
+    XCTAssertEqual(ctrl.gallery.count, 0, "No gallery entry for an id-less enrollment")
+    XCTAssertTrue(enrolled.isEmpty, "onEnrolled must not fire without a piece id")
+    XCTAssertTrue(box.contains(.failure))
+    XCTAssertFalse(box.contains(.success))
+  }
+
   // MARK: - 2. Matched → alreadyScanned
 
   func testMatchedResponseGivesWarningHapticAndDoesNotGrowGallery() async {

--- a/ios/PusselTests/PieceScanControllerTests.swift
+++ b/ios/PusselTests/PieceScanControllerTests.swift
@@ -1,0 +1,452 @@
+import XCTest
+
+@testable import Pussel
+
+// MARK: - Fake geometry client
+
+/// Recording fake that returns scripted `PieceGeometryUploadResponse` /
+/// `PieceGeometryListResponse` values without any network calls.
+@MainActor
+final class FakeGeometryClient: PieceGeometryScanning {
+  private(set) var uploadCallCount = 0
+  private(set) var lastEnrollUncertain: Bool?
+
+  /// Queue of upload responses. Each call to `uploadPieceGeometry` dequeues
+  /// one; panics if the queue runs dry (indicates the test over-called).
+  var uploadResponses: [Result<PieceGeometryUploadResponse, Error>] = []
+  var listResponse: Result<PieceGeometryListResponse, Error> = .success(
+    PieceGeometryListResponse(puzzleId: "p1", pieces: []))
+
+  func uploadPieceGeometry(
+    puzzleId: String, jpegData: Data, enrollUncertain: Bool
+  ) async throws -> PieceGeometryUploadResponse {
+    uploadCallCount += 1
+    lastEnrollUncertain = enrollUncertain
+    guard !uploadResponses.isEmpty else {
+      fatalError("FakeGeometryClient: no more scripted upload responses")
+    }
+    return try uploadResponses.removeFirst().get()
+  }
+
+  func listPieceGeometry(puzzleId: String) async throws -> PieceGeometryListResponse {
+    try listResponse.get()
+  }
+}
+
+// MARK: - Helpers
+
+/// Builds a minimal `PieceGeometryUploadResponse` for a given status.
+/// `zScore` defaults to a plausible gray-zone value because the controller
+/// keys the uncertain-vs-unreadable distinction on it (nil = the pipeline
+/// produced no fingerprint); tests for the unreadable branch pass nil
+/// explicitly.
+private func uploadResponse(
+  status: PieceGeometryStatus,
+  pieceId: String? = "piece-1",
+  matchPieceId: String? = nil,
+  zScore: Double? = -1.2,
+  edgeTypes: [GeometryEdgeType] = [.tab, .blank, .flat, .tab]
+) -> PieceGeometryUploadResponse {
+  PieceGeometryUploadResponse(
+    pieceId: pieceId,
+    status: status,
+    matchPieceId: matchPieceId,
+    zScore: zScore,
+    lockable: status == .new,
+    quality: GeometryQuality(isClean: true, cornerDisagreement: false),
+    record: PieceGeometryRecordSummary(
+      edges: edgeTypes.map { GeometryEdgeSummary(type: $0) }
+    )
+  )
+}
+
+/// Injects three stable lockable frames spanning ≥1 s, causing the default
+/// `PieceScanStabilityTracker` inside `controller` to fire once.
+@MainActor
+private func driveToFire(_ controller: PieceScanController) {
+  let square: [NormalizedPoint] = [
+    NormalizedPoint(x: 0.1, y: 0.1), NormalizedPoint(x: 0.9, y: 0.1),
+    NormalizedPoint(x: 0.9, y: 0.9), NormalizedPoint(x: 0.1, y: 0.9),
+  ]
+  let near: [NormalizedPoint] = [
+    NormalizedPoint(x: 0.10, y: 0.10), NormalizedPoint(x: 0.91, y: 0.10),
+    NormalizedPoint(x: 0.91, y: 0.91), NormalizedPoint(x: 0.10, y: 0.91),
+  ]
+  let t0 = Date(timeIntervalSince1970: 0)
+  controller.ingest(.lockable(polygon: square, confidence: 0.9), at: t0)
+  controller.ingest(
+    .lockable(polygon: near, confidence: 0.9), at: t0.addingTimeInterval(0.5))
+  controller.ingest(
+    .lockable(polygon: near, confidence: 0.9), at: t0.addingTimeInterval(1.0))
+}
+
+/// Yields the main-actor executor enough times for nested async tasks
+/// (capture → POST → rearm) to all complete when the sleep is instant.
+/// Eight yields covers: ingest Task spawn + capturePhoto await + post call
+/// + response processing + scheduleRearm Task spawn + sleep + reset.
+@MainActor
+private func settle() async {
+  for _ in 0..<8 { await Task.yield() }
+}
+
+/// Fixture JPEG bytes — not a valid image, but enough for the controller to
+/// treat the capture as successful.
+private let fixtureJPEG = Data("FAKEJPEG".utf8)
+
+// MARK: - Tests
+
+@MainActor
+final class PieceScanControllerTests: XCTestCase {
+
+  // MARK: - Factory
+
+  /// Builds a controller with an instant sleep and a capture closure that
+  /// returns `fixtureJPEG` by default (or `nil` if `captureReturnsNil`).
+  /// The controller's haptic events are routed to a `HapticBox` so the test
+  /// can check them without the inout-in-escaping-closure restriction.
+  private func makeController(
+    client: FakeGeometryClient,
+    captureReturnsNil: Bool = false
+  ) -> (ctrl: PieceScanController, haptics: HapticBox) {
+    let box = HapticBox()
+    let ctrl = PieceScanController(
+      puzzleId: "test-puzzle",
+      geometryClient: client,
+      capture: { captureReturnsNil ? nil : fixtureJPEG },
+      haptic: { [weak box] kind in box?.record(kind) },
+      sleep: { _ in }
+    )
+    return (ctrl, box)
+  }
+
+  // MARK: - 1. Happy path: locked
+
+  func testStableStreamLocksOnceGalleryGrowsAndSuccessHapticFires() async {
+    let client = FakeGeometryClient()
+    client.uploadResponses = [
+      .success(
+        uploadResponse(
+          status: .new, pieceId: "p-new",
+          edgeTypes: [.tab, .blank, .flat, .tab])
+      )
+    ]
+    let (ctrl, haptics) = makeController(client: client)
+
+    // Drive stability → fires once.
+    driveToFire(ctrl)
+    await settle()
+
+    // After settle(), the instant rearm has already moved phase back to .scanning.
+    // Test the durable effects instead of the transient verdict phase.
+    XCTAssertEqual(client.uploadCallCount, 1)
+    XCTAssertEqual(ctrl.gallery.count, 1)
+    XCTAssertEqual(ctrl.gallery.first?.pieceId, "p-new")
+    XCTAssertEqual(ctrl.gallery.first?.thumbnailJPEG, fixtureJPEG)
+    XCTAssertTrue(haptics.contains(.success))
+    XCTAssertFalse(haptics.contains(.failure))
+  }
+
+  func testRearmsAfterLockedForASecondPiece() async {
+    let client = FakeGeometryClient()
+    client.uploadResponses = [
+      .success(uploadResponse(status: .new, pieceId: "p-new")),
+      .success(uploadResponse(status: .new, pieceId: "p-new2")),
+    ]
+    let (ctrl, _) = makeController(client: client)
+
+    // First piece.
+    driveToFire(ctrl)
+    await settle()
+    XCTAssertEqual(ctrl.phase, .scanning, "Must be scanning after instant rearm")
+
+    // Second piece.
+    driveToFire(ctrl)
+    await settle()
+    XCTAssertEqual(client.uploadCallCount, 2)
+    XCTAssertEqual(ctrl.gallery.count, 2)
+  }
+
+  // MARK: - 2. Matched → alreadyScanned
+
+  func testMatchedResponseGivesWarningHapticAndDoesNotGrowGallery() async {
+    let client = FakeGeometryClient()
+    client.uploadResponses = [
+      .success(uploadResponse(status: .matched, pieceId: "p-orig", matchPieceId: "p-orig"))
+    ]
+    let (ctrl, haptics) = makeController(client: client)
+
+    driveToFire(ctrl)
+    await settle()
+
+    XCTAssertEqual(ctrl.gallery.count, 0, "Gallery must not grow on alreadyScanned")
+    XCTAssertTrue(haptics.contains(.warning))
+    XCTAssertFalse(haptics.contains(.success))
+  }
+
+  // MARK: - 3a. Uncertain: pending JPEG kept, no gallery change, no haptic
+
+  /// Uncertain requires a NON-instant sleep so the rearm has not cleared
+  /// pendingUncertainJPEG by the time we check. We use a sleep closure that
+  /// suspends forever (never resumes), giving us a deterministic window.
+  func testUncertainResponseKeepsPendingJPEGAndNoGalleryChange() async {
+    let client = FakeGeometryClient()
+    client.uploadResponses = [
+      .success(uploadResponse(status: .uncertain, pieceId: nil, matchPieceId: "p-maybe"))
+    ]
+    let box = HapticBox()
+    // Non-resuming sleep so the rearm doesn't clear pendingUncertainJPEG.
+    let ctrl = PieceScanController(
+      puzzleId: "test-puzzle",
+      geometryClient: client,
+      capture: { fixtureJPEG },
+      haptic: { [weak box] kind in box?.record(kind) },
+      sleep: { _ in await Task.yield() }  // yields but doesn't block long
+    )
+
+    driveToFire(ctrl)
+    await settle()
+
+    // After settle, uncertain rearm delay ran (Task.yield). The phase
+    // transitioned back, but pendingUncertainJPEG persists until confirmed.
+    // The gallery must still be empty.
+    XCTAssertEqual(ctrl.gallery.count, 0)
+    // Spec: no haptic on uncertain.
+    XCTAssertFalse(box.contains(.success))
+    XCTAssertFalse(box.contains(.failure))
+    XCTAssertFalse(box.contains(.warning))
+  }
+
+  // MARK: - 3a2. Uncertain WITHOUT a z-score → unreadable, no confirm chip
+
+  /// A nil z-score means the backend pipeline failed on the photo (no
+  /// fingerprint), so on_uncertain=enroll would have nothing to enroll —
+  /// the confirm chip must NOT appear, or the user gets a dead-end loop.
+  func testUncertainWithoutZScoreBecomesUnreadableWithoutChip() async {
+    let client = FakeGeometryClient()
+    client.uploadResponses = [
+      .success(uploadResponse(status: .uncertain, pieceId: nil, zScore: nil))
+    ]
+    let box = HapticBox()
+    let ctrl = PieceScanController(
+      puzzleId: "test-puzzle",
+      geometryClient: client,
+      capture: { fixtureJPEG },
+      haptic: { [weak box] kind in box?.record(kind) },
+      sleep: { _ in await Task.yield() }
+    )
+
+    driveToFire(ctrl)
+    await settle()
+
+    XCTAssertNil(ctrl.pendingUncertainJPEG, "unreadable must not offer the confirm chip")
+    XCTAssertEqual(ctrl.gallery.count, 0)
+    XCTAssertFalse(box.contains(.success))
+    // confirmUncertainAsNew with nothing pending must be a no-op.
+    await ctrl.confirmUncertainAsNew()
+    XCTAssertEqual(client.uploadCallCount, 1)
+  }
+
+  // MARK: - 3b. confirmUncertainAsNew → enrolled + gallery
+
+  func testConfirmUncertainAsNewEnrollsAndAddsToGallery() async {
+    let client = FakeGeometryClient()
+    client.uploadResponses = [
+      .success(uploadResponse(status: .uncertain, pieceId: nil, matchPieceId: "p-maybe")),
+      .success(
+        uploadResponse(
+          status: .new, pieceId: "p-confirmed",
+          edgeTypes: [.flat, .tab, .blank, .flat])),
+    ]
+    // Use a non-resuming sleep so the uncertain chip stays available long
+    // enough for us to call confirmUncertainAsNew.
+    let box = HapticBox()
+    let pendingJPEGClearedAfterConfirm = LockBox(false)
+    let ctrl = PieceScanController(
+      puzzleId: "test-puzzle",
+      geometryClient: client,
+      capture: { fixtureJPEG },
+      haptic: { [weak box] kind in box?.record(kind) },
+      sleep: { _ in
+        // Pause long enough that we can confirm before the rearm clears state.
+        try? await Task.sleep(nanoseconds: 10_000_000)
+      }
+    )
+
+    driveToFire(ctrl)
+    // Yield enough for capture + POST to complete (but not for the long sleep).
+    for _ in 0..<5 { await Task.yield() }
+
+    // The JPEG must be pending at this point (the rearm sleep is still in flight).
+    XCTAssertNotNil(ctrl.pendingUncertainJPEG, "JPEG must be pending before confirm")
+
+    // Now confirm.
+    await ctrl.confirmUncertainAsNew()
+    _ = pendingJPEGClearedAfterConfirm
+    await settle()
+
+    XCTAssertEqual(client.uploadCallCount, 2)
+    XCTAssertEqual(client.lastEnrollUncertain, true)
+    XCTAssertNil(ctrl.pendingUncertainJPEG)
+    XCTAssertEqual(ctrl.gallery.count, 1)
+    XCTAssertEqual(ctrl.gallery.first?.pieceId, "p-confirmed")
+    XCTAssertTrue(box.contains(.success))
+  }
+
+  // MARK: - 3c. Double-tap confirm doesn't double-enroll
+
+  func testDoubleTapConfirmDoesNotDoubleEnroll() async {
+    let client = FakeGeometryClient()
+    client.uploadResponses = [
+      .success(uploadResponse(status: .uncertain, pieceId: nil)),
+      .success(uploadResponse(status: .new, pieceId: "p-once")),
+    ]
+    let ctrl = PieceScanController(
+      puzzleId: "test-puzzle",
+      geometryClient: client,
+      capture: { fixtureJPEG },
+      haptic: { _ in },
+      sleep: { _ in try? await Task.sleep(nanoseconds: 10_000_000) }
+    )
+
+    driveToFire(ctrl)
+    for _ in 0..<5 { await Task.yield() }
+
+    // Tap confirm twice concurrently — second call should find pendingUncertainJPEG nil.
+    async let first: Void = ctrl.confirmUncertainAsNew()
+    async let second: Void = ctrl.confirmUncertainAsNew()
+    _ = await (first, second)
+    await settle()
+
+    // Only one POST after the uncertain one.
+    XCTAssertEqual(client.uploadCallCount, 2)
+    XCTAssertEqual(ctrl.gallery.count, 1)
+  }
+
+  // MARK: - 4. Nil capture → failure
+
+  func testNilCaptureGivesFailureHapticAndNeverPosts() async {
+    let client = FakeGeometryClient()
+    let (ctrl, haptics) = makeController(client: client, captureReturnsNil: true)
+
+    driveToFire(ctrl)
+    await settle()
+
+    XCTAssertEqual(client.uploadCallCount, 0, "No POST when capture returns nil")
+    XCTAssertTrue(haptics.contains(.failure))
+    XCTAssertFalse(haptics.contains(.success))
+  }
+
+  // MARK: - 5. API throw → failure haptic, then re-arms to scanning
+
+  func testAPIThrowGivesFailureHapticThenRearmsToScanning() async {
+    let client = FakeGeometryClient()
+    struct FakeError: Error, LocalizedError {
+      var errorDescription: String? { "server offline" }
+    }
+    client.uploadResponses = [.failure(FakeError())]
+    let (ctrl, haptics) = makeController(client: client)
+
+    driveToFire(ctrl)
+    await settle()
+
+    XCTAssertTrue(haptics.contains(.failure))
+    // Instant sleep re-arms back to .scanning.
+    XCTAssertEqual(ctrl.phase, .scanning)
+  }
+
+  // MARK: - 6. loadEnrolled merges gallery
+
+  func testLoadEnrolledMergesServerPiecesWithLocalGallery() async {
+    let client = FakeGeometryClient()
+    client.uploadResponses = [
+      .success(
+        uploadResponse(
+          status: .new, pieceId: "local-1",
+          edgeTypes: [.tab, .blank, .flat, .tab]))
+    ]
+    let listResult = PieceGeometryListResponse(
+      puzzleId: "test-puzzle",
+      pieces: [
+        PieceGeometrySummary(
+          pieceId: "local-1", edgeTypes: [.tab, .blank, .flat, .tab],
+          isClean: true, cornerDisagreement: false),
+        PieceGeometrySummary(
+          pieceId: "server-only", edgeTypes: [.flat, .flat, .flat, .flat],
+          isClean: true, cornerDisagreement: false),
+      ]
+    )
+    client.listResponse = .success(listResult)
+    let (ctrl, _) = makeController(client: client)
+
+    // Add local-1 to the gallery with a thumbnail via a lock cycle.
+    driveToFire(ctrl)
+    await settle()
+    XCTAssertEqual(ctrl.gallery.count, 1)
+    XCTAssertNotNil(ctrl.gallery.first?.thumbnailJPEG)
+
+    // loadEnrolled: local-1 already present (thumbnail preserved), server-only appended.
+    await ctrl.loadEnrolled()
+
+    XCTAssertEqual(ctrl.gallery.count, 2)
+    let local = ctrl.gallery.first { $0.pieceId == "local-1" }
+    let serverOnly = ctrl.gallery.first { $0.pieceId == "server-only" }
+    XCTAssertNotNil(local?.thumbnailJPEG, "Existing thumbnail must be preserved")
+    XCTAssertNil(serverOnly?.thumbnailJPEG, "Server-only piece has no local thumbnail")
+  }
+
+  // MARK: - 7. ingest during non-scanning phase is ignored
+
+  func testIngestDuringCapturingPhaseIsIgnored() async {
+    let client = FakeGeometryClient()
+    client.uploadResponses = [
+      .success(uploadResponse(status: .new, pieceId: "p1")),
+      // If ingest fires a second time, this would be dequeued.
+      .success(uploadResponse(status: .new, pieceId: "p2")),
+    ]
+    let (ctrl, _) = makeController(client: client)
+
+    driveToFire(ctrl)
+    // The phase is now .capturing or .verdict; feed more lockable frames.
+    let square: [NormalizedPoint] = [
+      NormalizedPoint(x: 0.1, y: 0.1), NormalizedPoint(x: 0.9, y: 0.1),
+      NormalizedPoint(x: 0.9, y: 0.9), NormalizedPoint(x: 0.1, y: 0.9),
+    ]
+    let t2 = Date(timeIntervalSince1970: 100)
+    ctrl.ingest(.lockable(polygon: square, confidence: 0.9), at: t2)
+    ctrl.ingest(
+      .lockable(polygon: square, confidence: 0.9), at: t2.addingTimeInterval(0.5))
+    ctrl.ingest(
+      .lockable(polygon: square, confidence: 0.9), at: t2.addingTimeInterval(1.0))
+
+    await settle()
+
+    // Only the first lock cycle should have posted.
+    XCTAssertEqual(client.uploadCallCount, 1)
+  }
+}
+
+// MARK: - HapticBox
+
+/// Reference-type box that captures haptic events from the controller's
+/// injected closure. Necessary because the controller's haptic closure is
+/// `@escaping` and Swift closures can't safely capture `inout` parameters
+/// beyond their enclosing function's lifetime.
+final class HapticBox {
+  private var recorded: [ScanHaptic] = []
+
+  func record(_ haptic: ScanHaptic) {
+    recorded.append(haptic)
+  }
+
+  func contains(_ haptic: ScanHaptic) -> Bool {
+    recorded.contains(haptic)
+  }
+}
+
+// MARK: - LockBox
+
+/// Generic reference-type box for sharing a value across closures in tests.
+final class LockBox<T> {
+  var value: T
+  init(_ value: T) { self.value = value }
+}

--- a/ios/PusselTests/PieceScanStabilityTrackerTests.swift
+++ b/ios/PusselTests/PieceScanStabilityTrackerTests.swift
@@ -1,0 +1,203 @@
+import XCTest
+
+@testable import Pussel
+
+/// Unit tests for `PieceScanStabilityTracker`. All calls use injected `Date`
+/// values so no wall clock is involved — tests are deterministic regardless of
+/// host speed.
+final class PieceScanStabilityTrackerTests: XCTestCase {
+
+  // MARK: - Fixtures
+
+  /// A tightly-packed square polygon covering most of [0,1]² — stable by design.
+  private let squarePolygon: [NormalizedPoint] = [
+    NormalizedPoint(x: 0.1, y: 0.1),
+    NormalizedPoint(x: 0.9, y: 0.1),
+    NormalizedPoint(x: 0.9, y: 0.9),
+    NormalizedPoint(x: 0.1, y: 0.9),
+  ]
+
+  /// A bbox-shifted square with IoU ≈ 0.62 against squarePolygon — below the
+  /// default 0.8 threshold. Manually: bbox A=[0.1,0.9]², bbox B=[0.2,1.0]²;
+  /// intersection=[0.2,0.9]²=0.49, union=0.64+0.64-0.49=0.79, IoU≈0.62.
+  private let shiftedPolygon: [NormalizedPoint] = [
+    NormalizedPoint(x: 0.2, y: 0.2),
+    NormalizedPoint(x: 1.0, y: 0.2),
+    NormalizedPoint(x: 1.0, y: 1.0),
+    NormalizedPoint(x: 0.2, y: 1.0),
+  ]
+
+  /// A polygon nearly identical to squarePolygon — IoU very close to 1.0.
+  private let nearlyIdenticalPolygon: [NormalizedPoint] = [
+    NormalizedPoint(x: 0.10, y: 0.10),
+    NormalizedPoint(x: 0.91, y: 0.10),
+    NormalizedPoint(x: 0.91, y: 0.91),
+    NormalizedPoint(x: 0.10, y: 0.91),
+  ]
+
+  // Shorthand: a lockable state using the stable square polygon.
+  private func lockableSquare(confidence: Double = 0.9) -> PiecePreviewState {
+    .lockable(polygon: squarePolygon, confidence: confidence)
+  }
+
+  // Shorthand: a lockable state using the nearly-identical polygon.
+  private func lockableNear(confidence: Double = 0.9) -> PiecePreviewState {
+    .lockable(polygon: nearlyIdenticalPolygon, confidence: confidence)
+  }
+
+  // MARK: - Happy path: streak fires after minDuration + minSamples
+
+  func testFiresAfterMinDurationAndMinSamples() {
+    // minDuration=1.0, minSamples=3: feed 3 stable frames spanning 1.0 s.
+    var tracker = PieceScanStabilityTracker(minDuration: 1.0, minSamples: 3, minIoU: 0.8)
+    let t0 = Date(timeIntervalSince1970: 0)
+
+    XCTAssertFalse(tracker.ingest(lockableSquare(), at: t0))
+    XCTAssertFalse(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(0.5)))
+    // Third sample at exactly t0+1.0 — boundary should fire.
+    XCTAssertTrue(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(1.0)))
+  }
+
+  // MARK: - Jumped bbox restarts the streak
+
+  func testJumpedBboxRestartsStreak() {
+    var tracker = PieceScanStabilityTracker(minDuration: 1.0, minSamples: 3, minIoU: 0.8)
+    let t0 = Date(timeIntervalSince1970: 0)
+
+    // Build a near-complete streak (2 of 3 needed samples, 0.9 s elapsed).
+    XCTAssertFalse(tracker.ingest(lockableSquare(), at: t0))
+    XCTAssertFalse(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(0.9)))
+    // A frame with IoU ≈ 0.62 (< 0.8) breaks the streak.
+    XCTAssertFalse(
+      tracker.ingest(
+        .lockable(polygon: shiftedPolygon, confidence: 0.9), at: t0.addingTimeInterval(0.95)))
+    // After the jump, 2 more stable frames within 0.5 s should NOT fire
+    // (new streak only has 2 samples and < 1.0 s elapsed).
+    XCTAssertFalse(
+      tracker.ingest(
+        .lockable(polygon: shiftedPolygon, confidence: 0.9), at: t0.addingTimeInterval(1.2)))
+    XCTAssertFalse(
+      tracker.ingest(
+        .lockable(polygon: shiftedPolygon, confidence: 0.9), at: t0.addingTimeInterval(1.3)))
+  }
+
+  // MARK: - .detected resets the streak
+
+  func testDetectedResetsStreak() {
+    var tracker = PieceScanStabilityTracker(minDuration: 1.0, minSamples: 3, minIoU: 0.8)
+    let t0 = Date(timeIntervalSince1970: 0)
+
+    XCTAssertFalse(tracker.ingest(lockableSquare(), at: t0))
+    XCTAssertFalse(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(0.5)))
+    // A single detected (quality gate not met) breaks the streak.
+    XCTAssertFalse(
+      tracker.ingest(
+        .detected(polygon: squarePolygon, confidence: 0.6), at: t0.addingTimeInterval(0.6)))
+    // New streak starts at t0+0.7. Two samples at 0.8 s elapsed is not enough.
+    XCTAssertFalse(tracker.ingest(lockableSquare(), at: t0.addingTimeInterval(0.7)))
+    XCTAssertFalse(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(1.5)))
+    // Third sample at t0+0.7+1.0 = t0+1.7 — fires because the new streak now
+    // spans exactly 1.0 s and has 3 samples. If the streak had NOT been reset,
+    // the very first 3-sample+1.0 s window would have fired much earlier.
+    XCTAssertTrue(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(1.7)))
+  }
+
+  // MARK: - .none resets the streak
+
+  func testNoneResetsStreak() {
+    var tracker = PieceScanStabilityTracker(minDuration: 1.0, minSamples: 3, minIoU: 0.8)
+    let t0 = Date(timeIntervalSince1970: 0)
+
+    XCTAssertFalse(tracker.ingest(lockableSquare(), at: t0))
+    XCTAssertFalse(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(0.5)))
+    XCTAssertFalse(tracker.ingest(.none, at: t0.addingTimeInterval(0.6)))
+    // New streak from t0+0.7: 2 samples at t0+1.5 is not enough.
+    XCTAssertFalse(tracker.ingest(lockableSquare(), at: t0.addingTimeInterval(0.7)))
+    XCTAssertFalse(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(1.5)))
+    // Third sample completes the new streak (3 samples, 1.0 s elapsed since t0+0.7).
+    XCTAssertTrue(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(1.7)))
+  }
+
+  // MARK: - Latch prevents double-fire until reset()
+
+  func testLatchPreventsdoubleFire() {
+    var tracker = PieceScanStabilityTracker(minDuration: 1.0, minSamples: 3, minIoU: 0.8)
+    let t0 = Date(timeIntervalSince1970: 0)
+
+    // Fire once.
+    XCTAssertFalse(tracker.ingest(lockableSquare(), at: t0))
+    XCTAssertFalse(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(0.5)))
+    XCTAssertTrue(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(1.0)))
+
+    // Additional lockable frames must NOT fire again.
+    XCTAssertFalse(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(1.1)))
+    XCTAssertFalse(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(5.0)))
+
+    // After reset() the tracker fires again on the next completed streak.
+    tracker.reset()
+    XCTAssertFalse(tracker.ingest(lockableSquare(), at: t0))
+    XCTAssertFalse(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(0.5)))
+    XCTAssertTrue(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(1.0)))
+  }
+
+  // MARK: - Degenerate polygon resets the streak
+
+  func testDegeneratePolygonLessThanThreePointsResetsStreak() {
+    var tracker = PieceScanStabilityTracker(minDuration: 1.0, minSamples: 3, minIoU: 0.8)
+    let t0 = Date(timeIntervalSince1970: 0)
+
+    XCTAssertFalse(tracker.ingest(lockableSquare(), at: t0))
+    // A two-point "polygon" collapses to a line — zero-area bbox.
+    let twoPoints: [NormalizedPoint] = [
+      NormalizedPoint(x: 0.1, y: 0.1),
+      NormalizedPoint(x: 0.9, y: 0.1),
+    ]
+    XCTAssertFalse(
+      tracker.ingest(
+        .lockable(polygon: twoPoints, confidence: 0.9), at: t0.addingTimeInterval(0.5)))
+    // Next stable lockable frame restarts a fresh streak.
+    XCTAssertFalse(tracker.ingest(lockableSquare(), at: t0.addingTimeInterval(0.6)))
+    XCTAssertFalse(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(1.3)))
+    // Only 2 samples in the streak (0.6 and 1.3), elapsed = 0.7 s — should NOT fire.
+    XCTAssertFalse(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(1.5)))
+  }
+
+  func testZeroAreaBboxPolygonResetsStreak() {
+    var tracker = PieceScanStabilityTracker(minDuration: 1.0, minSamples: 3, minIoU: 0.8)
+    let t0 = Date(timeIntervalSince1970: 0)
+
+    XCTAssertFalse(tracker.ingest(lockableSquare(), at: t0))
+    // All points collinear → zero-height bbox.
+    let collinear: [NormalizedPoint] = [
+      NormalizedPoint(x: 0.1, y: 0.5),
+      NormalizedPoint(x: 0.5, y: 0.5),
+      NormalizedPoint(x: 0.9, y: 0.5),
+    ]
+    XCTAssertFalse(
+      tracker.ingest(
+        .lockable(polygon: collinear, confidence: 0.9), at: t0.addingTimeInterval(0.5)))
+    // Streak was reset; a subsequent lockable frame begins a new one.
+    XCTAssertFalse(tracker.ingest(lockableSquare(), at: t0.addingTimeInterval(0.6)))
+  }
+
+  // MARK: - Boundary: exactly at minDuration / minSamples
+
+  func testBoundaryExactlyAtMinDurationAndMinSamples() {
+    // minSamples=2, minDuration=0.5 — fire on the second frame at t=0.5.
+    var tracker = PieceScanStabilityTracker(minDuration: 0.5, minSamples: 2, minIoU: 0.8)
+    let t0 = Date(timeIntervalSince1970: 0)
+
+    XCTAssertFalse(tracker.ingest(lockableSquare(), at: t0))
+    XCTAssertTrue(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(0.5)))
+  }
+
+  func testBoundaryOneFrameShortDoesNotFire() {
+    var tracker = PieceScanStabilityTracker(minDuration: 1.0, minSamples: 3, minIoU: 0.8)
+    let t0 = Date(timeIntervalSince1970: 0)
+
+    XCTAssertFalse(tracker.ingest(lockableSquare(), at: t0))
+    XCTAssertFalse(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(0.5)))
+    // Two samples, 0.99 s elapsed — short of both thresholds (needs 3 samples AND 1.0 s).
+    XCTAssertFalse(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(0.99)))
+  }
+}

--- a/ios/PusselTests/PieceScanStabilityTrackerTests.swift
+++ b/ios/PusselTests/PieceScanStabilityTrackerTests.swift
@@ -162,6 +162,29 @@ final class PieceScanStabilityTrackerTests: XCTestCase {
     XCTAssertFalse(tracker.ingest(lockableNear(), at: t0.addingTimeInterval(1.5)))
   }
 
+  func testTwoPointDiagonalWithPositiveAreaBboxResetsStreak() {
+    // A 2-point diagonal has a positive-area bbox (non-zero width AND height),
+    // so the area check alone would accept it — only the explicit point-count
+    // guard rejects it. This is the case Copilot flagged: without count >= 3
+    // a 2-point "polygon" could contribute to a lock.
+    var tracker = PieceScanStabilityTracker(minDuration: 1.0, minSamples: 2, minIoU: 0.0)
+    let t0 = Date(timeIntervalSince1970: 0)
+
+    XCTAssertFalse(tracker.ingest(lockableSquare(), at: t0))
+    let twoPointDiagonal: [NormalizedPoint] = [
+      NormalizedPoint(x: 0.1, y: 0.1),
+      NormalizedPoint(x: 0.9, y: 0.9),
+    ]
+    // Even with minSamples=2, minDuration met, and minIoU=0 (so IoU can't be
+    // the blocker), the diagonal must not count — it resets the streak.
+    XCTAssertFalse(
+      tracker.ingest(
+        .lockable(polygon: twoPointDiagonal, confidence: 0.9), at: t0.addingTimeInterval(1.0)))
+    // Proof the streak was reset (not merely non-firing): a single fresh frame
+    // after it cannot immediately satisfy minSamples=2.
+    XCTAssertFalse(tracker.ingest(lockableSquare(), at: t0.addingTimeInterval(1.1)))
+  }
+
   func testZeroAreaBboxPolygonResetsStreak() {
     var tracker = PieceScanStabilityTracker(minDuration: 1.0, minSamples: 3, minIoU: 0.8)
     let t0 = Date(timeIntervalSince1970: 0)

--- a/ios/PusselTests/PuzzleStoreTests.swift
+++ b/ios/PusselTests/PuzzleStoreTests.swift
@@ -63,7 +63,8 @@ final class PuzzleStoreTests: XCTestCase {
           rotationConfidence: 0.77,
           cleanedImage: nil,
           pieceSpan: PieceSpan(width: 0.34, height: 0.25)
-        )
+        ),
+        scanPieceId: "p001"
       )
     ]
     session.persist()
@@ -92,6 +93,9 @@ final class PuzzleStoreTests: XCTestCase {
     XCTAssertEqual(entry.result?.position, NormalizedPoint(x: 0.34, y: 0.4))
     XCTAssertEqual(entry.result?.rotation, 90)
     XCTAssertEqual(entry.result?.pieceSpan, PieceSpan(width: 0.34, height: 0.25))
+    // The scan-and-lock link survives the round trip, so the scan gallery
+    // can restore this entry's photo as its thumbnail on a later visit.
+    XCTAssertEqual(entry.scanPieceId, "p001")
   }
 
   func testUnpredictedPieceReloadsAsQueued() throws {

--- a/ios/README.md
+++ b/ios/README.md
@@ -135,5 +135,10 @@ Debug builds accept two escape hatches, both compiled out of Release:
 
   Commands: `trim?puzzle=<path>`, `accept`, `piece?path=<path>`, `reupload`,
   `reset`, `open?index=<n>` / `delete?index=<n>` (index into the saved-puzzles
-  list on the home screen). Simulator apps can read host file paths directly,
-  so fixtures can live anywhere (e.g. `frontend/public/test-puzzles/`).
+  list on the home screen), `camera[?open=0]` (force the piece camera cover
+  open/closed — needed on the Simulator, which has no
+  `PieceCameraSession.isCameraAvailable`), `previewloop?path=<path>` /
+  `previewloop?stop=1` (feed a host image through the live piece-preview
+  overlay pipeline on a ~3Hz timer, since the Simulator has no camera to
+  stream real frames from). Simulator apps can read host file paths
+  directly, so fixtures can live anywhere (e.g. `frontend/public/test-puzzles/`).

--- a/network/experiments/exp28_piece_geometry/.gitignore
+++ b/network/experiments/exp28_piece_geometry/.gitignore
@@ -1,0 +1,1 @@
+outputs/

--- a/network/experiments/exp28_piece_geometry/HANDOFF.md
+++ b/network/experiments/exp28_piece_geometry/HANDOFF.md
@@ -1,0 +1,103 @@
+# exp28 Handoff — M1 (contour extraction) + M2 (corner detection)
+
+Date: 2026-07-16 · Status: **both milestone success criteria met** · Plan: [docs/piece-geometry-scanning.html](../../../docs/piece-geometry-scanning.html)
+
+## M1 — High-fidelity contour extraction
+
+Ran both extraction methods over the full north_star set (236 pieces × 4 backgrounds = 944 photos).
+
+| Background   | rembg clean rate | Otsu-threshold clean rate |
+|--------------|------------------|---------------------------|
+| gray_fabric  | 233/236 (98.7%)  | 53/236 (22.5%)            |
+| red_carpet   | 231/236 (97.9%)  | 6/236 (2.5%)              |
+| wood         | 227/236 (96.2%)  | 2/236 (0.8%)              |
+| cardboard    | 225/236 (95.3%)  | 40/236 (16.9%)            |
+
+**Criterion (≥95% clean on the 2 friendly backgrounds): met — on all four backgrounds, not just two.**
+
+Findings beyond the numbers:
+
+- **Gate-failure modes** (28 rembg failures): 17 multi-component segmentations, 8 border-touching
+  crops, 3 implausible shape metrics. Spread thinly across puzzles; worst case was
+  lion_king × wood (4).
+- **Silent failures exist on wood** (visual review of contact sheets): a few pieces per sheet pass
+  the quality gate but the contour follows *dark artwork boundaries* instead of the physical piece
+  edge (dark art blends into wood tones/shadows). Gray fabric and red carpet sheets are essentially
+  flawless — contours hug piece edges and correctly exclude drop shadows.
+- **Otsu thresholding is dead on textured real backgrounds** — kept only as the documented baseline.
+  rembg (u2net) is the extraction method going forward.
+- **Capture-protocol recommendation for the future scanning mat: a neutral gray fabric-like
+  surface** (best clean rate, zero observed silent failures).
+
+Review artifacts: `outputs/review/*.png` (56 contact sheets, green = passed gate, red = failed),
+`outputs/summary.csv`, per-piece contour JSONs in `outputs/contours/`.
+
+## M2 — Corner detection bake-off
+
+Three detectors (`corner_detect.py`), all sharing a candidate-pool → best-4-subset → refinement
+pipeline: `curvature` (turn-angle extrema), `polydp` (approxPolyDP epsilon sweep), `shitomasi`
+(goodFeaturesToTrack on the filled mask).
+
+**Synthetic benchmark** (n=200 random `puzzle_shapes` pieces, random rotation, blur+noise, known
+ground-truth corners; metric = worst-of-4 corner error as % of piece diagonal):
+
+| Method    | Median err | ≤3% err (initial → final) |
+|-----------|-----------:|---------------------------|
+| polydp    | 0.72%      | 68.0% → **98.5%**         |
+| curvature | 0.68%      | 29.5% → **97.0%**         |
+| shitomasi | 27.08%     | 1.5% → 13.5%              |
+
+**Criterion (≤3% worst-corner error on ≥90% of pieces): met by polydp and curvature.**
+
+What made the difference (the initial versions failed on 30–70% of pieces by picking tab-bulb tips):
+
+1. **Cornerness prior**: true corners have locally *straight* contour shoulders on both sides; tab
+   tips curve away immediately. Per-candidate score = straightness(before) × straightness(after) ×
+   local-angle-90° score, from PCA line fits over arc-length windows.
+2. **Rebalanced subset score**: quad area normalized by hull area (0–1) so it can no longer dominate
+   the angle/spacing terms.
+3. **Corner refinement**: intersect the two shoulder lines (tight window) — recovers the un-rounded
+   corner position that corner_radius hides; p97 error dropped 3.6% → 0.8%.
+4. **Candidate-pool fixes**: the true corner must be *in* the pool before scoring can pick it
+   (polydp keeps all sweep vertices; curvature NMS separation halved).
+
+`shitomasi` fails structurally, not by tuning: goodFeaturesToTrack responds to sharp tab armpits and
+misses rounded true corners — ~33% of true corners never enter its candidate pool. Dropped from
+consideration.
+
+**Real photos** (all 944, no ground-truth labels yet): corner-overlay sheets in
+`outputs/review_corners/` look very strong — on gray fabric, nearly every piece has all methods
+agreeing on the true corners; occasional single-method outliers. Notably shitomasi performs fine on
+real pieces (real corners are sharper than the extreme synthetic ones), reinforcing that the
+synthetic benchmark is the *harder* test for corner geometry.
+
+**Quantitative real-photo eval is prepared but needs hand labels**: run
+`uv run python experiments/exp28_piece_geometry/label_corners.py` (click 4 corners per piece,
+~60-piece subset suggested), then `eval_corners.py --labels-file outputs/corner_labels.json`
+produces the per-method/per-background error table automatically. Optional but recommended before
+M4 conclusions.
+
+## Recommendation going into M3 (edge splitting + tab/blank/flat classification)
+
+- Use **polydp as the primary detector, curvature as cross-check** — when their corner sets
+  disagree materially, flag the piece as low-confidence (this doubles as the quality gate for the
+  future scan-lock UX).
+- Split contours at the detected corners into 4 edge arcs; classify by the chord-midpoint test.
+  Ground truth for edge types is nearly free from north_star grid positions (border edges flat,
+  interior edges tab/blank with parity constraints).
+- Wood-background silent contour failures will pollute M3/M4 metrics slightly — either restrict
+  M3/M4 development to gray_fabric + red_carpet, or add a per-piece cross-background consistency
+  check later.
+
+## Reproduce
+
+```bash
+cd network
+uv run python experiments/exp28_piece_geometry/extract_contours.py          # ~35 min (rembg over 944 photos)
+uv run python experiments/exp28_piece_geometry/contact_sheets.py
+uv run python experiments/exp28_piece_geometry/synth_benchmark.py --n 200 --seed 42
+uv run python experiments/exp28_piece_geometry/debug_synth_failures.py      # renders failure cases
+uv run python experiments/exp28_piece_geometry/eval_corners.py              # corner sheets (+ eval if labels exist)
+```
+
+Dataset: `network/datasets/north_star/v1` (local only, regenerate via `experiments/north_star/ingest.py`).

--- a/network/experiments/exp28_piece_geometry/HANDOFF.md
+++ b/network/experiments/exp28_piece_geometry/HANDOFF.md
@@ -291,14 +291,42 @@ strict accept threshold — production same-mat scans have more margin than this
 
 Tests: 212 backend tests pass (new-package coverage 87–96%); `make check-backend` clean.
 
-## Recommendation going into Phase D (M9: iOS live outline overlay)
+## M9 — iOS live piece-outline overlay (Phase D, first milestone)
 
-- iOS catches up to the web client first: stream downscaled `AVCaptureVideoDataOutput` frames to
-  `/api/v1/piece/preview?include_quality=true`, draw the polygon + lockable state over the preview
-  layer. The backend side is fully ready.
-- M10 (scan-and-lock) then drives the geometry endpoint on a stable, quality-gated frame and uses
-  `status`/`on_uncertain` for the enroll flow; M7's gray-zone rates predict the confirmation-UX
-  frequency.
+iOS now streams live camera frames and draws the piece outline over the preview — verified
+working on a physical iPhone 15 by the user ("looks much better" after the orientation fix;
+outline sits on the piece and tracks movement).
+
+Implementation (`ios/Pussel/Features/Solve/`): an `AVCaptureVideoDataOutput` tap on the existing
+capture session, throttled (≥250ms interval, one request in flight) downscale-to-480px JPEG
+streaming to `POST /api/v1/piece/preview?include_quality=true`; overlay is a `CAShapeLayer`
+(yellow = detected, green = lockable, 120ms animated tracking, hides when stale >1.5s). Pure
+logic extracted and unit-tested: `PiecePreviewThrottle`, `PiecePreviewGeometry` (76 iOS tests
+pass; `make check-ios` clean).
+
+Two hard-won lessons recorded for posterity:
+
+1. **Never guess buffer orientation.** The first device build drew the outline rotated and offset
+   — the fixed 90° sensor-rotation assumption was wrong for the device/connection. Fix: rotate
+   buffers to portrait at the connection level (`videoRotationAngle = 90`), so the streamed JPEG
+   is pixel-identical to what the preview shows, and map with ONE unit-tested aspect-fill
+   transform (`viewPolygon`) on both device and Simulator. The rotation-math path was deleted.
+2. **iOS 26 Simulator camera-permission dialogs cannot be scripted away** (`simctl privacy grant`
+   does not suppress the prompt; headless environments have no window to tap). DEBUG Simulator
+   builds therefore never start a real capture session; the `pusseldebug://previewloop?path=…`
+   command feeds fake frames through the identical pipeline for tap-free demos.
+
+Deploy recipe used (device): build with `API_BASE_URL=http://<mac LAN IP>:8001`, backend on
+`--host 0.0.0.0`; `devicectl device install app` + `process launch`.
+
+## Recommendation going into M10 (scan-and-lock)
+
+- Track stability across preview responses (contour IoU or polygon-center drift between
+  consecutive frames); when stable + `lockable`, auto-capture a full-res frame, POST it to
+  `/api/v1/puzzle/{id}/piece/geometry`, and flip the overlay to a locked state with haptics.
+- Use `status` (`matched` → "already scanned", `new` → enroll + green flash, `uncertain` →
+  keep scanning / confirm dialog with `on_uncertain=enroll`). M7 predicts the gray-zone rates.
+- Session gallery: `GET …/piece/geometry` already returns the enrolled list with edge types.
 - Still open (unchanged): capture-time exposure/white-balance on dark surfaces; a same-background
   repeat-capture set would measure true same-session accuracy (expected >95%).
 

--- a/network/experiments/exp28_piece_geometry/HANDOFF.md
+++ b/network/experiments/exp28_piece_geometry/HANDOFF.md
@@ -363,11 +363,38 @@ Tests: 110 iOS tests pass (tracker, controller incl. the unreadable branch, mode
 API client); `make check-ios` clean. Deployed to the physical iPhone 15 with
 `API_BASE_URL=http://192.168.86.63:8001`.
 
-Known limitation for the device run: the backend piece store is in-memory, so a saved puzzle's
-`puzzle_id` dies with a backend restart. The scan flow surfaces the 404 as a red failure banner
-but has no re-upload recovery of its own (the piece-queue flow does) — start the device test
-from a freshly captured puzzle, or re-upload via the queue's expired banner first. Worth folding
-into M11 or a small follow-up.
+**Device run (same day, physical iPhone 15, real pieces on a wood table) — verified working,
+with three findings that each turned into a same-day fix:**
+
+1. **Stale puzzle ids dead-ended every scan.** The backend piece store is in-memory, so a saved
+   session's `puzzle_id` 404s after a backend restart — the first device run red-bannered on every
+   lock. Fix: the controller reads the puzzle id through a closure and, on 404, re-uploads the
+   stored puzzle image (same recovery as the piece queue) and retries once. Watched working live:
+   404 → upload → retry 200 → enrolled.
+2. **Scanned pieces were a parallel world.** Locked pieces appeared only in the scan gallery — not
+   in the puzzle page's piece list — and gallery thumbnails died with the view (the GET carries no
+   images). Fix: an enrolled piece now enqueues its capture as a regular `CaptureEntry` (position
+   prediction, overlay marker, disk persistence) tagged with `scanPieceId`; the gallery restores
+   thumbnails from those persisted entries. Matched verdicts enqueue nothing, so the dedupe keeps
+   the piece list duplicate-free.
+3. **The confirm chip cost one tap per new piece** — M7's measurement (97.9% of new pieces land in
+   the gray zone at the strict thresholds) meant "scan 10 pieces hands-free" degenerated into 10
+   chip taps. Product decision (user): relax `t_accept` to M7's FMR=1% ROC point (−3.98; gray-zone
+   re-scans ~26–30% → ~8% at 1% wrong-lock risk) and auto-enroll gray-zone verdicts
+   (`on_uncertain=enroll` on the first post). Accepted cost: the ~8% of re-scans still in the gray
+   zone can enroll a duplicate (deletable in the piece list). After the change, the observed device
+   flow was: new piece → zero-tap lock → enrolled → predicted → in the piece list; re-pointing at
+   scanned pieces → "Already scanned", zero duplicates across repeated re-locks. The chip UX is
+   retained for response shapes that still report uncertain.
+
+Also observed on-device, matching M1: a black/very dark surface defeats the preview detector
+entirely (no outline, so no lock can fire); wood and mid-tone surfaces work well. The gray-mat
+recommendation stands.
+
+Backend surfaces still shared: piece ids are only unique within one store lifetime — after a
+restart + recovery the fresh store re-mints p001…, so client-side links to old ids are cleared on
+re-upload (implemented). A persistent piece store would remove this whole class; a candidate for
+Phase E.
 
 ## Recommendation going into M10 (scan-and-lock) — original brief, implemented above
 

--- a/network/experiments/exp28_piece_geometry/HANDOFF.md
+++ b/network/experiments/exp28_piece_geometry/HANDOFF.md
@@ -319,7 +319,57 @@ Two hard-won lessons recorded for posterity:
 Deploy recipe used (device): build with `API_BASE_URL=http://<mac LAN IP>:8001`, backend on
 `--host 0.0.0.0`; `devicectl device install app` + `process launch`.
 
-## Recommendation going into M10 (scan-and-lock)
+## M10 — iOS scan-and-lock (Phase D, second milestone)
+
+Implemented exactly along the recommendation below and E2E-verified in the Simulator against the
+real backend (the 10-physical-pieces-in-2-minutes criterion still needs the on-device run).
+
+Implementation (`ios/Pussel/Features/Solve/`):
+
+- `PieceScanStabilityTracker` (pure, unit-tested): bbox-IoU ≥ 0.8 between consecutive `lockable`
+  preview detections, streak ≥ 1 s and ≥ 3 samples → fire once (latched until reset). `.detected`
+  (non-lockable) and degenerate polygons reset the streak.
+- `PieceScanController` (@MainActor @Observable, DI for client/capture/haptics/sleep — fully
+  unit-testable without camera/network/clock): scanning → capturing (auto `capturePhoto()`, no
+  shutter; downscaled to 1600 px JPEG like the texture path) → POST → verdict → timed re-arm.
+  Verdicts: `new` → "Piece locked ✓ T·B·F·T" + green flash + success haptic + gallery append;
+  `matched` → "Already scanned" + warning haptic + gallery-tile highlight (no duplicate);
+  `uncertain` → scanning resumes immediately, a persistent one-tap chip re-posts the same JPEG
+  with `on_uncertain=enroll` (double-tap-safe).
+- `PieceScanView`: opened from a new viewfinder tile next to the piece grid's "+"; reuses the M9
+  `CameraPreview`/`PiecePreviewStreamer` stack unchanged; session gallery strip at the bottom
+  (thumbnail or placeholder + edge glyph, pre-filled from GET on open).
+- Debug driving on the Simulator: `pusseldebug://scan` opens the view, `previewloop` doubles as
+  the capture source (the loop image is returned by `capturePhoto()` in DEBUG sim builds), and
+  `pusseldebug://scanconfirm` taps the uncertain chip.
+
+**Simulator E2E (worktree backend on :8001, north_star puzzle01 photos, all verified on screen
+and against the store via GET):** r00_c00 auto-locked as `new p001` (edge glyph F·T·B·F,
+thumbnail in gallery); continued pointing → `matched` → "Already scanned" with gallery highlight,
+store still 1 piece; app relaunch → gallery pre-filled from GET (placeholder tile); r02_c02 →
+`unreadable` (see the gap below), no chip, scanning continues; r02_c00 → gray-zone chip →
+`scanconfirm` → enrolled `p002` (B·B·F·F), locked banner, store lists [p001, p002].
+
+**The E2E again caught a real-flow gap unit tests missed (third time in this project):** the
+backend's `uncertain` status has a second, fingerprint-less flavor — contour quality-gate failure
+(e.g. the north_star arrow marker merging into the crop: r02_c02, r01_c01 on gray_fabric) returns
+`uncertain` with `z_score = null`, and `on_uncertain=enroll` correctly refuses to enroll it. The
+confirm chip would have been a dead-end loop for those photos. The controller now branches on
+`z_score == nil` → a distinct `unreadable` verdict ("Couldn't read the piece — adjust and hold
+steady", no chip, keep scanning). Production note: this flavor should be rare on a clean mat —
+it was the arrow marker + dark-wood clutter in the dataset photos.
+
+Tests: 110 iOS tests pass (tracker, controller incl. the unreadable branch, model decoding,
+API client); `make check-ios` clean. Deployed to the physical iPhone 15 with
+`API_BASE_URL=http://192.168.86.63:8001`.
+
+Known limitation for the device run: the backend piece store is in-memory, so a saved puzzle's
+`puzzle_id` dies with a backend restart. The scan flow surfaces the 404 as a red failure banner
+but has no re-upload recovery of its own (the piece-queue flow does) — start the device test
+from a freshly captured puzzle, or re-upload via the queue's expired banner first. Worth folding
+into M11 or a small follow-up.
+
+## Recommendation going into M10 (scan-and-lock) — original brief, implemented above
 
 - Track stability across preview responses (contour IoU or polygon-center drift between
   consecutive frames); when stable + `lockable`, auto-capture a full-res frame, POST it to

--- a/network/experiments/exp28_piece_geometry/HANDOFF.md
+++ b/network/experiments/exp28_piece_geometry/HANDOFF.md
@@ -1,4 +1,4 @@
-# exp28 Handoff — Phase A+B complete: M1–M4, M6, M7 (M5 deferred)
+# exp28 Handoff — Phases A+B+C complete: M1–M4, M6, M7, M8 (M5 deferred)
 
 Date: 2026-07-16 · Status: **M1–M3 criteria met; M4 reported; M6's ≥95% criterion missed by its frozen scorer (91.5%) but retroactively met by M7's simpler z-sum scorer (95.2% on the same leakage-free cells, independently verified); M7 delivered thresholds + zero die-cut collisions** · Plan: [docs/piece-geometry-scanning.html](../../../docs/piece-geometry-scanning.html)
 
@@ -252,17 +252,55 @@ test-selected hyperparameters of its own (its two components were validation-cho
 this is an honest number: **the M6 ≥95% criterion is met by the M7 scorer** — production should
 use this single score for both ranking and thresholding, and the RRF machinery can be retired.
 
-## Recommendation going into Phase C (M8: backend geometry endpoint)
+## M8 — Backend geometry endpoint + session piece store (Phase C)
 
-- The production scoring stack is now settled: rembg contour → polydp corners (curvature
-  cross-check flag) → 4 typed edges + canonical polylines → fingerprint = shape polylines +
-  3×3 gray-world a\*b\* spatial histograms → z-sum score with per-gallery impostor normalization,
-  `t_accept`/`t_new` from M7.
-- The piece-record JSON from M3 is the natural API response shape; add the fingerprint fields and
-  the quality flags (is_clean, corner_disagreement, gray-zone verdicts).
-- Remaining open risk for production is capture-time exposure/white-balance on dark surfaces —
-  mitigate with the gray-mat protocol and consider a same-background repeat-capture set to
-  measure true same-session accuracy (expected >95%).
+The exp28 stack is now production code in `backend/app/services/piece_geometry/` (contour,
+corners, edges, fingerprint, scoring, service, store — each module carries a provenance note
+back to its exp28 source; keep algorithm changes in sync). Production adaptations: no scipy
+(numpy circular-Gaussian + exact brute-force 4-corner assignment, equivalence-tested), no N/E/S/W
+grid mapping (orientation unknown in production — edges stay contour-ordered, identity uses the
+rotation-invariant mode), shitomasi dropped per M2.
+
+**API:**
+- `POST /api/v1/puzzle/{id}/piece/geometry[?include_contour=true][&on_uncertain=report|enroll]` —
+  multipart photo → `{piece_id, status: new|matched|uncertain, match_piece_id, z_score, lockable,
+  quality{is_clean, corner_disagreement (null = not measured), …}, record{corners, edges[{type,
+  dominant_dev, polyline}], contour?}}`. Dedupe via the M7 z-sum: gallery impostor stats when ≥12
+  pieces enrolled, else the M7 fallback constants; `t_accept`/`t_new` configurable in Settings.
+  Gray-zone results are NOT auto-enrolled; the client resolves them with `on_uncertain=enroll`
+  after its own confirmation UX (per M7: 97.9% of new pieces land in the gray zone, so
+  "not accepted" is the practical new-piece signal).
+- `GET /api/v1/puzzle/{id}/piece/geometry` — enrolled pieces (id, edge types, quality).
+- `/api/v1/piece/preview?include_quality=true` — adds `{lockable, corner_disagreement}` for the
+  scan-lock UX; default response unchanged for the existing web client.
+
+**Two integration gaps found only by real-photo E2E** (the synthetic tests all passed):
+1. exp28 was calibrated on bbox *crops*; the service initially ran on full frames, so a stray
+   object (the north_star arrow) failed `n_large_components` and diluted `area_ratio`. Fixed:
+   service now crops to the largest alpha component + 15% margin and runs the calibrated pipeline
+   in that frame (coordinates mapped back to full-image space).
+2. The gray zone was a dead end — a genuinely new second piece could never be enrolled. Fixed with
+   the explicit `on_uncertain=enroll` escape hatch.
+
+**E2E acceptance (real north_star photos, port-8001 instance, all passed):**
+piece r00c00 on gray_fabric → `new p001`, lockable, edge types `flat/tab/blank/flat`; same
+physical piece on red_carpet → `matched p001` (z=−5.77); different piece r02c02 → `uncertain`
+(z=−2.0, correctly conservative); with `on_uncertain=enroll` → `new p002`; r02c02 on cardboard →
+`matched p002` (z=−4.90). Store lists `[p001, p002]`. Both cross-background matches cleared the
+strict accept threshold — production same-mat scans have more margin than this.
+
+Tests: 212 backend tests pass (new-package coverage 87–96%); `make check-backend` clean.
+
+## Recommendation going into Phase D (M9: iOS live outline overlay)
+
+- iOS catches up to the web client first: stream downscaled `AVCaptureVideoDataOutput` frames to
+  `/api/v1/piece/preview?include_quality=true`, draw the polygon + lockable state over the preview
+  layer. The backend side is fully ready.
+- M10 (scan-and-lock) then drives the geometry endpoint on a stable, quality-gated frame and uses
+  `status`/`on_uncertain` for the enroll flow; M7's gray-zone rates predict the confirmation-UX
+  frequency.
+- Still open (unchanged): capture-time exposure/white-balance on dark surfaces; a same-background
+  repeat-capture set would measure true same-session accuracy (expected >95%).
 
 ## Reproduce
 

--- a/network/experiments/exp28_piece_geometry/HANDOFF.md
+++ b/network/experiments/exp28_piece_geometry/HANDOFF.md
@@ -1,6 +1,6 @@
-# exp28 Handoff — M1 (contour extraction) + M2 (corner detection)
+# exp28 Handoff — M1 (contour extraction) + M2 (corner detection) + M3 (edge classification)
 
-Date: 2026-07-16 · Status: **both milestone success criteria met** · Plan: [docs/piece-geometry-scanning.html](../../../docs/piece-geometry-scanning.html)
+Date: 2026-07-16 · Status: **all three milestone success criteria met** · Plan: [docs/piece-geometry-scanning.html](../../../docs/piece-geometry-scanning.html)
 
 ## M1 — High-fidelity contour extraction
 
@@ -77,17 +77,54 @@ synthetic benchmark is the *harder* test for corner geometry.
 produces the per-method/per-background error table automatically. Optional but recommended before
 M4 conclusions.
 
-## Recommendation going into M3 (edge splitting + tab/blank/flat classification)
+## M3 — Edge splitting + tab/blank/flat classification
 
-- Use **polydp as the primary detector, curvature as cross-check** — when their corner sets
-  disagree materially, flag the piece as low-confidence (this doubles as the quality gate for the
-  future scan-lock UX).
-- Split contours at the detected corners into 4 edge arcs; classify by the chord-midpoint test.
-  Ground truth for edge types is nearly free from north_star grid positions (border edges flat,
-  interior edges tab/blank with parity constraints).
-- Wood-background silent contour failures will pollute M3/M4 metrics slightly — either restrict
-  M3/M4 development to gray_fabric + red_carpet, or add a per-piece cross-background consistency
-  check later.
+`edge_split.py` splits each clean contour at the polydp corners (curvature as cross-check →
+`corner_disagreement` flag), maps the 4 arcs to grid directions N/E/S/W (pieces are photographed
+upright), classifies each by signed chord deviation, and emits a **piece record** per photo
+(corners + 4 typed edges, each with a 100-point polyline — the direct input for M4). Coverage:
+916/944 photos (the 28 non-clean contours skipped), 0 splitting failures, 135 disagreement flags.
+
+The deviation distribution is strongly bimodal exactly as hoped: flat edges live in [0, ~0.04]
+(median 0.009, as fraction of chord length), tab/blank features in [~0.11, 0.42] (median 0.292).
+`FLAT_THRESHOLD = 0.07` sits mid-gap.
+
+**Evaluation against near-free ground truth** (`eval_edges.py`, `outputs/edge_eval.json`):
+
+| Metric | Result |
+|---|---|
+| Flat-edge accuracy vs grid borders — gray_fabric | **99.68%** |
+| — red_carpet | 98.38% |
+| — cardboard | 98.00% |
+| — wood | 97.25% |
+| Neighbor tab↔blank complementarity — gray_fabric | 99.43% of adjacent pairs |
+| — red_carpet / cardboard / wood | 95.9% / 96.3% / 92.2% |
+| Cross-background signature consistency | 80.5% of pieces (190/236) |
+
+**Criterion (≥98% edge-type accuracy on clean contours): met on the friendly backgrounds
+(99.68% / 98.38%).**
+
+Failure taxonomy (visually verified on review sheets in `outputs/review_edges/`):
+
+1. **Wood segmentation leaks** (dominates wood's errors and the consistency shortfall): silhouettes
+   that merged wood-grain shadow or neighboring props passed `is_clean`, corrupting corners and
+   hence edge types. An M1 issue surfacing downstream, exactly as predicted — the
+   `corner_disagreement` flags concentrate on these records, validating the flag as a quality gate.
+2. **Figural borders on toddler puzzles are GT noise, not classifier error**: peppa_kitchen (90.2%)
+   and peppa_aquarium (94.1%) have border edges with real shaped cutouts/protrusions (verified
+   visually — e.g. peppa_kitchen r01c01's bottom border). The classifier honestly reports non-flat
+   geometry; the "border ⇒ flat" assumption is what's wrong. Standard-die-cut puzzles score
+   99.5–100%.
+3. Residual tab↔blank flips across backgrounds trace to occasional corner mis-snaps rotating an
+   arc's chord — revisit only if M4 edge matching turns out sensitive to it.
+
+## Recommendation going into M4 (edge complementarity matching)
+
+- Match on the per-edge 100-point polylines already stored in the piece records; gray_fabric
+  records are the cleanest development set (99.7% edge types, 99.4% complementarity).
+- Exclude records with `corner_disagreement` from the first matching benchmark (135/916), then
+  measure how much including them hurts — that quantifies the quality gate's value for the scan UX.
+- True-neighbor ranking GT comes from grid adjacency, same as the complementarity check.
 
 ## Reproduce
 
@@ -98,6 +135,8 @@ uv run python experiments/exp28_piece_geometry/contact_sheets.py
 uv run python experiments/exp28_piece_geometry/synth_benchmark.py --n 200 --seed 42
 uv run python experiments/exp28_piece_geometry/debug_synth_failures.py      # renders failure cases
 uv run python experiments/exp28_piece_geometry/eval_corners.py              # corner sheets (+ eval if labels exist)
+uv run python experiments/exp28_piece_geometry/edge_split.py                # M3: piece records + edge_summary.csv
+uv run python experiments/exp28_piece_geometry/eval_edges.py                # M3: eval + edge-type sheets
 ```
 
 Dataset: `network/datasets/north_star/v1` (local only, regenerate via `experiments/north_star/ingest.py`).

--- a/network/experiments/exp28_piece_geometry/HANDOFF.md
+++ b/network/experiments/exp28_piece_geometry/HANDOFF.md
@@ -1,6 +1,6 @@
-# exp28 Handoff — M1 (contours) + M2 (corners) + M3 (edge types) + M4 (edge matching) + M6 (re-ID)
+# exp28 Handoff — Phase A+B complete: M1–M4, M6, M7 (M5 deferred)
 
-Date: 2026-07-16 · Status: **M1–M3 criteria met; M4 reported; M6 criterion not met (91.5% vs ≥95%) with the gap isolated to wood-query capture quality** · Plan: [docs/piece-geometry-scanning.html](../../../docs/piece-geometry-scanning.html)
+Date: 2026-07-16 · Status: **M1–M3 criteria met; M4 reported; M6's ≥95% criterion missed by its frozen scorer (91.5%) but retroactively met by M7's simpler z-sum scorer (95.2% on the same leakage-free cells, independently verified); M7 delivered thresholds + zero die-cut collisions** · Plan: [docs/piece-geometry-scanning.html](../../../docs/piece-geometry-scanning.html)
 
 ## M1 — High-fidelity contour extraction
 
@@ -211,13 +211,58 @@ than every number above; the non-wood cells and within-puzzle numbers suggest �
 with the planned gray mat, but north_star cannot prove it (one photo per piece per background) —
 a same-background repeat-capture set would close that evidence gap.
 
-## Recommendation going into M7 (uniqueness / collision study)
+## M7 — Uniqueness / collision study + scan-lock thresholds
 
-- Most of M7's raw material already exists in `outputs/reid_eval.json` (genuine/impostor
-  distributions per metric). Remaining work: per-brand collision analysis, ROC curves, and choosing
-  the scan-UX "locked" threshold from the impostor tail.
-- Do it with RRF(shape, spatial) as the primary metric, and consider re-freezing the fusion choice
-  on a bigger validation split first.
+`collision_study.py`. Works in **distance space** (RRF rank scores depend on gallery composition
+and cannot be thresholded): combined score z = z_shape + z_spatial, each component z-normalized by
+the *enroll gallery's own impostor statistics* — which turn out to be nearly identical across all
+four galleries, so one threshold transfers. Thresholds frozen on cardboard-validation cells;
+errors reported on the 9 leakage-free cells (1,572 queries).
+
+**Verification quality**: EER 2.29%; FNR 8.27% @ FMR 1%; FNR 28.5% @ FMR 0.1%.
+
+**Two-threshold scan-lock recipe (the milestone's deliverable):**
+
+| Setting | Value | Measured on test cells |
+|---|---|---|
+| `t_accept` (auto-lock) | z < −4.78 | 0.19% wrong-lock; 1.08% false-merge of new pieces |
+| `t_new` (auto-declare-new) | z > −0.80 | 0.89% of genuine re-scans wrongly declared new |
+| Gray zone (ask for more frames) | between | ~26–30% of genuine re-scans at these strict settings |
+
+Relaxing `t_accept` to the FMR=1% point (z=−3.98) cuts genuine gray-zone traffic to ~8% at 1%
+wrong-lock risk — a product decision; both operating points are on the shipped ROC
+(`outputs/collision_plots/roc.png`). Note: 97.9% of genuinely-new pieces land in the gray zone
+rather than above `t_new` — the dedupe UX should treat "not accepted" as the effective new-piece
+signal.
+
+**Zero full-piece die-cut collisions.** Across all 1,695 distinct within-puzzle piece pairs
+(gray_fabric), not one pair's shape distance falls below the "same piece re-photographed" bar
+(median genuine cross-background distance). Every puzzle's nearest pair sits 1.1–3.4× above it,
+and the visual sheets show clearly distinguishable outlines (no pipeline artifacts). This resolves
+M4's collision warning cleanly: **single edges collide badly (M4: 1.22× median margin), but
+requiring all four edges simultaneously eliminates full-piece shape collisions** on these 14
+puzzles. Uniqueness within a puzzle is not the bottleneck; wood-photo capture quality remains the
+only weak link.
+
+**The bonus finding that closes M6's gap**: the thresholdable z-sum is also the best retriever —
+**95.2% top-1 on the 9 leakage-free cells** (independently re-verified from
+`outputs/collision_samples.npz`), vs 91.5% for M6's frozen RRF winner. Per query background:
+red_carpet 96.3%, gray_fabric 96.7%, cardboard 96.9%, wood 92.5%. The z-sum has no
+test-selected hyperparameters of its own (its two components were validation-chosen in M6), so
+this is an honest number: **the M6 ≥95% criterion is met by the M7 scorer** — production should
+use this single score for both ranking and thresholding, and the RRF machinery can be retired.
+
+## Recommendation going into Phase C (M8: backend geometry endpoint)
+
+- The production scoring stack is now settled: rembg contour → polydp corners (curvature
+  cross-check flag) → 4 typed edges + canonical polylines → fingerprint = shape polylines +
+  3×3 gray-world a\*b\* spatial histograms → z-sum score with per-gallery impostor normalization,
+  `t_accept`/`t_new` from M7.
+- The piece-record JSON from M3 is the natural API response shape; add the fingerprint fields and
+  the quality flags (is_clean, corner_disagreement, gray-zone verdicts).
+- Remaining open risk for production is capture-time exposure/white-balance on dark surfaces —
+  mitigate with the gray-mat protocol and consider a same-background repeat-capture set to
+  measure true same-session accuracy (expected >95%).
 
 ## Reproduce
 
@@ -234,6 +279,7 @@ uv run python experiments/exp28_piece_geometry/edge_match.py                # M4
 uv run python experiments/exp28_piece_geometry/eval_matching.py             # M4: neighbor-ranking eval + sheets
 uv run python experiments/exp28_piece_geometry/fingerprint.py               # M6: build fingerprints per background
 uv run python experiments/exp28_piece_geometry/eval_reid.py                 # M6: 12-cell re-ID eval + failure sheets
+uv run python experiments/exp28_piece_geometry/collision_study.py           # M7: thresholds, ROC, collision study
 ```
 
 Dataset: `network/datasets/north_star/v1` (local only, regenerate via `experiments/north_star/ingest.py`).

--- a/network/experiments/exp28_piece_geometry/HANDOFF.md
+++ b/network/experiments/exp28_piece_geometry/HANDOFF.md
@@ -1,6 +1,6 @@
-# exp28 Handoff — M1 (contours) + M2 (corners) + M3 (edge types) + M4 (edge matching)
+# exp28 Handoff — M1 (contours) + M2 (corners) + M3 (edge types) + M4 (edge matching) + M6 (re-ID)
 
-Date: 2026-07-16 · Status: **M1–M3 criteria met; M4 numbers reported (its deliverable)** · Plan: [docs/piece-geometry-scanning.html](../../../docs/piece-geometry-scanning.html)
+Date: 2026-07-16 · Status: **M1–M3 criteria met; M4 reported; M6 criterion not met (91.5% vs ≥95%) with the gap isolated to wood-query capture quality** · Plan: [docs/piece-geometry-scanning.html](../../../docs/piece-geometry-scanning.html)
 
 ## M1 — High-fidelity contour extraction
 
@@ -158,16 +158,66 @@ Key findings:
 Review sheets: `outputs/review_matching/*.png` (query vs flipped mate vs best impostor, canonical
 frame). Full numbers: `outputs/matching_eval.json`.
 
-## Recommendation going into M6 (piece fingerprint + re-identification)
+## M6 — Piece fingerprint + re-identification (M5 deferred: optional, nothing depends on it)
 
-- Phases A's outputs are all in place: piece records with corners, edge types, canonical edge
-  polylines, and a proven L2 edge distance. (M5, TabParameters fitting, is optional/parallel and
-  can be skipped or done later — nothing downstream hard-depends on it.)
-- Fingerprint = 4 canonical edge polylines (rotation-normalized ordering) + a LAB color histogram
-  of the piece face; nearest-neighbor over enrolled pieces; north_star's 4 backgrounds per piece
-  are the natural enroll/query split.
-- Given M4's thin geometric margins, expect color to carry much of the identity signal — the M6
-  ablation (shape only vs color only vs combined) is the important table.
+`fingerprint.py` + `eval_reid.py`. Protocol: enroll all 236 physical pieces from one background,
+query with the other three (12 enroll×query cells), nearest-neighbor over the full **cross-puzzle**
+gallery; rotation-invariant shape (min over 4 cyclic edge shifts, edge-type-signature gated); all
+hyperparameters frozen on cardboard-as-query validation cells, headline = the 9 leakage-free cells.
+This is deliberately **harsher than production**: enrollment and query differ in background,
+lighting, and exposure, while the real scan-and-lock UX enrolls and queries on the same mat in the
+same session.
+
+**Headline (9 leakage-free cells, top-1 / top-5):**
+
+| Fingerprint | Top-1 | Top-5 |
+|---|---|---|
+| shape only (4 canonical edge polylines) | 81.5% | 92.2% |
+| global color histogram (LAB) | 19.0% | 35.8% |
+| global color (a\*b\*, gray-world normalized) | 50.7% | 71.5% |
+| **spatial color (3×3 grid of gray-world a\*b\* hists)** | **85.2%** | 93.9% |
+| RRF(shape, global color) | 86.1% | 96.6% |
+| RRF(shape, spatial color) | 94.3% | 98.9% |
+| **frozen winner: RRF(shape, global, spatial)** | **91.5%** | **97.5%** |
+
+**Criterion (≥95% top-1 combined): NOT MET** — 91.5% (progression across three iterations:
+81.5% → 86.1% → 91.5%; genuine/impostor overlap 70.4% → 28.7% → 20.3%).
+
+What M6 taught us (each verified on failure sheets):
+
+1. **Naive color fails; fusion style is everything.** A z-normalized linear blend degenerated to
+   shape-only (the weight sweep chose w=1.0) even though the failures were gross color mismatches.
+   Reciprocal-rank fusion fixed it: rank space is robust where distance space is not.
+2. **Illumination is the enemy of color**: plain a\*b\* histograms scored 22.8% top-1; gray-world
+   normalization more than doubled that (50.7%).
+3. **The spatial color layout (3×3 grid) is the discovery of the milestone**: alone it beats shape
+   (85.2% vs 81.5%), and it dissolved the same-palette sibling confusion that global histograms
+   cannot see. RRF(shape, spatial) reached 94.3% on the headline cells — it lost the frozen-winner
+   selection by ~1 validation query, an honest selection-discipline artifact worth revisiting with
+   a larger validation set.
+4. **The remaining gap is wood-query capture, not the descriptor**: wood queries are underexposed
+   with a strong warm cast (dark artwork reads as umber; wrong matches are consistently tan pieces
+   from other puzzles). Wood accounts for 77 of 156 misses; **excluding wood-as-query, the frozen
+   winner hits 94.8% and RRF(shape, spatial) runs 95.3–97.5% per cell.** Fix is at capture time
+   (exposure/white-balance, mat choice) or an M1 segmentation pass targeted at dark-art-on-wood —
+   not more descriptor engineering.
+5. Fixed-orientation beats rotation-invariant by ~1 point throughout — rotation invariance is
+   cheap but not free; keep both modes.
+6. Within-puzzle gallery (the "which of MY 24 pieces is this" setting): winner 94.5% top-1 /
+   99.3% top-5; RRF(shape, spatial) 96.2% / 99.6%.
+
+**Production outlook**: same-session, same-mat re-ID (the actual app scenario) is strictly easier
+than every number above; the non-wood cells and within-puzzle numbers suggest ≥95% is realistic
+with the planned gray mat, but north_star cannot prove it (one photo per piece per background) —
+a same-background repeat-capture set would close that evidence gap.
+
+## Recommendation going into M7 (uniqueness / collision study)
+
+- Most of M7's raw material already exists in `outputs/reid_eval.json` (genuine/impostor
+  distributions per metric). Remaining work: per-brand collision analysis, ROC curves, and choosing
+  the scan-UX "locked" threshold from the impostor tail.
+- Do it with RRF(shape, spatial) as the primary metric, and consider re-freezing the fusion choice
+  on a bigger validation split first.
 
 ## Reproduce
 
@@ -182,6 +232,8 @@ uv run python experiments/exp28_piece_geometry/edge_split.py                # M3
 uv run python experiments/exp28_piece_geometry/eval_edges.py                # M3: eval + edge-type sheets
 uv run python experiments/exp28_piece_geometry/edge_match.py                # M4: synthetic self-check
 uv run python experiments/exp28_piece_geometry/eval_matching.py             # M4: neighbor-ranking eval + sheets
+uv run python experiments/exp28_piece_geometry/fingerprint.py               # M6: build fingerprints per background
+uv run python experiments/exp28_piece_geometry/eval_reid.py                 # M6: 12-cell re-ID eval + failure sheets
 ```
 
 Dataset: `network/datasets/north_star/v1` (local only, regenerate via `experiments/north_star/ingest.py`).

--- a/network/experiments/exp28_piece_geometry/HANDOFF.md
+++ b/network/experiments/exp28_piece_geometry/HANDOFF.md
@@ -1,6 +1,6 @@
-# exp28 Handoff — M1 (contour extraction) + M2 (corner detection) + M3 (edge classification)
+# exp28 Handoff — M1 (contours) + M2 (corners) + M3 (edge types) + M4 (edge matching)
 
-Date: 2026-07-16 · Status: **all three milestone success criteria met** · Plan: [docs/piece-geometry-scanning.html](../../../docs/piece-geometry-scanning.html)
+Date: 2026-07-16 · Status: **M1–M3 criteria met; M4 numbers reported (its deliverable)** · Plan: [docs/piece-geometry-scanning.html](../../../docs/piece-geometry-scanning.html)
 
 ## M1 — High-fidelity contour extraction
 
@@ -118,13 +118,56 @@ Failure taxonomy (visually verified on review sheets in `outputs/review_edges/`)
 3. Residual tab↔blank flips across backgrounds trace to occasional corner mis-snaps rotating an
    arc's chord — revisit only if M4 edge matching turns out sensitive to it.
 
-## Recommendation going into M4 (edge complementarity matching)
+## M4 — Edge complementarity matching (the column's first payoff number)
 
-- Match on the per-edge 100-point polylines already stored in the piece records; gray_fabric
-  records are the cleanest development set (99.7% edge types, 99.4% complementarity).
-- Exclude records with `corner_disagreement` from the first matching benchmark (135/916), then
-  measure how much including them hurts — that quantifies the quality gate's value for the scan UX.
-- True-neighbor ranking GT comes from grid adjacency, same as the complementarity check.
+`edge_match.py` (canonical chord-normalized edge frames, mate-flip transform verified against a
+`puzzle_shapes` shared-edge pair: distance(edge, flip(mate)) = 0.0000 exactly) +
+`eval_matching.py` (protocol: every interior edge queries ALL type-compatible edges of other
+pieces in the same puzzle × background — no orientation leak; true mate known from grid
+adjacency; 1878 queries, mean pool ≈ 25 candidates).
+
+**Metric bake-off (top-1 / top-3 / top-5, corner_disagreement records excluded):**
+
+| Metric | Top-1 | Top-3 | Top-5 |
+|---|---|---|---|
+| **pointwise L2** (canonical 100-pt polylines) | **67.4%** | **85.2%** | **90.5%** |
+| symmetric chamfer | 61.9% | 82.3% | 88.7% |
+| 6-scalar descriptor | 29.3% | 51.3% | 62.6% |
+| L2 + chord-length penalty | 28.2% | 48.3% | 61.1% |
+
+Per background (L2 top-1): gray_fabric **77.4%**, red_carpet 69.6%, cardboard 61.7%, wood 57.6% —
+matching accuracy tracks upstream segmentation quality, as expected. Median rank of the true mate
+is 1 on every puzzle × gray_fabric; per-puzzle top-1 ranges 54.5–100%.
+
+Key findings:
+
+1. **Index-aligned L2 beats chamfer** — arc-length correspondence carries information; chamfer's
+   nearest-point freedom lets impostors cheat. The 6-scalar descriptor loses too much shape detail.
+2. **The chord-length penalty actively hurts** (67.4% → 28.2%): camera distance varies between
+   photos, so pixel chord length is unreliable — the scale-free decision from the plan is
+   empirically confirmed.
+3. **The corner_disagreement gate is worth ~8 top-1 points** (67.4% excluded vs 59.4% included) —
+   it is a genuinely useful quality signal for the future scan-lock UX.
+4. **Die-cut shape collisions are real on these puzzles** (the jigsawlutioner warning, now
+   quantified on our data): median margin between best impostor and true mate is only **1.22×**,
+   and 74% of genuine distances exceed the impostor 5th percentile. Visual review confirms
+   failures are mostly *near-identical competing tabs*, not matcher errors. Consequence:
+   **geometry ranks candidates well but cannot serve as a sole accept/reject threshold — color
+   must join for identity (M6/M7), exactly as the plan anticipated.**
+
+Review sheets: `outputs/review_matching/*.png` (query vs flipped mate vs best impostor, canonical
+frame). Full numbers: `outputs/matching_eval.json`.
+
+## Recommendation going into M6 (piece fingerprint + re-identification)
+
+- Phases A's outputs are all in place: piece records with corners, edge types, canonical edge
+  polylines, and a proven L2 edge distance. (M5, TabParameters fitting, is optional/parallel and
+  can be skipped or done later — nothing downstream hard-depends on it.)
+- Fingerprint = 4 canonical edge polylines (rotation-normalized ordering) + a LAB color histogram
+  of the piece face; nearest-neighbor over enrolled pieces; north_star's 4 backgrounds per piece
+  are the natural enroll/query split.
+- Given M4's thin geometric margins, expect color to carry much of the identity signal — the M6
+  ablation (shape only vs color only vs combined) is the important table.
 
 ## Reproduce
 
@@ -137,6 +180,8 @@ uv run python experiments/exp28_piece_geometry/debug_synth_failures.py      # re
 uv run python experiments/exp28_piece_geometry/eval_corners.py              # corner sheets (+ eval if labels exist)
 uv run python experiments/exp28_piece_geometry/edge_split.py                # M3: piece records + edge_summary.csv
 uv run python experiments/exp28_piece_geometry/eval_edges.py                # M3: eval + edge-type sheets
+uv run python experiments/exp28_piece_geometry/edge_match.py                # M4: synthetic self-check
+uv run python experiments/exp28_piece_geometry/eval_matching.py             # M4: neighbor-ranking eval + sheets
 ```
 
 Dataset: `network/datasets/north_star/v1` (local only, regenerate via `experiments/north_star/ingest.py`).

--- a/network/experiments/exp28_piece_geometry/README.md
+++ b/network/experiments/exp28_piece_geometry/README.md
@@ -47,6 +47,15 @@ piece photos, 1024x768 JPEGs.
 - `eval_corners.py` (**M2 evaluation + review**) — runs the detectors on
   real photos, renders corner contact sheets, and (given hand labels) scores
   them the same way as `synth_benchmark.py`.
+- `edge_split.py` (**M3**) — splits each clean contour at the polydp corners
+  (curvature as cross-check -> `corner_disagreement` flag) into 4 arcs,
+  maps them to grid directions N/E/S/W, and classifies each as
+  tab/blank/flat by dominant chord deviation (`FLAT_THRESHOLD`); writes
+  per-piece records + `edge_summary.csv` and prints the deviation histogram.
+- `eval_edges.py` (**M3 evaluation + review**) — scores edge types against
+  grid ground truth (flat accuracy vs border edges, cross-background
+  consistency, neighbor tab/blank complementarity), renders color-coded
+  review sheets, and writes `edge_eval.json`.
 
 ## Usage
 
@@ -71,6 +80,10 @@ uv run python experiments/exp28_piece_geometry/label_corners.py --limit 60
 # M2: evaluate detectors on real photos (with review sheets + optional scoring)
 uv run python experiments/exp28_piece_geometry/eval_corners.py \
     --labels-file outputs/corner_labels.json
+
+# M3: split contours into classified N/E/S/W edges, then evaluate
+uv run python experiments/exp28_piece_geometry/edge_split.py
+uv run python experiments/exp28_piece_geometry/eval_edges.py
 ```
 
 ## Success criteria
@@ -80,6 +93,8 @@ uv run python experiments/exp28_piece_geometry/eval_corners.py \
 - **M2**: the best detector places all 4 corners within 3% of piece size
   (the `synth_benchmark.py` / `eval_corners.py` max-corner-error metric) on
   >=90% of the evaluated subset.
+- **M3**: flat-vs-nonflat edge accuracy >=98% (vs grid-position ground
+  truth) on the 2 friendly backgrounds (gray_fabric, red_carpet).
 
 ## Output layout
 
@@ -92,6 +107,10 @@ outputs/
   synth_benchmark.csv                      # per synthetic piece x method scores
   corner_labels.json                       # hand-labeled ground truth (label_corners.py)
   corner_eval.csv                          # per method x background error stats
+  piece_records/{puzzle_id}/{piece_stem}.json  # M3: corners + 4 classified edges per piece
+  edge_summary.csv                         # M3: one row per edge
+  review_edges/{puzzle}_{background}.png   # M3 review sheets (flat=yellow tab=green blank=red)
+  edge_eval.json                           # M3 evaluation numbers
 ```
 
 `outputs/` is gitignored, matching other experiments (e.g. `exp1`,

--- a/network/experiments/exp28_piece_geometry/README.md
+++ b/network/experiments/exp28_piece_geometry/README.md
@@ -1,0 +1,98 @@
+# Experiment 28: Piece Geometry Scanning — Contour Extraction + Corner Bake-off
+
+## Objective
+
+Implements milestones **M1** (high-fidelity contour extraction) and **M2**
+(corner detection bake-off) of the piece-geometry-scanning plan
+(`../../../docs/piece-geometry-scanning.html`): turn an existing real photo
+of a puzzle piece into a clean, closed contour and 4 labeled corners, as the
+first step toward extracting exact piece geometry (contour + tab/blank/flat
+edge classification) from real photos.
+
+- **M1**: upgrade the existing rembg pipeline (`piece_detector.py` /
+  `background_remover.py` in the backend) from a coarse UI polygon to a
+  full-resolution, morphologically-cleaned, closed contour, run over the
+  `north_star v1` dataset (236 pieces x 4 backgrounds).
+- **M2**: bake off three corner-detection strategies (contour curvature,
+  `approxPolyDP` epsilon sweep, Shi-Tomasi corners on the filled mask)
+  against both a synthetic benchmark with known ground truth and hand-labeled
+  real photos.
+
+## Dataset
+
+`network/datasets/north_star/v1/` (local-only, see
+`../north_star/README.md`): 14 puzzles, 236 pieces, each photographed
+upright on 4 backgrounds (red_carpet, gray_fabric, cardboard, wood) = 944
+piece photos, 1024x768 JPEGs.
+
+## Files
+
+- `common.py` — shared utilities: metadata loading, cropping, rembg session
+  management, mask -> contour extraction, quality scoring, arc-length
+  resampling.
+- `extract_contours.py` (**M1**) — per-piece contour extraction via rembg
+  and/or Otsu thresholding; writes per-piece JSON + a run summary CSV +
+  a clean-rate table.
+- `contact_sheets.py` (**M1 review**) — renders per-puzzle x background grid
+  contact sheets with the extracted contour overlaid (green = clean, red =
+  flagged), for human QA.
+- `corner_detect.py` (**M2**) — three pure, rotation-agnostic corner
+  detectors (`detect_corners_curvature`, `detect_corners_polydp`,
+  `detect_corners_shitomasi`) sharing a brute-force best-4-subset scorer.
+- `synth_benchmark.py` (**M2 quantitative**) — generates random pieces via
+  `puzzle_shapes`, rasterizes + rotates + degrades them, and scores all three
+  detectors against known ground-truth corners.
+- `label_corners.py` (**M2 ground truth**) — interactive matplotlib tool to
+  hand-click the 4 true corners of real piece photos.
+- `eval_corners.py` (**M2 evaluation + review**) — runs the detectors on
+  real photos, renders corner contact sheets, and (given hand labels) scores
+  them the same way as `synth_benchmark.py`.
+
+## Usage
+
+All commands run from `network/`:
+
+```bash
+# M1: extract contours (rembg + threshold) for a few pieces
+uv run python experiments/exp28_piece_geometry/extract_contours.py --limit 8
+
+# M1: extract the full dataset, rembg only
+uv run python experiments/exp28_piece_geometry/extract_contours.py --method rembg
+
+# M1 review: build contact sheets for one puzzle
+uv run python experiments/exp28_piece_geometry/contact_sheets.py --puzzle bambi
+
+# M2: synthetic corner-detector benchmark
+uv run python experiments/exp28_piece_geometry/synth_benchmark.py --n 200
+
+# M2: hand-label ground-truth corners on a subset
+uv run python experiments/exp28_piece_geometry/label_corners.py --limit 60
+
+# M2: evaluate detectors on real photos (with review sheets + optional scoring)
+uv run python experiments/exp28_piece_geometry/eval_corners.py \
+    --labels-file outputs/corner_labels.json
+```
+
+## Success criteria
+
+- **M1**: >=95% of pieces yield a single clean closed contour (`is_clean` in
+  `extract_contours.py`'s summary) on at least the 2 friendliest backgrounds.
+- **M2**: the best detector places all 4 corners within 3% of piece size
+  (the `synth_benchmark.py` / `eval_corners.py` max-corner-error metric) on
+  >=90% of the evaluated subset.
+
+## Output layout
+
+```
+outputs/
+  contours/{puzzle_id}/{piece_stem}.json   # per-piece metadata + per-method contour + quality
+  summary.csv                              # one row per piece x method
+  review/{puzzle}_{background}_{method}.png       # M1 contact sheets
+  review_corners/{puzzle}_{background}.png        # M2 contact sheets
+  synth_benchmark.csv                      # per synthetic piece x method scores
+  corner_labels.json                       # hand-labeled ground truth (label_corners.py)
+  corner_eval.csv                          # per method x background error stats
+```
+
+`outputs/` is gitignored, matching other experiments (e.g. `exp1`,
+`exp2`, `exp4`, `exp5`); rerun the scripts above to regenerate it.

--- a/network/experiments/exp28_piece_geometry/README.md
+++ b/network/experiments/exp28_piece_geometry/README.md
@@ -56,6 +56,16 @@ piece photos, 1024x768 JPEGs.
   grid ground truth (flat accuracy vs border edges, cross-background
   consistency, neighbor tab/blank complementarity), renders color-coded
   review sheets, and writes `edge_eval.json`.
+- `edge_match.py` (**M4**) — canonical edge frames (chord-normalized;
+  outward = negative canonical y), the mate `flip_edge` transform, and the
+  match distances (l2, chamfer, scalar6 feature vector, chord-penalty
+  variants). Its CLI runs a synthetic self-check on a `puzzle_shapes`
+  shared edge.
+- `eval_matching.py` (**M4 evaluation + review**) — ranks each interior
+  edge's true mate among all type-compatible edges of the other pieces in
+  the same puzzle x background; reports top-k / median rank per metric,
+  the corner_disagreement gate delta, genuine-vs-impostor stats, renders
+  query/mate/impostor curve sheets, and writes `matching_eval.json`.
 
 ## Usage
 
@@ -84,6 +94,10 @@ uv run python experiments/exp28_piece_geometry/eval_corners.py \
 # M3: split contours into classified N/E/S/W edges, then evaluate
 uv run python experiments/exp28_piece_geometry/edge_split.py
 uv run python experiments/exp28_piece_geometry/eval_edges.py
+
+# M4: edge-match self-check, then mate-ranking evaluation
+uv run python experiments/exp28_piece_geometry/edge_match.py
+uv run python experiments/exp28_piece_geometry/eval_matching.py
 ```
 
 ## Success criteria
@@ -111,6 +125,8 @@ outputs/
   edge_summary.csv                         # M3: one row per edge
   review_edges/{puzzle}_{background}.png   # M3 review sheets (flat=yellow tab=green blank=red)
   edge_eval.json                           # M3 evaluation numbers
+  review_matching/{puzzle}_{background}.png    # M4: query vs mate vs impostor curves
+  matching_eval.json                       # M4 evaluation numbers
 ```
 
 `outputs/` is gitignored, matching other experiments (e.g. `exp1`,

--- a/network/experiments/exp28_piece_geometry/collision_study.py
+++ b/network/experiments/exp28_piece_geometry/collision_study.py
@@ -1,0 +1,682 @@
+#!/usr/bin/env python3
+"""M7: uniqueness/collision study - accept/reject thresholds in DISTANCE space.
+
+M6's retrieval winner (reciprocal rank fusion) is rank-based: its scores
+depend on gallery composition and are not valid absolute similarities for
+thresholding. M7 therefore works in raw distance space, using M6's two
+strong component distances - rotation-invariant canonical-polyline shape L2
+and 3x3 gray-world a*b* spatial color chi-square - combined into one
+thresholdable score:
+
+    z = (d_shape - mu_s) / sd_s + (d_spatial - mu_sp) / sd_sp
+
+where (mu, sd) are the mean/std of IMPOSTOR (distinct-identity) pairwise
+distances WITHIN the enroll gallery. Per-gallery normalization is what
+makes one threshold transferable across galleries: each gallery's z is
+expressed in units of its own impostor spread, so a threshold learned on
+one enroll background applies to another without re-tuning.
+
+Analyses (all 12 M6 enroll x query cells; thresholds are FROZEN on the 3
+cardboard-as-query validation cells and error rates reported on the other
+9, consistent with M6's selection discipline):
+
+1. Genuine/impostor extraction: per query, the genuine z (to its true
+   identity) and the best-impostor z (min over all wrong identities); full
+   sample arrays dumped to `outputs/collision_samples.npz`.
+2. Verification analysis ("is the top-1 match actually this piece?"):
+   threshold sweep reporting FMR (wrong top-1 accepted) and FNR (correct
+   top-1 rejected) as fractions of all queries, EER, FNR at FMR = 1% and
+   0.1%, ROC data + plot.
+3. New-piece detection (enrollment dedupe): removing the query's identity
+   from the gallery makes its best match an impostor by construction, so
+   the best-impostor samples ARE the new-piece score distribution;
+   false-merge rate = fraction below the accept threshold.
+4. Two-threshold recommendation: accept if z < t_accept (validation
+   best-impostor 1st percentile), declare new if z > t_new (validation
+   genuine 99th percentile), gray zone in between; gray-zone occupancy
+   reported for both genuine and new-piece samples.
+5. Per-puzzle die-cut collision study (shape only): within each puzzle x
+   gray_fabric, all distinct-piece pairwise shape distances; a collision is
+   a pair below the median GENUINE cross-background shape distance (two
+   different pieces as alike as the same piece re-photographed). Pair
+   sheets rendered for the 2 tightest puzzles (their nearest pairs,
+   whether or not any pair crosses the collision bar).
+
+Outputs: `outputs/collision_eval.json`, `outputs/collision_samples.npz`,
+plots in `outputs/collision_plots/`.
+
+Usage:
+    cd network
+    uv run python experiments/exp28_piece_geometry/fingerprint.py     # galleries first
+    uv run python experiments/exp28_piece_geometry/collision_study.py
+"""
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import cv2
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402  (backend must be set first)
+import numpy as np  # noqa: E402
+from common import crop_with_margin  # noqa: E402
+from eval_reid import (  # noqa: E402
+    GalleryArrays,
+    build_arrays,
+    compute_cell_base,
+    load_bbox_lookup,
+)
+from fingerprint import (  # noqa: E402
+    BACKGROUNDS,
+    PieceFingerprint,
+    load_gallery,
+    shape_distance_matrix,
+    spatial_color_distance_matrix,
+)
+
+VALIDATION_QUERY_BACKGROUND = "cardboard"
+
+# Background used for the within-puzzle die-cut collision study (the best
+# segmented background, so shape distances reflect die-cut geometry, not
+# segmentation noise).
+COLLISION_BACKGROUND = "gray_fabric"
+
+# Validation quantiles defining the frozen threshold pair: t_accept admits
+# at most this fraction of new-piece (best-impostor) scores, t_new rejects
+# at most this fraction of genuine scores.
+ACCEPT_QUANTILE = 0.01
+NEW_QUANTILE = 0.99
+
+N_THRESHOLD_GRID = 2001
+N_COLLISION_SHEETS = 2
+N_COLLISION_PAIRS_PER_SHEET = 4
+
+
+@dataclass
+class ZStats:
+    """Impostor-distance normalization statistics for one enroll gallery.
+
+    Attributes:
+        shape_mean: Mean pairwise distinct-identity shape distance.
+        shape_std: Std of the same.
+        spatial_mean: Mean pairwise distinct-identity spatial color distance.
+        spatial_std: Std of the same.
+    """
+
+    shape_mean: float
+    shape_std: float
+    spatial_mean: float
+    spatial_std: float
+
+
+@dataclass
+class Samples:
+    """Aligned genuine/best-impostor score samples over all evaluated queries.
+
+    Attributes:
+        enroll_bg: Enroll background per query.
+        query_bg: Query background per query.
+        puzzle: Puzzle id per query.
+        row: Piece grid row per query.
+        col: Piece grid col per query.
+        z_genuine: Combined z to the query's true identity.
+        z_best_impostor: Minimum combined z over all wrong identities.
+        d_shape_genuine: Raw genuine shape distance.
+        d_spatial_genuine: Raw genuine spatial color distance.
+    """
+
+    enroll_bg: np.ndarray
+    query_bg: np.ndarray
+    puzzle: np.ndarray
+    row: np.ndarray
+    col: np.ndarray
+    z_genuine: np.ndarray
+    z_best_impostor: np.ndarray
+    d_shape_genuine: np.ndarray
+    d_spatial_genuine: np.ndarray
+
+
+def gallery_z_stats(arrays: GalleryArrays, fingerprints: List[PieceFingerprint]) -> ZStats:
+    """Impostor mean/std of shape and spatial distances within one enroll gallery.
+
+    Every within-gallery pair is a distinct-identity (impostor) pair, since
+    a gallery holds one entry per physical piece. Spatial distances use the
+    shape distance's winning rotation k per pair, matching query-time
+    scoring.
+
+    Args:
+        arrays: The gallery's stacked arrays.
+        fingerprints: The gallery's fingerprints (for typed edge signatures).
+
+    Returns:
+        The gallery's `ZStats`.
+    """
+    shape_parts: List[np.ndarray] = []
+    spatial_parts: List[np.ndarray] = []
+    n = len(fingerprints)
+    for i, fp in enumerate(fingerprints):
+        rest = np.arange(n) != i
+        d_shape, best_k = shape_distance_matrix(
+            fp.edges_canonical, fp.edge_types, arrays.edges[rest], arrays.types[rest], True
+        )
+        d_spatial = spatial_color_distance_matrix(
+            fp.spatial_hists,
+            fp.spatial_nonempty,
+            arrays.spatial_hists[rest],
+            arrays.spatial_nonempty[rest],
+            best_k,
+        )
+        shape_parts.append(d_shape)
+        spatial_parts.append(d_spatial)
+    shape_all = np.concatenate(shape_parts)
+    spatial_all = np.concatenate(spatial_parts)
+    return ZStats(
+        shape_mean=float(shape_all.mean()),
+        shape_std=float(shape_all.std()),
+        spatial_mean=float(spatial_all.mean()),
+        spatial_std=float(spatial_all.std()),
+    )
+
+
+def collect_samples(
+    galleries: Dict[str, GalleryArrays],
+    gallery_fps: Dict[str, List[PieceFingerprint]],
+    stats_by_bg: Dict[str, ZStats],
+) -> Samples:
+    """Compute genuine and best-impostor combined z for every query in all 12 cells.
+
+    Args:
+        galleries: enroll background -> stacked gallery arrays.
+        gallery_fps: background -> fingerprints (used as both galleries and queries).
+        stats_by_bg: enroll background -> z-normalization stats.
+
+    Returns:
+        The pooled `Samples`.
+    """
+    rows: List[Tuple[str, str, str, int, int, float, float, float, float]] = []
+    for enroll_bg in BACKGROUNDS:
+        stats = stats_by_bg[enroll_bg]
+        for query_bg in BACKGROUNDS:
+            if enroll_bg == query_bg:
+                continue
+            cell = compute_cell_base(galleries[enroll_bg], gallery_fps[query_bg], enroll_bg, query_bg)
+            for base in cell.queries:
+                z = (base.d_shape_ri - stats.shape_mean) / max(stats.shape_std, 1e-9) + (
+                    base.d_spatial - stats.spatial_mean
+                ) / max(stats.spatial_std, 1e-9)
+                z_genuine = float(z[base.true_local])
+                masked = z.copy()
+                masked[base.true_local] = np.inf
+                z_best_imp = float(masked.min())
+                puzzle_id, row, col = base.query.identity
+                rows.append(
+                    (
+                        enroll_bg,
+                        query_bg,
+                        puzzle_id,
+                        row,
+                        col,
+                        z_genuine,
+                        z_best_imp,
+                        float(base.d_shape_ri[base.true_local]),
+                        float(base.d_spatial[base.true_local]),
+                    )
+                )
+
+    return Samples(
+        enroll_bg=np.array([r[0] for r in rows]),
+        query_bg=np.array([r[1] for r in rows]),
+        puzzle=np.array([r[2] for r in rows]),
+        row=np.array([r[3] for r in rows], dtype=np.int64),
+        col=np.array([r[4] for r in rows], dtype=np.int64),
+        z_genuine=np.array([r[5] for r in rows]),
+        z_best_impostor=np.array([r[6] for r in rows]),
+        d_shape_genuine=np.array([r[7] for r in rows]),
+        d_spatial_genuine=np.array([r[8] for r in rows]),
+    )
+
+
+def verification_curves(z_genuine: np.ndarray, z_best_impostor: np.ndarray) -> Dict[str, np.ndarray]:
+    """Operational FMR/FNR threshold sweep for top-1 verification.
+
+    The system returns the z-nearest candidate; its score is
+    min(z_genuine, z_best_impostor) and it is correct iff the genuine score
+    wins. FMR(t) = fraction of ALL queries whose top-1 is wrong AND
+    accepted (score < t); FNR(t) = fraction whose top-1 is correct but
+    rejected (score >= t).
+
+    Args:
+        z_genuine: (Q,) genuine combined z per query.
+        z_best_impostor: (Q,) best-impostor combined z per query.
+
+    Returns:
+        {"thresholds", "fmr", "fnr"} arrays over an even threshold grid.
+    """
+    z_top1 = np.minimum(z_genuine, z_best_impostor)
+    top1_correct = z_genuine <= z_best_impostor
+    lo = float(z_top1.min()) - 0.5
+    hi = float(z_top1.max()) + 0.5
+    thresholds = np.linspace(lo, hi, N_THRESHOLD_GRID)
+    fmr = np.array([np.mean(~top1_correct & (z_top1 < t)) for t in thresholds])
+    fnr = np.array([np.mean(top1_correct & (z_top1 >= t)) for t in thresholds])
+    return {"thresholds": thresholds, "fmr": fmr, "fnr": fnr}
+
+
+def eer_and_operating_points(curves: Dict[str, np.ndarray]) -> Dict[str, float]:
+    """EER and FNR at fixed FMR operating points from a threshold sweep.
+
+    Args:
+        curves: `verification_curves` output.
+
+    Returns:
+        Dict with eer, eer_threshold, and fnr/threshold at FMR = 1% and 0.1%.
+    """
+    thresholds = curves["thresholds"]
+    fmr = curves["fmr"]
+    fnr = curves["fnr"]
+    eer_idx = int(np.argmin(np.abs(fmr - fnr)))
+    out = {
+        "eer": float((fmr[eer_idx] + fnr[eer_idx]) / 2.0),
+        "eer_threshold": float(thresholds[eer_idx]),
+    }
+    for target, label in ((0.01, "1pct"), (0.001, "0p1pct")):
+        ok = np.where(fmr <= target)[0]
+        idx = int(ok[-1]) if len(ok) else 0
+        out[f"fnr_at_fmr_{label}"] = float(fnr[idx])
+        out[f"threshold_at_fmr_{label}"] = float(thresholds[idx])
+    return out
+
+
+def threshold_report(
+    z_genuine: np.ndarray, z_best_impostor: np.ndarray, t_accept: float, t_new: float
+) -> Dict[str, float]:
+    """Error rates of a frozen (t_accept, t_new) pair on one sample set.
+
+    Args:
+        z_genuine: (Q,) genuine z (the re-scan scenario's correct-match scores).
+        z_best_impostor: (Q,) best-impostor z (the new-piece scenario's scores).
+        t_accept: Accept threshold (z below -> lock onto the match).
+        t_new: New-piece threshold (z above -> declare unseen piece).
+
+    Returns:
+        Dict with FMR/FNR at t_accept, false-merge and false-new rates, and
+        gray-zone occupancy for genuine and new-piece samples.
+    """
+    z_top1 = np.minimum(z_genuine, z_best_impostor)
+    top1_correct = z_genuine <= z_best_impostor
+    return {
+        "fmr_at_t_accept": float(np.mean(~top1_correct & (z_top1 < t_accept))),
+        "fnr_at_t_accept": float(np.mean(top1_correct & (z_top1 >= t_accept))),
+        "false_merge_rate": float(np.mean(z_best_impostor < t_accept)),
+        "false_new_rate": float(np.mean(z_genuine > t_new)),
+        "gray_zone_genuine": float(np.mean((z_genuine >= t_accept) & (z_genuine <= t_new))),
+        "gray_zone_new_piece": float(np.mean((z_best_impostor >= t_accept) & (z_best_impostor <= t_new))),
+    }
+
+
+@dataclass
+class CollisionPair:
+    """One distinct-piece pair and its shape distance within a puzzle.
+
+    Attributes:
+        idx_a: First piece's index into the gallery arrays.
+        idx_b: Second piece's index.
+        distance: Rotation-invariant shape distance between the two pieces.
+    """
+
+    idx_a: int
+    idx_b: int
+    distance: float
+
+
+def puzzle_pair_distances(
+    arrays: GalleryArrays, fingerprints: List[PieceFingerprint], puzzle_id: str
+) -> List[CollisionPair]:
+    """All distinct-piece pairwise shape distances within one puzzle, ascending.
+
+    Args:
+        arrays: The collision background's stacked gallery.
+        fingerprints: The same gallery's fingerprints.
+        puzzle_id: Puzzle to analyze.
+
+    Returns:
+        Every distinct pair as a `CollisionPair`, sorted by ascending distance.
+    """
+    idx = [i for i, fp in enumerate(fingerprints) if fp.puzzle_id == puzzle_id]
+    pairs: List[CollisionPair] = []
+    for pos, i in enumerate(idx):
+        others = idx[pos + 1 :]
+        if not others:
+            continue
+        others_arr = np.array(others)
+        d, _ = shape_distance_matrix(
+            fingerprints[i].edges_canonical,
+            fingerprints[i].edge_types,
+            arrays.edges[others_arr],
+            arrays.types[others_arr],
+            True,
+        )
+        pairs.extend(CollisionPair(idx_a=i, idx_b=others[j], distance=float(dist)) for j, dist in enumerate(d))
+    pairs.sort(key=lambda p: p.distance)
+    return pairs
+
+
+def render_collision_sheet(
+    pairs: List[CollisionPair],
+    fingerprints: List[PieceFingerprint],
+    puzzle_id: str,
+    dataset_root: Path,
+    bbox_lookup: Dict[str, Tuple[int, int, int, int]],
+    plots_dir: Path,
+) -> Path:
+    """Render side-by-side crops of a puzzle's nearest distinct-piece pairs.
+
+    Args:
+        pairs: The puzzle's pairs, ascending by distance (nearest first).
+        fingerprints: The collision background's gallery fingerprints.
+        puzzle_id: Puzzle being rendered.
+        dataset_root: The north_star v1 dataset root.
+        bbox_lookup: `load_bbox_lookup` output.
+        plots_dir: The collision plots directory.
+
+    Returns:
+        The written PNG path.
+    """
+    shown = pairs[:N_COLLISION_PAIRS_PER_SHEET]
+    fig, axes = plt.subplots(len(shown), 2, figsize=(7, 3.2 * len(shown)), squeeze=False)
+    fig.suptitle(f"Nearest die-cut shape pairs: {puzzle_id} ({COLLISION_BACKGROUND})")
+    for row, pair in enumerate(shown):
+        for col, piece_idx in enumerate((pair.idx_a, pair.idx_b)):
+            fp = fingerprints[piece_idx]
+            image = cv2.imread(str(dataset_root / fp.piece_file))
+            crop, _ = crop_with_margin(image, bbox_lookup[fp.piece_file])
+            ax = axes[row][col]
+            ax.imshow(cv2.cvtColor(crop, cv2.COLOR_BGR2RGB))
+            ax.set_title(f"r{fp.row}c{fp.col}" + (f"   shape d={pair.distance:.4f}" if col == 0 else ""), fontsize=9)
+            ax.axis("off")
+    out_path = plots_dir / f"collisions_{puzzle_id}.png"
+    fig.savefig(out_path, dpi=100, bbox_inches="tight")
+    plt.close(fig)
+    return out_path
+
+
+def plot_histograms(samples: Samples, plots_dir: Path) -> Path:
+    """Plot genuine vs best-impostor z histograms, one panel per query background.
+
+    Args:
+        samples: The pooled samples.
+        plots_dir: The collision plots directory.
+
+    Returns:
+        The written PNG path.
+    """
+    fig, axes = plt.subplots(2, 2, figsize=(12, 8))
+    for ax, query_bg in zip(axes.flat, BACKGROUNDS):
+        mask = samples.query_bg == query_bg
+        bins = np.linspace(
+            min(samples.z_genuine[mask].min(), samples.z_best_impostor[mask].min()),
+            max(samples.z_genuine[mask].max(), samples.z_best_impostor[mask].max()),
+            60,
+        )
+        ax.hist(samples.z_genuine[mask], bins=bins, alpha=0.6, label="genuine", color="tab:green")
+        ax.hist(samples.z_best_impostor[mask], bins=bins, alpha=0.6, label="best impostor", color="tab:red")
+        ax.set_title(f"query background: {query_bg}")
+        ax.set_xlabel("combined z")
+        ax.legend()
+    fig.tight_layout()
+    out_path = plots_dir / "genuine_impostor_hist.png"
+    fig.savefig(out_path, dpi=100)
+    plt.close(fig)
+    return out_path
+
+
+def plot_roc(curves: Dict[str, np.ndarray], points: Dict[str, float], plots_dir: Path) -> Path:
+    """Plot the FNR-vs-FMR trade-off curve with the EER and operating points marked.
+
+    Args:
+        curves: `verification_curves` output (9 test cells).
+        points: `eer_and_operating_points` output.
+        plots_dir: The collision plots directory.
+
+    Returns:
+        The written PNG path.
+    """
+    fig, ax = plt.subplots(figsize=(7, 6))
+    positive = curves["fmr"] > 0
+    ax.plot(curves["fmr"][positive], curves["fnr"][positive], "b-")
+    ax.scatter([points["eer"]], [points["eer"]], color="k", zorder=3, label=f"EER = {points['eer'] * 100:.2f}%")
+    for target, label in ((0.01, "1pct"), (0.001, "0p1pct")):
+        fnr = points[f"fnr_at_fmr_{label}"]
+        ax.scatter([target], [fnr], zorder=3, label=f"FNR@FMR={target * 100:g}% -> {fnr * 100:.2f}%")
+    ax.set_xscale("log")
+    ax.set_xlabel("FMR (wrong top-1 accepted, fraction of all queries)")
+    ax.set_ylabel("FNR (correct top-1 rejected, fraction of all queries)")
+    ax.set_title("Top-1 verification trade-off, combined z (9 non-validation cells)")
+    ax.legend()
+    ax.grid(True, which="both", alpha=0.3)
+    out_path = plots_dir / "roc.png"
+    fig.savefig(out_path, dpi=100, bbox_inches="tight")
+    plt.close(fig)
+    return out_path
+
+
+def plot_collision_rates(rates: Dict[str, float], plots_dir: Path) -> Path:
+    """Bar chart of per-puzzle die-cut collision rates.
+
+    Args:
+        rates: {puzzle_id: collision rate}.
+        plots_dir: The collision plots directory.
+
+    Returns:
+        The written PNG path.
+    """
+    fig, ax = plt.subplots(figsize=(10, 5))
+    names = sorted(rates, key=lambda p: -rates[p])
+    ax.bar(range(len(names)), [rates[p] * 100 for p in names], color="tab:blue")
+    ax.set_xticks(range(len(names)))
+    ax.set_xticklabels(names, rotation=45, ha="right", fontsize=8)
+    ax.set_ylabel("collision rate (% of distinct pairs)")
+    ax.set_title(f"Die-cut shape collision rate per puzzle ({COLLISION_BACKGROUND})")
+    fig.tight_layout()
+    out_path = plots_dir / "collision_rates.png"
+    fig.savefig(out_path, dpi=100)
+    plt.close(fig)
+    return out_path
+
+
+def main() -> None:  # noqa: C901  (evaluation driver, sequential report sections)
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Uniqueness/collision study in distance space.")
+    parser.add_argument(
+        "--dataset-root", type=Path, default=Path("/Users/claus/Repos/pussel/network/datasets/north_star/v1")
+    )
+    parser.add_argument("--records-dir", type=Path, default=Path(__file__).parent / "outputs" / "piece_records")
+    parser.add_argument("--output-dir", type=Path, default=Path(__file__).parent / "outputs")
+    parser.add_argument("--no-sheets", action="store_true", help="Skip rendering plots and collision sheets")
+    args = parser.parse_args()
+
+    plots_dir = args.output_dir / "collision_plots"
+    plots_dir.mkdir(parents=True, exist_ok=True)
+
+    gallery_fps: Dict[str, List[PieceFingerprint]] = {}
+    for background in BACKGROUNDS:
+        fp_path = args.output_dir / "fingerprints" / f"{background}.json"
+        if not fp_path.exists():
+            raise SystemExit(f"{fp_path} missing - run fingerprint.py first.")
+        gallery_fps[background] = load_gallery(fp_path, args.records_dir)
+        print(f"{background:12s}: {len(gallery_fps[background]):3d} pieces enrolled")
+    galleries = {bg: build_arrays(fps) for bg, fps in gallery_fps.items()}
+
+    print("\nPer-gallery impostor z-normalization stats (shape mean/std, spatial mean/std):")
+    stats_by_bg: Dict[str, ZStats] = {}
+    for bg in BACKGROUNDS:
+        stats = gallery_z_stats(galleries[bg], gallery_fps[bg])
+        stats_by_bg[bg] = stats
+        print(
+            f"  {bg:12s}: shape {stats.shape_mean:.4f}/{stats.shape_std:.4f}   "
+            f"spatial {stats.spatial_mean:.4f}/{stats.spatial_std:.4f}"
+        )
+
+    samples = collect_samples(galleries, gallery_fps, stats_by_bg)
+    npz_path = args.output_dir / "collision_samples.npz"
+    np.savez(
+        npz_path,
+        enroll_bg=samples.enroll_bg,
+        query_bg=samples.query_bg,
+        puzzle=samples.puzzle,
+        row=samples.row,
+        col=samples.col,
+        z_genuine=samples.z_genuine,
+        z_best_impostor=samples.z_best_impostor,
+        d_shape_genuine=samples.d_shape_genuine,
+        d_spatial_genuine=samples.d_spatial_genuine,
+    )
+    print(f"\n{len(samples.z_genuine)} query samples across 12 cells -> {npz_path}")
+
+    top1_z = float(np.mean(samples.z_genuine <= samples.z_best_impostor))
+    print(f"Context: top-1 accuracy of the thresholdable z score itself (all 12 cells): {top1_z * 100:.1f}%")
+
+    is_validation = samples.query_bg == VALIDATION_QUERY_BACKGROUND
+    val_genuine = samples.z_genuine[is_validation]
+    val_impostor = samples.z_best_impostor[is_validation]
+    test_genuine = samples.z_genuine[~is_validation]
+    test_impostor = samples.z_best_impostor[~is_validation]
+
+    # (2) Verification threshold sweep on the 9 test cells.
+    curves = verification_curves(test_genuine, test_impostor)
+    points = eer_and_operating_points(curves)
+    print(
+        f"\nVerification (9 non-validation cells): EER = {points['eer'] * 100:.2f}% (z = {points['eer_threshold']:.3f})"
+    )
+    print(
+        f"  FNR @ FMR=1%:   {points['fnr_at_fmr_1pct'] * 100:.2f}%  (z = {points['threshold_at_fmr_1pct']:.3f})\n"
+        f"  FNR @ FMR=0.1%: {points['fnr_at_fmr_0p1pct'] * 100:.2f}%  (z = {points['threshold_at_fmr_0p1pct']:.3f})"
+    )
+
+    # (3+4) Two-threshold recommendation, frozen on validation.
+    t_accept = float(np.quantile(val_impostor, ACCEPT_QUANTILE))
+    t_new = float(np.quantile(val_genuine, NEW_QUANTILE))
+    print(
+        f"\nFrozen thresholds (validation query={VALIDATION_QUERY_BACKGROUND}): "
+        f"t_accept = {t_accept:.3f} (impostor p{ACCEPT_QUANTILE * 100:g}), "
+        f"t_new = {t_new:.3f} (genuine p{NEW_QUANTILE * 100:g})"
+    )
+    if t_accept >= t_new:
+        print("  NOTE: t_accept >= t_new - the distributions separate cleanly enough that no gray zone is needed.")
+    report = threshold_report(test_genuine, test_impostor, t_accept, t_new)
+    print("Frozen-threshold error rates on the 9 non-validation cells:")
+    print(
+        f"  accept (z < t_accept):  FMR = {report['fmr_at_t_accept'] * 100:.2f}%   "
+        f"FNR = {report['fnr_at_t_accept'] * 100:.2f}%"
+    )
+    print(
+        f"  new-piece scenario:     false-merge = {report['false_merge_rate'] * 100:.2f}%   "
+        f"false-new (genuine > t_new) = {report['false_new_rate'] * 100:.2f}%"
+    )
+    print(
+        f"  gray zone occupancy:    genuine {report['gray_zone_genuine'] * 100:.2f}%   "
+        f"new-piece {report['gray_zone_new_piece'] * 100:.2f}%"
+    )
+
+    # (5) Per-puzzle die-cut collision study (shape only).
+    shape_bar = float(np.median(samples.d_shape_genuine))
+    print(f"\nDie-cut collision bar = median genuine cross-background shape distance = {shape_bar:.4f}")
+    collision_fps = gallery_fps[COLLISION_BACKGROUND]
+    collision_arrays = galleries[COLLISION_BACKGROUND]
+    puzzle_ids = sorted({fp.puzzle_id for fp in collision_fps})
+    collision_table: Dict[str, Dict[str, object]] = {}
+    collision_rates: Dict[str, float] = {}
+    all_pairs: Dict[str, List[CollisionPair]] = {}
+    print(f"\n{'puzzle':<28}{'pairs':>7}{'collisions':>12}{'rate':>8}{'min d':>9}{'/bar':>7}  nearest pair")
+    for puzzle_id in puzzle_ids:
+        pairs = puzzle_pair_distances(collision_arrays, collision_fps, puzzle_id)
+        all_pairs[puzzle_id] = pairs
+        n_total = len(pairs)
+        n_collisions = sum(1 for p in pairs if p.distance < shape_bar)
+        rate = n_collisions / n_total if n_total else 0.0
+        collision_rates[puzzle_id] = rate
+        nearest = pairs[0] if pairs else None
+        nearest_desc = "-"
+        min_d = float("nan")
+        if nearest is not None:
+            fp_a = collision_fps[nearest.idx_a]
+            fp_b = collision_fps[nearest.idx_b]
+            nearest_desc = f"r{fp_a.row}c{fp_a.col} vs r{fp_b.row}c{fp_b.col}"
+            min_d = nearest.distance
+        collision_table[puzzle_id] = {
+            "n_pairs": n_total,
+            "n_collisions": n_collisions,
+            "collision_rate": rate,
+            "min_pair_distance": min_d,
+            "min_over_bar": min_d / shape_bar if shape_bar > 0 else float("nan"),
+            "nearest_pair": nearest_desc,
+        }
+        print(
+            f"{puzzle_id:<28}{n_total:>7}{n_collisions:>12}{rate * 100:>7.1f}%"
+            f"{min_d:>9.4f}{min_d / shape_bar:>6.1f}x  {nearest_desc}"
+        )
+
+    overall_pairs = sum(int(t["n_pairs"]) for t in collision_table.values())  # type: ignore[call-overload]
+    overall_collisions = sum(int(t["n_collisions"]) for t in collision_table.values())  # type: ignore[call-overload]
+    print(
+        f"{'OVERALL':<28}{overall_pairs:>7}{overall_collisions:>12}"
+        f"{overall_collisions / max(overall_pairs, 1) * 100:>7.1f}%"
+    )
+
+    sheet_paths: List[str] = []
+    if not args.no_sheets:
+        plot_histograms(samples, plots_dir)
+        plot_roc(curves, points, plots_dir)
+        plot_collision_rates(collision_rates, plots_dir)
+        bbox_lookup = load_bbox_lookup(args.dataset_root)
+        # Sheets for the 2 tightest puzzles (smallest nearest-pair distance);
+        # with zero collisions these show the closest NEAR-collisions, which
+        # is what needs visual verification.
+        tightest = sorted(
+            (p for p in puzzle_ids if all_pairs[p]),
+            key=lambda p: all_pairs[p][0].distance,
+        )[:N_COLLISION_SHEETS]
+        for puzzle_id in tightest:
+            path = render_collision_sheet(
+                all_pairs[puzzle_id], collision_fps, puzzle_id, args.dataset_root, bbox_lookup, plots_dir
+            )
+            sheet_paths.append(str(path))
+            print(f"Wrote {path}")
+        print(f"Plots in {plots_dir}")
+
+    eval_path = args.output_dir / "collision_eval.json"
+    with open(eval_path, "w", encoding="utf-8") as handle:
+        json.dump(
+            {
+                "n_samples": len(samples.z_genuine),
+                "z_stats_per_gallery": {
+                    bg: {
+                        "shape_mean": s.shape_mean,
+                        "shape_std": s.shape_std,
+                        "spatial_mean": s.spatial_mean,
+                        "spatial_std": s.spatial_std,
+                    }
+                    for bg, s in stats_by_bg.items()
+                },
+                "top1_accuracy_z_score_all_cells": top1_z,
+                "verification_9_cells": points,
+                "frozen_thresholds": {"t_accept": t_accept, "t_new": t_new},
+                "threshold_report_9_cells": report,
+                "collision_bar_median_genuine_shape": shape_bar,
+                "collision_background": COLLISION_BACKGROUND,
+                "per_puzzle_collisions": collision_table,
+                "overall_collision_rate": overall_collisions / max(overall_pairs, 1),
+                "collision_sheets": sheet_paths,
+            },
+            handle,
+            indent=2,
+        )
+    print(f"\nWrote {eval_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/network/experiments/exp28_piece_geometry/common.py
+++ b/network/experiments/exp28_piece_geometry/common.py
@@ -295,6 +295,87 @@ def resample_contour(contour: np.ndarray, n: int) -> np.ndarray:
     return np.column_stack([resampled_x, resampled_y])
 
 
+def resample_polyline(points: np.ndarray, n: int) -> np.ndarray:
+    """Resample an OPEN polyline to `n` arc-length-equidistant points.
+
+    Unlike `resample_contour`, the polyline is not closed: the first and last
+    output points coincide with the input endpoints.
+
+    Args:
+        points: Mx2 array of polyline points.
+        n: Number of output points (>= 2).
+
+    Returns:
+        Nx2 resampled polyline.
+    """
+    diffs = np.diff(points, axis=0)
+    segment_lengths = np.sqrt((diffs**2).sum(axis=1))
+    cumulative_length = np.concatenate([[0.0], np.cumsum(segment_lengths)])
+    total_length = cumulative_length[-1]
+
+    if total_length == 0:
+        return np.repeat(points[:1], n, axis=0)
+
+    target_lengths = np.linspace(0, total_length, n)
+    resampled_x = np.interp(target_lengths, cumulative_length, points[:, 0])
+    resampled_y = np.interp(target_lengths, cumulative_length, points[:, 1])
+    return np.column_stack([resampled_x, resampled_y])
+
+
+# --- Contact-sheet plumbing (shared by the review scripts) -----------------
+
+SHEET_TITLE_HEIGHT = 18
+
+
+def make_titled_cell(image: np.ndarray, label: str, cell_width: int) -> np.ndarray:
+    """Resize an image to a fixed cell width and stack a title strip on top.
+
+    Args:
+        image: BGR image for the cell body.
+        label: Title text (e.g. "r00c03").
+        cell_width: Output cell width in pixels.
+
+    Returns:
+        BGR cell image of width `cell_width` including the title strip.
+    """
+    scale = cell_width / image.shape[1]
+    resized = cv2.resize(image, (cell_width, max(1, round(image.shape[0] * scale))))
+
+    title = np.full((SHEET_TITLE_HEIGHT, cell_width, 3), 255, dtype=np.uint8)
+    cv2.putText(title, label, (2, SHEET_TITLE_HEIGHT - 5), cv2.FONT_HERSHEY_SIMPLEX, 0.4, (0, 0, 0), 1, cv2.LINE_AA)
+    return np.vstack([title, resized])
+
+
+def assemble_grid_sheet(cells: dict, rows: int, cols: int, cell_width: int) -> np.ndarray:
+    """Assemble per-position cells into one contact-sheet image.
+
+    Missing positions get a gray placeholder; cells in a row are bottom-padded
+    to a common height so rows stack cleanly.
+
+    Args:
+        cells: Dict mapping (row, col) to a BGR cell image of width `cell_width`.
+        rows: Grid row count.
+        cols: Grid column count.
+        cell_width: Cell width in pixels (all cells must match).
+
+    Returns:
+        The assembled BGR contact sheet.
+    """
+    placeholder = np.full((SHEET_TITLE_HEIGHT + cell_width, cell_width, 3), 128, dtype=np.uint8)
+    sheet_rows: List[np.ndarray] = []
+    for row in range(rows):
+        row_cells = [cells.get((row, col), placeholder) for col in range(cols)]
+        row_h = max(cell.shape[0] for cell in row_cells)
+        padded = []
+        for cell in row_cells:
+            if cell.shape[0] < row_h:
+                pad = np.full((row_h - cell.shape[0], cell_width, 3), 255, dtype=np.uint8)
+                cell = np.vstack([cell, pad])
+            padded.append(cell)
+        sheet_rows.append(np.hstack(padded))
+    return np.vstack(sheet_rows)
+
+
 @dataclass(frozen=True)
 class QualityMetrics:
     """Quality signals for a contour extracted from a piece photo.

--- a/network/experiments/exp28_piece_geometry/common.py
+++ b/network/experiments/exp28_piece_geometry/common.py
@@ -1,0 +1,379 @@
+"""Shared utilities for exp28: piece geometry extraction and corner detection.
+
+Reuses the general segmentation approach from
+``backend/app/services/piece_detector.py`` (harden alpha, largest connected
+component, morphological cleanup) but is implemented locally so this
+experiment stays self-contained apart from the ``puzzle_shapes`` workspace
+package.
+"""
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import cv2
+import numpy as np
+from PIL import Image
+from rembg import new_session, remove  # type: ignore[import-untyped]
+from scipy.ndimage import gaussian_filter1d
+
+# rembg model used for segmentation, matching backend/app/services/background_remover.py.
+REMBG_MODEL = "u2net"
+
+# Alpha value above which a rembg pixel counts as opaque (matches piece_detector.py).
+ALPHA_THRESHOLD = 128
+
+# Morphological open+close kernel used to clean up masks before contour extraction.
+MORPH_KERNEL = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (5, 5))
+
+# A connected component must be at least this fraction of the largest component's
+# area to count as a distinct "large" component for quality scoring.
+LARGE_COMPONENT_AREA_FRAC = 0.02
+
+# A contour point within this many pixels of the crop edge counts as border-touching.
+BORDER_TOUCH_MARGIN_PX = 2.0
+
+
+@dataclass(frozen=True)
+class PieceRecord:
+    """One row of `north_star/v1/metadata.csv`: a single piece photo.
+
+    Attributes:
+        puzzle_id: Puzzle identifier, e.g. "puzzle01_frozen_scene".
+        piece_file: Path to the piece photo, relative to the dataset root.
+        rows: Number of rows in the puzzle's grid.
+        cols: Number of columns in the puzzle's grid.
+        row: Piece's row index (0-indexed).
+        col: Piece's column index (0-indexed).
+        rotation: Applied clockwise rotation label (0/90/180/270).
+        background: Background surface name (red_carpet, gray_fabric, cardboard, wood).
+        source_image: Original capture filename (HEIC).
+        captured_at: Capture timestamp string.
+        device: Capture device string.
+        image_w: Full photo width in pixels.
+        image_h: Full photo height in pixels.
+        bbox: Piece bounding box (x1, y1, x2, y2), inclusive pixel coordinates
+            in the upright photo.
+        applied_k: Number of 90-degree rotations applied to make the shot upright.
+        orientation_source: Provenance of the upright rotation (e.g. "arrow+match").
+        flagged: Whether the ingest pipeline flagged this piece for review.
+        bbox_suspect: Whether the bounding box detection was flagged as suspect.
+    """
+
+    puzzle_id: str
+    piece_file: str
+    rows: int
+    cols: int
+    row: int
+    col: int
+    rotation: int
+    background: str
+    source_image: str
+    captured_at: str
+    device: str
+    image_w: int
+    image_h: int
+    bbox: Tuple[int, int, int, int]
+    applied_k: int
+    orientation_source: str
+    flagged: bool
+    bbox_suspect: bool
+
+    @property
+    def piece_stem(self) -> str:
+        """Filename stem for outputs derived from this piece photo, e.g. "piece_r00_c00_red_carpet"."""
+        return Path(self.piece_file).stem
+
+
+def load_metadata(dataset_root: Path) -> List[PieceRecord]:
+    """Load `metadata.csv` from a north_star dataset root.
+
+    Args:
+        dataset_root: Directory containing `metadata.csv` and per-puzzle folders.
+
+    Returns:
+        One `PieceRecord` per row, in file order.
+    """
+    csv_path = dataset_root / "metadata.csv"
+    records: List[PieceRecord] = []
+    with open(csv_path, newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            records.append(
+                PieceRecord(
+                    puzzle_id=row["puzzle_id"],
+                    piece_file=row["piece_file"],
+                    rows=int(row["rows"]),
+                    cols=int(row["cols"]),
+                    row=int(row["row"]),
+                    col=int(row["col"]),
+                    rotation=int(row["rotation"]),
+                    background=row["background"],
+                    source_image=row["source_image"],
+                    captured_at=row["captured_at"],
+                    device=row["device"],
+                    image_w=int(row["image_w"]),
+                    image_h=int(row["image_h"]),
+                    bbox=(
+                        int(row["piece_x1"]),
+                        int(row["piece_y1"]),
+                        int(row["piece_x2"]),
+                        int(row["piece_y2"]),
+                    ),
+                    applied_k=int(row["applied_k"]),
+                    orientation_source=row["orientation_source"],
+                    flagged=row["flagged"] == "1",
+                    bbox_suspect=row["bbox_suspect"] == "1",
+                )
+            )
+    return records
+
+
+def crop_with_margin(
+    image: np.ndarray, bbox: Tuple[int, int, int, int], margin_frac: float = 0.15
+) -> Tuple[np.ndarray, Tuple[int, int]]:
+    """Crop an image to a bounding box expanded by a margin, clamped to image bounds.
+
+    Args:
+        image: Source image as a numpy array (H, W, C) or (H, W).
+        bbox: Bounding box (x1, y1, x2, y2), inclusive pixel coordinates.
+        margin_frac: Extra margin added on each side, as a fraction of the
+            bbox width/height.
+
+    Returns:
+        Tuple of (crop, (offset_x, offset_y)) where offset is the crop's
+        top-left corner in the original image's pixel coordinates.
+    """
+    height, width = image.shape[:2]
+    x1, y1, x2, y2 = bbox
+    box_w = max(1, x2 - x1)
+    box_h = max(1, y2 - y1)
+    pad_x = round(box_w * margin_frac)
+    pad_y = round(box_h * margin_frac)
+
+    left = max(0, x1 - pad_x)
+    top = max(0, y1 - pad_y)
+    right = min(width, x2 + pad_x + 1)
+    bottom = min(height, y2 + pad_y + 1)
+
+    crop = image[top:bottom, left:right]
+    return crop, (left, top)
+
+
+_rembg_session = None
+
+
+def get_rembg_session():  # type: ignore[no-untyped-def]
+    """Get or create the shared rembg session (created once, reused across calls).
+
+    Returns:
+        The rembg session object for `REMBG_MODEL`.
+    """
+    global _rembg_session
+    if _rembg_session is None:
+        _rembg_session = new_session(REMBG_MODEL)
+    return _rembg_session
+
+
+def remove_background_rgba(bgr_image: np.ndarray) -> np.ndarray:
+    """Run rembg segmentation on a BGR image crop.
+
+    Args:
+        bgr_image: Image crop in OpenCV BGR channel order.
+
+    Returns:
+        RGBA numpy array (H, W, 4) with the segmentation alpha matte.
+    """
+    rgb = cv2.cvtColor(bgr_image, cv2.COLOR_BGR2RGB)
+    pil_image = Image.fromarray(rgb)
+    session = get_rembg_session()
+    output = remove(pil_image, session=session)
+    return np.asarray(output.convert("RGBA"))
+
+
+def alpha_to_mask(rgba: np.ndarray, alpha_threshold: int = ALPHA_THRESHOLD) -> np.ndarray:
+    """Harden a soft rembg alpha matte into a binary mask.
+
+    Mirrors `harden_alpha` in `backend/app/services/piece_detector.py`: pixels
+    at or below the threshold become background, pixels above it become
+    foreground.
+
+    Args:
+        rgba: RGBA image array (H, W, 4).
+        alpha_threshold: Alpha value above which a pixel counts as opaque.
+
+    Returns:
+        Binary mask (H, W) with values in {0, 255}.
+    """
+    alpha = rgba[..., 3]
+    return np.where(alpha > alpha_threshold, np.uint8(255), np.uint8(0))
+
+
+def otsu_masks(gray: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Threshold a grayscale image with Otsu's method at both polarities.
+
+    Args:
+        gray: Single-channel grayscale image (H, W).
+
+    Returns:
+        Tuple of (normal_mask, inverted_mask), each a binary mask in {0, 255}.
+    """
+    _, normal = cv2.threshold(gray, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+    _, inverted = cv2.threshold(gray, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+    return normal, inverted
+
+
+def mask_to_contour(mask: np.ndarray) -> Optional[np.ndarray]:
+    """Clean up a binary mask and extract its largest external contour.
+
+    Applies a morphological open then close (5px ellipse) to remove speckle
+    noise and close small gaps, then returns the largest external contour at
+    full point density.
+
+    Args:
+        mask: Binary mask (H, W) with values in {0, 255}.
+
+    Returns:
+        Nx2 float array of contour points in the mask's own pixel coordinates
+        (row/col frame of `mask`), or None when no contour is found.
+    """
+    cleaned = cv2.morphologyEx(mask, cv2.MORPH_OPEN, MORPH_KERNEL)
+    cleaned = cv2.morphologyEx(cleaned, cv2.MORPH_CLOSE, MORPH_KERNEL)
+    contours, _ = cv2.findContours(cleaned, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)
+    if not contours:
+        return None
+    largest = max(contours, key=cv2.contourArea)
+    if cv2.contourArea(largest) <= 0:
+        return None
+    return largest.reshape(-1, 2).astype(np.float64)
+
+
+def smooth_contour(contour: np.ndarray, sigma: float = 2.0) -> np.ndarray:
+    """Smooth a closed contour with circular Gaussian filtering.
+
+    Args:
+        contour: Nx2 array of contour points, implicitly closed (first point
+            follows the last).
+        sigma: Gaussian standard deviation in samples.
+
+    Returns:
+        Nx2 smoothed contour, same length as the input.
+    """
+    x = gaussian_filter1d(contour[:, 0], sigma=sigma, mode="wrap")
+    y = gaussian_filter1d(contour[:, 1], sigma=sigma, mode="wrap")
+    return np.column_stack([x, y])
+
+
+def resample_contour(contour: np.ndarray, n: int) -> np.ndarray:
+    """Resample a closed contour to `n` arc-length-equidistant points.
+
+    Adapted from `network/docs/puzzle_shape_generation/scripts/shape_comparator.py`,
+    but treats the contour as a closed loop (wraps back to the first point)
+    rather than an open polyline.
+
+    Args:
+        contour: Nx2 array of contour points, implicitly closed.
+        n: Number of output points.
+
+    Returns:
+        Nx2 resampled contour.
+    """
+    closed = np.vstack([contour, contour[:1]])
+    diffs = np.diff(closed, axis=0)
+    segment_lengths = np.sqrt((diffs**2).sum(axis=1))
+    cumulative_length = np.concatenate([[0.0], np.cumsum(segment_lengths)])
+    total_length = cumulative_length[-1]
+
+    if total_length == 0:
+        idx = np.linspace(0, len(contour) - 1, n).astype(int)
+        return contour[idx]
+
+    target_lengths = np.linspace(0, total_length, n, endpoint=False)
+    resampled_x = np.interp(target_lengths, cumulative_length, closed[:, 0])
+    resampled_y = np.interp(target_lengths, cumulative_length, closed[:, 1])
+    return np.column_stack([resampled_x, resampled_y])
+
+
+@dataclass(frozen=True)
+class QualityMetrics:
+    """Quality signals for a contour extracted from a piece photo.
+
+    Attributes:
+        n_large_components: Number of connected components in the source mask
+            with area at least `LARGE_COMPONENT_AREA_FRAC` of the largest one.
+        border_touching: Whether any contour point lies within
+            `BORDER_TOUCH_MARGIN_PX` of the crop edge (segmentation likely
+            clipped the piece).
+        area_ratio: Contour area divided by the crop's pixel area.
+        solidity: Contour area divided by its convex hull area (low solidity
+            indicates a ragged or multi-lobed contour).
+        is_clean: Overall pass/fail: exactly one large component, not
+            border-touching, plausible area ratio, and plausible solidity.
+    """
+
+    n_large_components: int
+    border_touching: bool
+    area_ratio: float
+    solidity: float
+    is_clean: bool
+
+    def to_dict(self) -> dict:
+        """Serialize to a JSON-friendly dict."""
+        return {
+            "n_large_components": self.n_large_components,
+            "border_touching": self.border_touching,
+            "area_ratio": self.area_ratio,
+            "solidity": self.solidity,
+            "is_clean": self.is_clean,
+        }
+
+
+def contour_quality(contour: np.ndarray, mask: np.ndarray, crop_shape: Tuple[int, int]) -> QualityMetrics:
+    """Score how trustworthy an extracted contour is.
+
+    Args:
+        contour: Nx2 contour points in the mask's own pixel coordinates.
+        mask: The (uncleaned) binary mask the contour was derived from,
+            used to count connected components.
+        crop_shape: (height, width) of the crop the mask was computed on.
+
+    Returns:
+        The computed `QualityMetrics`.
+    """
+    height, width = crop_shape
+    crop_area = float(height * width)
+
+    n_components, labels, stats, _ = cv2.connectedComponentsWithStats(mask, connectivity=8)
+    component_areas = stats[1:n_components, cv2.CC_STAT_AREA] if n_components > 1 else np.array([])
+    if len(component_areas) == 0:
+        n_large_components = 0
+    else:
+        largest_area = float(component_areas.max())
+        n_large_components = int(np.sum(component_areas >= LARGE_COMPONENT_AREA_FRAC * largest_area))
+
+    border_touching = bool(
+        np.any(contour[:, 0] <= BORDER_TOUCH_MARGIN_PX)
+        or np.any(contour[:, 1] <= BORDER_TOUCH_MARGIN_PX)
+        or np.any(contour[:, 0] >= width - 1 - BORDER_TOUCH_MARGIN_PX)
+        or np.any(contour[:, 1] >= height - 1 - BORDER_TOUCH_MARGIN_PX)
+    )
+
+    contour_area = float(cv2.contourArea(contour.astype(np.float32)))
+    area_ratio = contour_area / crop_area if crop_area > 0 else 0.0
+
+    hull = cv2.convexHull(contour.astype(np.float32))
+    hull_area = float(cv2.contourArea(hull))
+    solidity = contour_area / hull_area if hull_area > 0 else 0.0
+
+    is_clean = (
+        n_large_components == 1 and not border_touching and 0.05 <= area_ratio <= 0.9 and 0.6 <= solidity <= 0.995
+    )
+
+    return QualityMetrics(
+        n_large_components=n_large_components,
+        border_touching=border_touching,
+        area_ratio=area_ratio,
+        solidity=solidity,
+        is_clean=is_clean,
+    )

--- a/network/experiments/exp28_piece_geometry/contact_sheets.py
+++ b/network/experiments/exp28_piece_geometry/contact_sheets.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""M1 review: render contact sheets of extracted contours for human QA.
+
+For each puzzle x background combination, lays the piece crops out in a
+rows x cols grid (matching the puzzle's own grid), draws the extracted
+contour on each cell (green if `is_clean`, red otherwise), and titles each
+cell "r{row}c{col}". Saves one PNG per puzzle x background to
+`outputs/review/{puzzle_id}_{background}_{method}.png`.
+
+Usage:
+    cd network
+    uv run python experiments/exp28_piece_geometry/contact_sheets.py
+    uv run python experiments/exp28_piece_geometry/contact_sheets.py --puzzle bambi --method threshold
+"""
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import cv2
+import numpy as np
+from common import PieceRecord, crop_with_margin, load_metadata
+
+DEFAULT_DATASET_ROOT = Path("/Users/claus/Repos/pussel/network/datasets/north_star/v1")
+DEFAULT_MARGIN_FRAC = 0.15
+CELL_WIDTH = 220
+TITLE_HEIGHT = 18
+CLEAN_COLOR = (0, 200, 0)  # BGR green
+DIRTY_COLOR = (0, 0, 220)  # BGR red
+MISSING_COLOR = (0, 165, 255)  # BGR orange
+
+
+def _load_contour_json(contours_dir: Path, record: PieceRecord) -> Optional[Dict[str, Any]]:
+    """Load the saved contour JSON for one piece, if present.
+
+    Args:
+        contours_dir: The `outputs/contours` directory.
+        record: The piece's metadata row.
+
+    Returns:
+        The parsed JSON dict, or None if no file exists for this piece.
+    """
+    path = contours_dir / record.puzzle_id / f"{record.piece_stem}.json"
+    if not path.exists():
+        return None
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _render_cell(
+    dataset_root: Path, record: PieceRecord, margin_frac: float, method_data: Optional[Dict[str, Any]]
+) -> np.ndarray:
+    """Render one contact-sheet cell: the piece crop with its contour overlaid.
+
+    Args:
+        dataset_root: The north_star dataset root.
+        record: The piece's metadata row.
+        margin_frac: Crop margin fraction, matching what `extract_contours.py`
+            used so the contour overlay lines up with the crop.
+        method_data: The `methods[method]` block from the piece's contour
+            JSON, or None if no contour data is available for this method.
+
+    Returns:
+        A fixed-size BGR image cell, including a title strip.
+    """
+    image_path = dataset_root / record.piece_file
+    image = cv2.imread(str(image_path))
+    crop, offset = crop_with_margin(image, record.bbox, margin_frac=margin_frac)
+    offset_x, offset_y = offset
+
+    scale = CELL_WIDTH / crop.shape[1]
+    resized = cv2.resize(crop, (CELL_WIDTH, max(1, round(crop.shape[0] * scale))))
+
+    contour = None
+    is_clean = False
+    if method_data is not None and method_data.get("contour"):
+        contour = np.array(method_data["contour"], dtype=np.float64)
+        contour = contour - np.array([offset_x, offset_y])
+        contour = contour * scale
+        is_clean = bool(method_data["quality"]["is_clean"])
+
+    if contour is not None:
+        color = CLEAN_COLOR if is_clean else DIRTY_COLOR
+        cv2.polylines(resized, [contour.astype(np.int32)], isClosed=True, color=color, thickness=2)
+    else:
+        cv2.rectangle(resized, (0, 0), (resized.shape[1] - 1, resized.shape[0] - 1), MISSING_COLOR, 2)
+
+    title = np.full((TITLE_HEIGHT, CELL_WIDTH, 3), 255, dtype=np.uint8)
+    label = f"r{record.row:02d}c{record.col:02d}"
+    cv2.putText(title, label, (2, TITLE_HEIGHT - 5), cv2.FONT_HERSHEY_SIMPLEX, 0.4, (0, 0, 0), 1, cv2.LINE_AA)
+
+    cell = np.full((TITLE_HEIGHT + resized.shape[0], CELL_WIDTH, 3), 255, dtype=np.uint8)
+    cell[:TITLE_HEIGHT] = title
+    cell[TITLE_HEIGHT : TITLE_HEIGHT + resized.shape[0]] = resized
+    return cell
+
+
+def build_contact_sheet(dataset_root: Path, contours_dir: Path, records: List[PieceRecord], method: str) -> np.ndarray:
+    """Build one puzzle x background contact sheet image.
+
+    Args:
+        dataset_root: The north_star dataset root.
+        contours_dir: The `outputs/contours` directory.
+        records: All piece records for this puzzle x background (one per grid cell).
+        method: Which method's contour to draw ("rembg" or "threshold").
+
+    Returns:
+        The assembled BGR contact sheet image.
+    """
+    rows = records[0].rows
+    cols = records[0].cols
+    by_pos: Dict[Tuple[int, int], PieceRecord] = {(r.row, r.col): r for r in records}
+
+    cells: List[List[np.ndarray]] = []
+    cell_h = 0
+    for row in range(rows):
+        row_cells = []
+        for col in range(cols):
+            record = by_pos.get((row, col))
+            if record is None:
+                row_cells.append(np.full((TITLE_HEIGHT + CELL_WIDTH, CELL_WIDTH, 3), 128, dtype=np.uint8))
+                continue
+            data = _load_contour_json(contours_dir, record)
+            method_data = data["methods"].get(method) if data else None
+            margin_frac = data["piece"]["margin_frac"] if data else DEFAULT_MARGIN_FRAC
+            cell = _render_cell(dataset_root, record, margin_frac, method_data)
+            cell_h = max(cell_h, cell.shape[0])
+            row_cells.append(cell)
+        cells.append(row_cells)
+
+    # Pad every cell to a common height so rows stack cleanly.
+    sheet_rows = []
+    for row_cells in cells:
+        padded = []
+        for cell in row_cells:
+            if cell.shape[0] < cell_h:
+                pad = np.full((cell_h - cell.shape[0], CELL_WIDTH, 3), 255, dtype=np.uint8)
+                cell = np.vstack([cell, pad])
+            padded.append(cell)
+        sheet_rows.append(np.hstack(padded))
+
+    return np.vstack(sheet_rows)
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Render contact sheets of extracted contours for review.")
+    parser.add_argument("--contours-dir", type=Path, default=Path(__file__).parent / "outputs" / "contours")
+    parser.add_argument("--dataset-root", type=Path, default=DEFAULT_DATASET_ROOT)
+    parser.add_argument("--output-dir", type=Path, default=Path(__file__).parent / "outputs")
+    parser.add_argument("--method", choices=["rembg", "threshold"], default="rembg")
+    parser.add_argument("--puzzle", type=str, default=None, help="Substring filter on puzzle_id")
+    args = parser.parse_args()
+
+    records = load_metadata(args.dataset_root)
+    if args.puzzle:
+        records = [r for r in records if args.puzzle in r.puzzle_id]
+
+    groups: Dict[Tuple[str, str], List[PieceRecord]] = defaultdict(list)
+    for record in records:
+        groups[(record.puzzle_id, record.background)].append(record)
+
+    review_dir = args.output_dir / "review"
+    review_dir.mkdir(parents=True, exist_ok=True)
+
+    for (puzzle_id, background), group_records in sorted(groups.items()):
+        sheet = build_contact_sheet(args.dataset_root, args.contours_dir, group_records, args.method)
+        out_path = review_dir / f"{puzzle_id}_{background}_{args.method}.png"
+        cv2.imwrite(str(out_path), sheet)
+        print(f"Wrote {out_path} ({sheet.shape[1]}x{sheet.shape[0]}, {len(group_records)} pieces)")
+
+
+if __name__ == "__main__":
+    main()

--- a/network/experiments/exp28_piece_geometry/contact_sheets.py
+++ b/network/experiments/exp28_piece_geometry/contact_sheets.py
@@ -23,7 +23,9 @@ import cv2
 import numpy as np
 from common import PieceRecord, crop_with_margin, load_metadata
 
-DEFAULT_DATASET_ROOT = Path("/Users/claus/Repos/pussel/network/datasets/north_star/v1")
+# Repo-relative default (this script lives in network/experiments/exp28_piece_geometry/,
+# so parents[2] is the network/ dir); override with --dataset-root.
+DEFAULT_DATASET_ROOT = Path(__file__).resolve().parents[2] / "datasets" / "north_star" / "v1"
 DEFAULT_MARGIN_FRAC = 0.15
 CELL_WIDTH = 220
 TITLE_HEIGHT = 18

--- a/network/experiments/exp28_piece_geometry/corner_detect.py
+++ b/network/experiments/exp28_piece_geometry/corner_detect.py
@@ -1,0 +1,593 @@
+"""M2: corner detection bake-off — three pure, rotation-agnostic detectors.
+
+Each detector takes a full-density contour (Nx2, original image coordinates)
+and returns a `CornerResult`: 4 corner points ordered clockwise starting near
+the top-left, one confidence per corner, and the method name.
+
+All three detectors share the same selection pipeline, built around puzzle
+structure: a true piece corner has locally STRAIGHT contour on both sides
+(the edge shoulder regions), while a tab bulb tip curves away immediately.
+Each candidate gets a "cornerness" score (shoulder straightness on both
+sides x local angle near 90 degrees), the best 4-subset is chosen by
+mean-cornerness x quadrilateral angle-score x spacing-balance x normalized
+area, and the winning corners are refined by intersecting the two fitted
+shoulder lines (which recovers the un-rounded corner that `corner_radius`
+rounds off the actual contour).
+"""
+
+import itertools
+import math
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import cv2
+import numpy as np
+from common import resample_contour
+from scipy.ndimage import gaussian_filter1d
+
+# --- Shared config -----------------------------------------------------
+
+# All detectors snap candidates to a contour resampled to this many points.
+RESAMPLE_POINTS = 512
+
+CURVATURE_K = 12
+CURVATURE_SMOOTH_SIGMA = 2.0
+CURVATURE_MAX_CANDIDATES = 16
+
+POLYDP_EPSILON_FRACS = np.linspace(0.005, 0.05, 10)
+
+SHITOMASI_MAX_CORNERS = 20
+SHITOMASI_QUALITY_LEVEL = 0.02
+
+# Cap on the candidate pool entering the brute-force 4-subset search; when a
+# detector proposes more, the top candidates by cornerness are kept.
+MAX_SUBSET_CANDIDATES = 16
+
+# Cornerness windows, in resampled-contour samples: skip the first W1 samples
+# on each side of a candidate (~0.8% of perimeter, the corner-rounding zone),
+# then fit a line to the following samples out to W2 (~4% of perimeter, the
+# edge shoulder region).
+CORNERNESS_W1 = 4
+CORNERNESS_W2 = 24
+
+# Straightness falloff: shoulder-fit RMS residual (as a fraction of the piece
+# bbox diagonal) at which the straightness score drops to 1/e. Straight
+# shoulders sit well under this; curved tab necks sit several times above it.
+STRAIGHTNESS_FALLOFF = 0.004
+
+# Corner refinement: the shoulder-line intersection replaces the raw contour
+# point only when the lines are not near-parallel and the intersection stays
+# close to the candidate. Refinement uses its own, much tighter window pair
+# than the cornerness score: right next to the corner the contour tangents
+# point at the un-rounded corner, whereas a wide fit picks up the edges'
+# slight `corner_slope` curvature and lands off-corner.
+REFINE_W1 = 2
+REFINE_W2 = 10
+REFINE_MIN_ANGLE_DEG = 20.0
+REFINE_MAX_SHIFT_FRAC = 0.03
+
+
+class InsufficientCornersError(RuntimeError):
+    """Raised when a detector cannot find enough candidate points to form a quadrilateral."""
+
+
+@dataclass(frozen=True)
+class CornerResult:
+    """Four detected piece corners with per-corner confidence.
+
+    Attributes:
+        corners: 4x2 float array, ordered clockwise starting near the
+            top-left corner.
+        confidences: One confidence value per corner, in [0, 1], aligned with
+            `corners` (candidate cornerness x the winning quadrilateral's
+            per-corner angle score).
+        method: Name of the detector that produced this result.
+    """
+
+    corners: np.ndarray
+    confidences: List[float]
+    method: str
+
+
+@dataclass(frozen=True)
+class CandidateGeometry:
+    """Local shoulder geometry at one corner candidate.
+
+    Attributes:
+        cornerness: Straightness-before x straightness-after x local angle
+            score, in [0, 1]. Near 1 for true piece corners (straight
+            shoulders meeting near 90 degrees), near 0 for tab bulb tips
+            (curved neighborhoods on both sides).
+        line_before: (centroid, away-pointing unit direction) of the line
+            fitted to the shoulder window preceding the candidate
+            (`CORNERNESS_W1..W2`, used for the cornerness score).
+        line_after: (centroid, away-pointing unit direction) of the line
+            fitted to the shoulder window following the candidate.
+        refine_line_before: Like `line_before` but fitted on the tight
+            `REFINE_W1..W2` window, used for corner refinement.
+        refine_line_after: Like `line_after` but on the tight window.
+    """
+
+    cornerness: float
+    line_before: Tuple[np.ndarray, np.ndarray]
+    line_after: Tuple[np.ndarray, np.ndarray]
+    refine_line_before: Tuple[np.ndarray, np.ndarray]
+    refine_line_after: Tuple[np.ndarray, np.ndarray]
+
+
+# --- Geometry helpers ----------------------------------------------------
+
+
+def _cumulative_arc_length(contour: np.ndarray) -> np.ndarray:
+    """Compute cumulative closed-loop arc length at each contour point.
+
+    Args:
+        contour: Nx2 contour points, implicitly closed.
+
+    Returns:
+        Length-N array; element i is the arc length from point 0 to point i.
+    """
+    closed = np.vstack([contour, contour[:1]])
+    diffs = np.diff(closed, axis=0)
+    segment_lengths = np.sqrt((diffs**2).sum(axis=1))
+    return np.concatenate([[0.0], np.cumsum(segment_lengths)])[:-1]
+
+
+def _polygon_interior_angles(pts: np.ndarray) -> np.ndarray:
+    """Compute the interior angle (degrees) at each vertex of a quadrilateral.
+
+    Args:
+        pts: 4x2 array of vertices in order around the polygon.
+
+    Returns:
+        Length-4 array of interior angles in degrees.
+    """
+    angles = np.zeros(4)
+    for i in range(4):
+        prev_pt = pts[(i - 1) % 4]
+        curr_pt = pts[i]
+        next_pt = pts[(i + 1) % 4]
+        v1 = prev_pt - curr_pt
+        v2 = next_pt - curr_pt
+        cos_angle = np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2) + 1e-8)
+        angles[i] = np.degrees(np.arccos(np.clip(cos_angle, -1.0, 1.0)))
+    return angles
+
+
+def _quad_area(pts: np.ndarray) -> float:
+    """Shoelace-formula area of a quadrilateral.
+
+    Args:
+        pts: 4x2 array of vertices in order around the polygon.
+
+    Returns:
+        Absolute area.
+    """
+    x = pts[:, 0]
+    y = pts[:, 1]
+    return 0.5 * abs(np.dot(x, np.roll(y, -1)) - np.dot(y, np.roll(x, -1)))
+
+
+def _fit_line_pca(points: np.ndarray) -> Tuple[np.ndarray, np.ndarray, float]:
+    """Fit a line to 2D points via PCA.
+
+    Args:
+        points: Mx2 array of points.
+
+    Returns:
+        Tuple of (centroid, unit direction of the first principal component,
+        RMS perpendicular residual).
+    """
+    centroid = points.mean(axis=0)
+    centered = points - centroid
+    _, _, vt = np.linalg.svd(centered, full_matrices=False)
+    direction = vt[0]
+    normal = np.array([-direction[1], direction[0]])
+    residuals = centered @ normal
+    rms = float(np.sqrt(np.mean(residuals**2)))
+    return centroid, direction, rms
+
+
+def _intersect_lines(c1: np.ndarray, d1: np.ndarray, c2: np.ndarray, d2: np.ndarray) -> Optional[np.ndarray]:
+    """Intersect two lines given in point + direction form.
+
+    Args:
+        c1: A point on the first line.
+        d1: Unit direction of the first line.
+        c2: A point on the second line.
+        d2: Unit direction of the second line.
+
+    Returns:
+        The intersection point, or None when the lines are near-parallel.
+    """
+    matrix = np.column_stack([d1, -d2])
+    det = float(np.linalg.det(matrix))
+    if abs(det) < 1e-9:
+        return None
+    params = np.linalg.solve(matrix, c2 - c1)
+    return c1 + params[0] * d1
+
+
+def _bbox_diagonal(contour: np.ndarray) -> float:
+    """Diagonal length of a contour's axis-aligned bounding box.
+
+    Args:
+        contour: Nx2 contour points.
+
+    Returns:
+        Euclidean length of the bbox diagonal.
+    """
+    extent = contour.max(axis=0) - contour.min(axis=0)
+    return float(np.linalg.norm(extent))
+
+
+def _nearest_contour_index(contour: np.ndarray, point: Tuple[float, float]) -> int:
+    """Find the index of the contour point nearest to `point`.
+
+    Args:
+        contour: Nx2 contour points.
+        point: (x, y) query point.
+
+    Returns:
+        Index into `contour` of the nearest point.
+    """
+    dists = np.sum((contour - np.array(point)) ** 2, axis=1)
+    return int(np.argmin(dists))
+
+
+# --- Cornerness ------------------------------------------------------------
+
+
+def candidate_geometry(resampled: np.ndarray, index: int, diagonal: float) -> CandidateGeometry:
+    """Score one candidate's local shoulder geometry.
+
+    Fits a line to the contour window on each side of the candidate (skipping
+    the first `CORNERNESS_W1` samples for corner rounding, using the samples
+    out to `CORNERNESS_W2`). Straightness of each fit and the angle between
+    the two fitted lines combine into the cornerness score: a true piece
+    corner has two straight shoulders meeting near 90 degrees, while a tab
+    bulb tip curves away immediately on both sides.
+
+    Args:
+        resampled: Arc-length-resampled contour (`RESAMPLE_POINTS` x 2).
+        index: Candidate index into `resampled`.
+        diagonal: Piece bbox diagonal, for scale-normalizing fit residuals.
+
+    Returns:
+        The computed `CandidateGeometry`.
+    """
+    n = len(resampled)
+    idx_before = [(index - j) % n for j in range(CORNERNESS_W1, CORNERNESS_W2 + 1)]
+    idx_after = [(index + j) % n for j in range(CORNERNESS_W1, CORNERNESS_W2 + 1)]
+    pts_before = resampled[idx_before]
+    pts_after = resampled[idx_after]
+
+    centroid_b, dir_b, rms_b = _fit_line_pca(pts_before)
+    centroid_a, dir_a, rms_a = _fit_line_pca(pts_after)
+
+    scale = max(diagonal, 1e-8)
+    straightness_before = math.exp(-(rms_b / scale) / STRAIGHTNESS_FALLOFF)
+    straightness_after = math.exp(-(rms_a / scale) / STRAIGHTNESS_FALLOFF)
+
+    # Orient each direction away from the corner (from the window's near end
+    # toward its far end) so their angle approximates the interior angle.
+    if np.dot(dir_b, pts_before[-1] - pts_before[0]) < 0:
+        dir_b = -dir_b
+    if np.dot(dir_a, pts_after[-1] - pts_after[0]) < 0:
+        dir_a = -dir_a
+
+    cos_angle = float(np.clip(np.dot(dir_b, dir_a), -1.0, 1.0))
+    angle = math.degrees(math.acos(cos_angle))
+    local_angle_score = max(0.0, 1.0 - abs(angle - 90.0) / 45.0)
+
+    cornerness = straightness_before * straightness_after * local_angle_score
+
+    # Tight-window fits for refinement: right next to the corner the contour
+    # tangents point at the un-rounded corner.
+    ref_before = [(index - j) % n for j in range(REFINE_W1, REFINE_W2 + 1)]
+    ref_after = [(index + j) % n for j in range(REFINE_W1, REFINE_W2 + 1)]
+    ref_centroid_b, ref_dir_b, _ = _fit_line_pca(resampled[ref_before])
+    ref_centroid_a, ref_dir_a, _ = _fit_line_pca(resampled[ref_after])
+
+    return CandidateGeometry(
+        cornerness=cornerness,
+        line_before=(centroid_b, dir_b),
+        line_after=(centroid_a, dir_a),
+        refine_line_before=(ref_centroid_b, ref_dir_b),
+        refine_line_after=(ref_centroid_a, ref_dir_a),
+    )
+
+
+# --- Shared 4-subset scorer and refinement --------------------------------
+
+
+def best_four_subset(
+    contour: np.ndarray,
+    candidate_indices: Sequence[int],
+    arc_length: np.ndarray,
+    cornerness: Dict[int, float],
+    hull_area: float,
+) -> Tuple[Tuple[int, int, int, int], float, np.ndarray]:
+    """Brute-force the best 4-corner subset of a candidate index set.
+
+    Scores each combination by mean-cornerness x quadrilateral angle-score x
+    spacing-balance x normalized area: cornerness rejects tab bulb tips
+    (which have curved shoulders), angle-score rewards interior angles near
+    90 degrees, spacing-balance (ratio of the smallest to largest arc-length
+    gap between consecutive corners) penalizes lopsided corner placement, and
+    the normalized area (quad area / contour convex hull area, in [0, 1])
+    suppresses degenerate small quads without dominating the other 0-1 terms.
+
+    Args:
+        contour: Nx2 contour points the candidate indices refer into.
+        candidate_indices: Indices into `contour` to consider as corners.
+        arc_length: Cumulative closed-loop arc length at each contour point
+            (see `_cumulative_arc_length`), used for spacing-balance.
+        cornerness: Per-candidate cornerness score (see `candidate_geometry`).
+        hull_area: Convex hull area of the full contour, for area normalization.
+
+    Returns:
+        Tuple of (best 4-tuple of indices, its score, its per-corner angle
+        scores).
+
+    Raises:
+        InsufficientCornersError: When fewer than 4 unique candidates are given.
+    """
+    unique = sorted(set(candidate_indices))
+    if len(unique) < 4:
+        raise InsufficientCornersError(f"Need >=4 candidate corners, got {len(unique)}")
+
+    perimeter = arc_length[-1] + np.linalg.norm(contour[-1] - contour[0])
+    hull_area = max(hull_area, 1e-8)
+    best_combo: Tuple[int, int, int, int] = tuple(unique[:4])  # type: ignore[assignment]
+    best_score = -1.0
+    best_corner_scores = np.zeros(4)
+
+    for combo in itertools.combinations(unique, 4):
+        pts = contour[list(combo)]
+        area_normalized = _quad_area(pts) / hull_area
+        if area_normalized <= 0:
+            continue
+        angles = _polygon_interior_angles(pts)
+        corner_scores = np.clip(1.0 - np.abs(angles - 90.0) / 45.0, 0.0, None)
+        angle_score = float(corner_scores.mean())
+
+        positions = np.sort(arc_length[list(combo)])
+        gaps = np.diff(np.concatenate([positions, positions[:1] + perimeter]))
+        spacing_balance = float(gaps.min() / gaps.max()) if gaps.max() > 0 else 0.0
+
+        mean_cornerness = float(np.mean([cornerness[i] for i in combo]))
+        score = mean_cornerness * angle_score * spacing_balance * area_normalized
+        if score > best_score:
+            best_score = score
+            best_combo = combo  # type: ignore[assignment]
+            best_corner_scores = corner_scores
+
+    return best_combo, best_score, best_corner_scores
+
+
+def _order_clockwise(corners: np.ndarray, confidences: np.ndarray) -> Tuple[np.ndarray, List[float]]:
+    """Order 4 corners clockwise (image coordinates, y-down) starting near the top-left.
+
+    Args:
+        corners: 4x2 array of corner points.
+        confidences: Length-4 array of per-corner confidences, aligned with `corners`.
+
+    Returns:
+        Tuple of (reordered 4x2 corners, reordered confidence list).
+    """
+    centroid = corners.mean(axis=0)
+    angles = np.arctan2(corners[:, 1] - centroid[1], corners[:, 0] - centroid[0])
+    order = np.argsort(angles)
+    ordered = corners[order]
+    ordered_conf = confidences[order]
+
+    start = int(np.argmin(ordered[:, 0] + ordered[:, 1]))
+    ordered = np.roll(ordered, -start, axis=0)
+    ordered_conf = np.roll(ordered_conf, -start, axis=0)
+    return ordered, ordered_conf.tolist()
+
+
+def _refine_corner(candidate_point: np.ndarray, geometry: CandidateGeometry, diagonal: float) -> np.ndarray:
+    """Refine a corner by intersecting its two fitted shoulder lines.
+
+    Ground truth is the un-rounded base-square corner while `corner_radius`
+    rounds the actual contour, so the intersection of the two straight
+    shoulder lines lands closer to the true corner than any contour point.
+
+    Args:
+        candidate_point: The candidate's raw contour point.
+        geometry: The candidate's shoulder geometry.
+        diagonal: Piece bbox diagonal, for the max-shift sanity check.
+
+    Returns:
+        The refined corner, or `candidate_point` unchanged when the shoulder
+        lines are near-parallel (angle < `REFINE_MIN_ANGLE_DEG`) or the
+        intersection lands more than `REFINE_MAX_SHIFT_FRAC` of the diagonal
+        away from the candidate.
+    """
+    centroid_b, dir_b = geometry.refine_line_before
+    centroid_a, dir_a = geometry.refine_line_after
+
+    cos_angle = float(np.clip(abs(np.dot(dir_b, dir_a)), 0.0, 1.0))
+    angle_between = math.degrees(math.acos(cos_angle))
+    if angle_between < REFINE_MIN_ANGLE_DEG:
+        return candidate_point
+
+    intersection = _intersect_lines(centroid_b, dir_b, centroid_a, dir_a)
+    if intersection is None:
+        return candidate_point
+    if float(np.linalg.norm(intersection - candidate_point)) > REFINE_MAX_SHIFT_FRAC * diagonal:
+        return candidate_point
+    return intersection
+
+
+def _select_and_refine(resampled: np.ndarray, candidate_indices: Sequence[int], method: str) -> CornerResult:
+    """Shared back half of every detector: score candidates, pick 4, refine, order.
+
+    When the detector proposes more than `MAX_SUBSET_CANDIDATES` candidates,
+    the pool is capped to the top candidates by cornerness — the corner prior
+    itself, rather than any detector-specific persistence ranking (which
+    tends to favor tab bulb tips over shallow true corners).
+
+    Args:
+        resampled: Arc-length-resampled contour (`RESAMPLE_POINTS` x 2).
+        candidate_indices: Candidate indices into `resampled`.
+        method: Detector name for the result.
+
+    Returns:
+        The final `CornerResult`.
+
+    Raises:
+        InsufficientCornersError: When fewer than 4 unique candidates are given.
+    """
+    unique = sorted(set(candidate_indices))
+    if len(unique) < 4:
+        raise InsufficientCornersError(f"Need >=4 candidate corners, got {len(unique)}")
+
+    diagonal = _bbox_diagonal(resampled)
+    geometries = {i: candidate_geometry(resampled, i, diagonal) for i in unique}
+    cornerness = {i: g.cornerness for i, g in geometries.items()}
+    if len(unique) > MAX_SUBSET_CANDIDATES:
+        unique = sorted(sorted(unique, key=lambda i: -cornerness[i])[:MAX_SUBSET_CANDIDATES])
+    arc_length = _cumulative_arc_length(resampled)
+    hull_area = float(cv2.contourArea(cv2.convexHull(resampled.astype(np.float32))))
+
+    combo, _, quad_corner_scores = best_four_subset(resampled, unique, arc_length, cornerness, hull_area)
+
+    refined = np.zeros((4, 2))
+    confidences = np.zeros(4)
+    for j, idx in enumerate(combo):
+        geometry = geometries[idx]
+        refined[j] = _refine_corner(resampled[idx], geometry, diagonal)
+        confidences[j] = float(np.clip(geometry.cornerness * quad_corner_scores[j], 0.0, 1.0))
+
+    ordered, ordered_conf = _order_clockwise(refined, confidences)
+    return CornerResult(corners=ordered, confidences=ordered_conf, method=method)
+
+
+# --- Detectors ------------------------------------------------------------
+
+
+def detect_corners_curvature(contour: np.ndarray) -> CornerResult:
+    """Detect corners from local curvature (turn angle) along the resampled contour.
+
+    Resamples the contour to a fixed point count, scores each point by how
+    much the path turns over a +-k window, smooths that response, picks
+    well-separated local maxima via non-max suppression, then runs the shared
+    cornerness-based selection and shoulder-line refinement.
+
+    Args:
+        contour: Nx2 contour points in original image coordinates.
+
+    Returns:
+        The detected `CornerResult`.
+
+    Raises:
+        InsufficientCornersError: When fewer than 4 corner candidates survive.
+    """
+    resampled = resample_contour(contour, RESAMPLE_POINTS)
+    n = len(resampled)
+    k = CURVATURE_K
+
+    response = np.zeros(n)
+    for i in range(n):
+        p_prev = resampled[(i - k) % n]
+        p_curr = resampled[i]
+        p_next = resampled[(i + k) % n]
+        v1 = p_curr - p_prev
+        v2 = p_next - p_curr
+        cos_angle = np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2) + 1e-8)
+        response[i] = np.degrees(np.arccos(np.clip(cos_angle, -1.0, 1.0)))
+
+    response = gaussian_filter1d(response, sigma=CURVATURE_SMOOTH_SIGMA, mode="wrap")
+
+    # ~3% of the perimeter: tight enough that a true corner is not suppressed
+    # by a nearby higher-curvature tab armpit, wide enough to dedupe peaks.
+    min_separation = n // 32
+    order = np.argsort(-response)
+    selected: List[int] = []
+    for idx in order:
+        if all(min(abs(idx - s), n - abs(idx - s)) >= min_separation for s in selected):
+            selected.append(int(idx))
+        if len(selected) >= CURVATURE_MAX_CANDIDATES:
+            break
+
+    if len(selected) < 4:
+        selected = [int(i) for i in order[:CURVATURE_MAX_CANDIDATES]]
+
+    return _select_and_refine(resampled, selected, "curvature")
+
+
+def detect_corners_polydp(contour: np.ndarray) -> CornerResult:
+    """Detect corners via an `approxPolyDP` epsilon sweep.
+
+    Sweeps the Douglas-Peucker epsilon from 0.5% to 5% of the perimeter,
+    collecting every vertex candidate seen across the sweep (snapped to the
+    resampled contour and deduplicated), then runs the shared
+    cornerness-based selection (which caps the pool by cornerness) and
+    shoulder-line refinement.
+
+    Args:
+        contour: Nx2 contour points in original image coordinates.
+
+    Returns:
+        The detected `CornerResult`.
+
+    Raises:
+        InsufficientCornersError: When fewer than 4 corner candidates survive.
+    """
+    resampled = resample_contour(contour, RESAMPLE_POINTS)
+    contour_cv = contour.astype(np.float32).reshape(-1, 1, 2)
+    perimeter = cv2.arcLength(contour_cv, closed=True)
+
+    candidates: set[int] = set()
+    for eps_frac in POLYDP_EPSILON_FRACS:
+        epsilon = eps_frac * perimeter
+        approx = cv2.approxPolyDP(contour_cv, epsilon, closed=True).reshape(-1, 2)
+        for pt in approx:
+            candidates.add(_nearest_contour_index(resampled, (float(pt[0]), float(pt[1]))))
+
+    return _select_and_refine(resampled, sorted(candidates), "polydp")
+
+
+def detect_corners_shitomasi(contour: np.ndarray, crop_shape: Tuple[int, int]) -> CornerResult:
+    """Detect corners via Shi-Tomasi ("good features to track") on the filled piece mask.
+
+    Args:
+        contour: Nx2 contour points in original image coordinates.
+        crop_shape: (height, width) of the crop the contour lives in, used to
+            render the filled mask for `cv2.goodFeaturesToTrack`.
+
+    Returns:
+        The detected `CornerResult`.
+
+    Raises:
+        InsufficientCornersError: When fewer than 4 corner candidates survive.
+    """
+    resampled = resample_contour(contour, RESAMPLE_POINTS)
+    height, width = crop_shape
+    mask = np.zeros((height, width), dtype=np.uint8)
+    cv2.fillPoly(mask, [contour.astype(np.int32)], (255,))
+
+    x, y, w, h = cv2.boundingRect(contour.astype(np.int32))
+    piece_size = max(w, h)
+    # /16 (not /8): with a wider suppression radius, sharp tab armpits knock
+    # out the rounded (weaker-response) true corners next to them.
+    min_distance = max(1.0, piece_size / 16)
+
+    detected = cv2.goodFeaturesToTrack(
+        mask,
+        maxCorners=SHITOMASI_MAX_CORNERS,
+        qualityLevel=SHITOMASI_QUALITY_LEVEL,
+        minDistance=min_distance,
+    )
+
+    candidates: List[int] = []
+    if detected is not None:
+        for pt in detected.reshape(-1, 2):
+            idx = _nearest_contour_index(resampled, (float(pt[0]), float(pt[1])))
+            if idx not in candidates:
+                candidates.append(idx)
+
+    return _select_and_refine(resampled, candidates, "shitomasi")

--- a/network/experiments/exp28_piece_geometry/debug_synth_failures.py
+++ b/network/experiments/exp28_piece_geometry/debug_synth_failures.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Render synthetic-benchmark failure cases for visual analysis.
+
+Re-runs the same deterministic generation loop as `synth_benchmark.py` and
+saves an annotated render for every piece where a detector's max corner error
+exceeds the success threshold: contour (white), ground-truth corners (green),
+predicted corners (red), and the detector's candidate pool (small blue dots)
+when available.
+
+Usage:
+    cd network
+    uv run python experiments/exp28_piece_geometry/debug_synth_failures.py --n 200 --seed 42 --max-renders 12
+"""
+
+import argparse
+import random
+from pathlib import Path
+
+import cv2
+import numpy as np
+from common import mask_to_contour
+from synth_benchmark import SUCCESS_THRESHOLD_PCT, generate_synthetic_piece, run_detector, score_corners
+
+DEBUG_METHODS = ("polydp", "curvature")
+
+
+def render_failure(
+    mask: np.ndarray,
+    contour: np.ndarray,
+    predicted: np.ndarray,
+    gt_corners: np.ndarray,
+    error_pct: float,
+    out_path: Path,
+) -> None:
+    """Save an annotated BGR render of one failure case.
+
+    Args:
+        mask: The degraded binary mask the contour came from.
+        contour: Nx2 extracted contour.
+        predicted: 4x2 predicted corners.
+        gt_corners: 4x2 ground-truth corners.
+        error_pct: The scored max corner error (percent of diagonal).
+        out_path: PNG destination.
+    """
+    canvas = cv2.cvtColor((mask // 3).astype(np.uint8), cv2.COLOR_GRAY2BGR)
+    cv2.polylines(canvas, [contour.astype(np.int32)], isClosed=True, color=(200, 200, 200), thickness=2)
+    for pt in gt_corners:
+        cv2.circle(canvas, (int(pt[0]), int(pt[1])), 10, (0, 255, 0), 3)
+    for pt in predicted:
+        cv2.drawMarker(canvas, (int(pt[0]), int(pt[1])), (0, 0, 255), cv2.MARKER_CROSS, 24, 4)
+    cv2.putText(canvas, f"err {error_pct:.1f}%", (12, 36), cv2.FONT_HERSHEY_SIMPLEX, 1.0, (0, 200, 255), 2)
+    cv2.imwrite(str(out_path), canvas)
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Render synthetic corner-benchmark failures.")
+    parser.add_argument("--n", type=int, default=200)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--max-renders", type=int, default=12)
+    parser.add_argument("--output-dir", type=Path, default=Path(__file__).parent / "outputs" / "synth_failures")
+    args = parser.parse_args()
+
+    random.seed(args.seed)
+    rng = np.random.default_rng(args.seed)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    rendered = dict.fromkeys(DEBUG_METHODS, 0)
+    for i in range(args.n):
+        piece = generate_synthetic_piece(rng)
+        if piece is None:
+            continue
+        contour = mask_to_contour(piece.mask)
+        if contour is None:
+            continue
+        for method in DEBUG_METHODS:
+            if rendered[method] >= args.max_renders:
+                continue
+            result = run_detector(method, contour, piece.mask.shape)
+            if result is None:
+                continue
+            error_pct = score_corners(result.corners, piece.gt_corners)
+            if error_pct <= SUCCESS_THRESHOLD_PCT:
+                continue
+            out_path = args.output_dir / f"piece{i:03d}_{method}_err{error_pct:.0f}.png"
+            render_failure(piece.mask, contour, result.corners, piece.gt_corners, error_pct, out_path)
+            rendered[method] += 1
+        if all(count >= args.max_renders for count in rendered.values()):
+            break
+
+    print(f"Rendered failures: {rendered} -> {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/network/experiments/exp28_piece_geometry/edge_match.py
+++ b/network/experiments/exp28_piece_geometry/edge_match.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""M4: canonical edge frames, mate flipping, and pairwise edge match distances.
+
+Canonical frame: an M3 edge polyline (100 pts, corner A -> corner B in
+clockwise contour order, image coordinates) is translated so A is at the
+origin, rotated so B lies on the +x axis, and scaled so the chord |AB| = 1.
+Because M3 contours are traversed clockwise in image coordinates (y down),
+OUTWARD deviation maps to NEGATIVE canonical y: a tab dips below the x axis
+at its peak, a blank rises above it.
+
+Mate flip: a physically mating edge is the same curve traversed in the
+opposite direction by the neighboring piece. In canonical frames the mate
+transform is: reverse point order, then re-canonicalize. Re-canonicalizing
+the reversed polyline rotates by 180 degrees, which maps (x, y) ->
+(1 - x, -y) - the y negation the mate needs is inherent in that rotation,
+so `flip_edge` is exactly reverse + re-canonicalize, and for a perfect mate
+``flip_edge(mate) == query`` pointwise.
+
+Distances (query Q vs flipped candidate C', both canonical 100-pt):
+- ``l2``: mean pointwise Euclidean distance (same index alignment).
+- ``chamfer``: symmetric mean nearest-neighbor distance.
+- ``scalar6``: Euclidean distance between 6-feature vectors; the candidate
+  contributes its OWN features mirrored (see `mirror_features`) instead of a
+  flipped polyline.
+- l2/chamfer chord-penalty variants: dist + LAMBDA * |log(chordQ/chordC)|.
+
+The CLI runs a synthetic self-check: it builds a `puzzle_shapes` edge grid,
+extracts the shared edge between two neighboring pieces from both sides, and
+verifies distance(edge, flip(mate)) is near zero while
+distance(edge, flip(non-mate)) is large.
+
+Usage:
+    cd network
+    uv run python experiments/exp28_piece_geometry/edge_match.py   # self-check
+"""
+
+import argparse
+from typing import List, Tuple
+
+import numpy as np
+from common import resample_polyline
+from puzzle_shapes import BezierCurve, generate_edge_grid, reverse_curves, transform_curves
+from scipy.spatial.distance import cdist
+
+CANONICAL_POINTS = 100
+
+# Chord-length penalty weight for the *_chord distance variants.
+CHORD_PENALTY_LAMBDA = 0.5
+
+# Only tab<->blank pairs can mate; flat edges never mate. A query whose own
+# type prediction is "flat" (necessarily a misclassification when the grid
+# says the edge is interior) is scored against both feature types.
+COMPATIBLE_TYPES = {"tab": ("blank",), "blank": ("tab",), "flat": ("tab", "blank")}
+
+
+def canonicalize_edge(polyline: np.ndarray) -> np.ndarray:
+    """Map an edge polyline to the canonical frame.
+
+    Translates the first point to the origin, rotates so the last point lies
+    on the +x axis, and scales so the chord length is 1.
+
+    Args:
+        polyline: Nx2 edge points, corner A first, corner B last.
+
+    Returns:
+        Nx2 canonical polyline (A at (0,0), B at (1,0)).
+    """
+    a = polyline[0]
+    chord = polyline[-1] - a
+    length = float(np.linalg.norm(chord))
+    if length < 1e-9:
+        return np.zeros_like(polyline)
+    cos_t = chord[0] / length
+    sin_t = chord[1] / length
+    rotation = np.array([[cos_t, sin_t], [-sin_t, cos_t]])
+    return (polyline - a) @ rotation.T / length
+
+
+def flip_edge(canonical: np.ndarray) -> np.ndarray:
+    """Transform a canonical edge into the frame of its would-be mate.
+
+    Reverses the point order and re-canonicalizes; the re-canonicalization
+    rotates by 180 degrees, mapping (x, y) -> (1 - x, -y). For a true mate
+    the result coincides with the query's canonical polyline pointwise.
+
+    Args:
+        canonical: Nx2 canonical edge polyline.
+
+    Returns:
+        Nx2 flipped canonical polyline.
+    """
+    return canonicalize_edge(canonical[::-1])
+
+
+def dist_l2(query: np.ndarray, candidate_flipped: np.ndarray) -> float:
+    """Mean pointwise Euclidean distance between two canonical polylines.
+
+    Args:
+        query: Nx2 canonical query edge.
+        candidate_flipped: Nx2 flipped canonical candidate edge.
+
+    Returns:
+        The mean pointwise distance.
+    """
+    return float(np.mean(np.linalg.norm(query - candidate_flipped, axis=1)))
+
+
+def dist_chamfer(query: np.ndarray, candidate_flipped: np.ndarray) -> float:
+    """Symmetric mean nearest-neighbor (chamfer) distance.
+
+    Args:
+        query: Nx2 canonical query edge.
+        candidate_flipped: Nx2 flipped canonical candidate edge.
+
+    Returns:
+        The chamfer distance.
+    """
+    dists = cdist(query, candidate_flipped)
+    return float((dists.min(axis=1).mean() + dists.min(axis=0).mean()) / 2.0)
+
+
+def edge_features(canonical: np.ndarray, chord_length_px: float) -> np.ndarray:
+    """Compute the 6-feature scalar descriptor of a canonical edge.
+
+    Features (outward-positive convention, i.e. dev = -canonical_y):
+    0. signed peak deviation (positive for tabs, negative for blanks),
+    1. arc-position of the peak along the chord, clipped to [0, 1],
+    2. width at half peak height (x-extent of the contiguous half-peak run),
+    3. total |area| between polyline and chord,
+    4. asymmetry: signed outward area of the first half minus the second half,
+    5. log(chord length in px) - pairwise differences of this feature give
+       the log chord-ratio term.
+
+    Args:
+        canonical: Nx2 canonical edge polyline.
+        chord_length_px: The edge's chord length in original-image pixels.
+
+    Returns:
+        The 6-element feature vector.
+    """
+    x = canonical[:, 0]
+    dev = -canonical[:, 1]
+
+    peak_idx = int(np.argmax(np.abs(dev)))
+    peak = float(dev[peak_idx])
+    pos = float(np.clip(x[peak_idx], 0.0, 1.0))
+
+    width = 0.0
+    if abs(peak) > 1e-9:
+        above = dev * np.sign(peak) >= abs(peak) / 2.0
+        lo = peak_idx
+        while lo > 0 and above[lo - 1]:
+            lo -= 1
+        hi = peak_idx
+        while hi < len(dev) - 1 and above[hi + 1]:
+            hi += 1
+        width = float(abs(x[lo : hi + 1].max() - x[lo : hi + 1].min()))
+
+    # Signed outward area via the line integral -integral(y dx) along the
+    # polyline (the chord return path lies on y=0 and contributes nothing).
+    seg_areas = 0.5 * (dev[:-1] + dev[1:]) * np.diff(x)
+    half = len(canonical) // 2
+    area_first = float(seg_areas[:half].sum())
+    area_second = float(seg_areas[half:].sum())
+    total_area = abs(area_first + area_second)
+    asymmetry = area_first - area_second
+
+    return np.array([peak, pos, width, total_area, asymmetry, np.log(max(chord_length_px, 1e-9))])
+
+
+def mirror_features(features: np.ndarray) -> np.ndarray:
+    """Mirror a candidate edge's features into the query's frame.
+
+    Mirror rules for viewing the same physical junction from the mating
+    side: the peak sign flips (tab <-> blank), the peak position reflects
+    (pos -> 1 - pos), width and total |area| are invariant, and asymmetry is
+    invariant (reversing traversal swaps the halves AND flips the outward
+    sign, which cancel). The log-chord feature is unchanged; the query -
+    candidate difference of it is the log chord-ratio term.
+
+    Args:
+        features: 6-element feature vector from `edge_features`.
+
+    Returns:
+        The mirrored 6-element feature vector.
+    """
+    peak, pos, width, total_area, asymmetry, log_chord = features
+    return np.array([-peak, 1.0 - pos, width, total_area, asymmetry, log_chord])
+
+
+def dist_scalar6(query_features: np.ndarray, candidate_features_mirrored: np.ndarray) -> float:
+    """Euclidean distance between a query's features and a mirrored candidate's.
+
+    Args:
+        query_features: The query edge's 6-feature vector.
+        candidate_features_mirrored: The candidate's feature vector after
+            `mirror_features`.
+
+    Returns:
+        The Euclidean feature distance.
+    """
+    return float(np.linalg.norm(query_features - candidate_features_mirrored))
+
+
+def chord_penalty(chord_q_px: float, chord_c_px: float, lam: float = CHORD_PENALTY_LAMBDA) -> float:
+    """Chord-length penalty term: lam * |log(chordQ / chordC)|.
+
+    Args:
+        chord_q_px: Query chord length in pixels.
+        chord_c_px: Candidate chord length in pixels.
+        lam: Penalty weight (0 disables).
+
+    Returns:
+        The penalty value.
+    """
+    return lam * abs(float(np.log(max(chord_q_px, 1e-9) / max(chord_c_px, 1e-9))))
+
+
+# --- Synthetic self-check ---------------------------------------------------
+
+
+def _curves_to_polyline(curves: List[BezierCurve], n: int = CANONICAL_POINTS) -> np.ndarray:
+    """Sample a curve chain densely and resample to n equidistant points.
+
+    Args:
+        curves: Bezier curves in traversal order.
+        n: Output point count.
+
+    Returns:
+        Nx2 polyline.
+    """
+    points: List[Tuple[float, float]] = []
+    for curve in curves:
+        samples = curve.get_points(50)
+        points.extend((float(p[0]), float(p[1])) for p in samples[:-1])
+    last = curves[-1].get_points(2)[-1]
+    points.append((float(last[0]), float(last[1])))
+    return resample_polyline(np.array(points), n)
+
+
+def self_check(seed: int = 7) -> None:
+    """Verify flip/distance semantics on a synthetic shared edge from puzzle_shapes.
+
+    Builds a 2x2 edge grid, extracts the interior vertical edge between
+    pieces (0,0) and (0,1) from BOTH sides (as each piece traverses it,
+    mirroring `get_piece_curves`), plus a non-mating interior edge, and
+    prints distance(edge, flip(mate)) vs distance(edge, flip(non-mate)).
+
+    Args:
+        seed: Random seed for the edge grid.
+    """
+    grid = generate_edge_grid(2, 2, seed=seed)
+
+    shared = grid.vertical_edges[0][1]
+    # Piece (0,0) traverses this edge as its RIGHT edge: reversed, rotated 90 CCW.
+    right_curves = transform_curves(
+        reverse_curves(shared.curves), translate=(1.0, 0.0), scale=(1.0, 1.0), rotate_90_ccw=1
+    )
+    # Piece (0,1) traverses the same edge as its LEFT edge: forward, rotated 90 CCW.
+    left_curves = transform_curves(shared.curves, translate=(0.0, 0.0), scale=(1.0, 1.0), rotate_90_ccw=1)
+
+    other = grid.horizontal_edges[1][0]  # interior edge between (0,0) and (1,0)
+    other_curves = transform_curves(
+        reverse_curves(other.curves), translate=(0.0, 0.0), scale=(1.0, 1.0), rotate_90_ccw=0
+    )
+
+    query = canonicalize_edge(_curves_to_polyline(right_curves))
+    mate = canonicalize_edge(_curves_to_polyline(left_curves))
+    non_mate = canonicalize_edge(_curves_to_polyline(other_curves))
+
+    for name, dist_fn in (("l2", dist_l2), ("chamfer", dist_chamfer)):
+        d_mate = dist_fn(query, flip_edge(mate))
+        d_other = dist_fn(query, flip_edge(non_mate))
+        status = "OK" if d_mate < 0.01 and d_other > 5 * max(d_mate, 1e-9) else "FAIL"
+        print(
+            f"  {name:8s} dist(edge, flip(mate)) = {d_mate:.5f}   dist(edge, flip(non-mate)) = {d_other:.5f}  {status}"
+        )
+
+    fq = edge_features(query, 100.0)
+    d_mate6 = dist_scalar6(fq, mirror_features(edge_features(mate, 100.0)))
+    d_other6 = dist_scalar6(fq, mirror_features(edge_features(non_mate, 100.0)))
+    status = "OK" if d_mate6 < 0.05 and d_other6 > 5 * max(d_mate6, 1e-9) else "FAIL"
+    print(
+        f"  {'scalar6':8s} dist(edge, mirror(mate)) = {d_mate6:.5f}   "
+        f"dist(edge, mirror(non-mate)) = {d_other6:.5f}  {status}"
+    )
+
+
+def main() -> None:
+    """CLI entry point: run the synthetic self-check."""
+    parser = argparse.ArgumentParser(description="Edge match distances - synthetic self-check.")
+    parser.add_argument("--seed", type=int, default=7)
+    args = parser.parse_args()
+    print("Synthetic self-check (puzzle_shapes shared edge, 2x2 grid):")
+    self_check(seed=args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/network/experiments/exp28_piece_geometry/edge_split.py
+++ b/network/experiments/exp28_piece_geometry/edge_split.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""M3: split clean contours into 4 edges and classify each as tab/blank/flat.
+
+For every piece x background with a clean rembg contour (produced by
+`extract_contours.py`):
+
+1. Detect corners with polydp (primary); run curvature as a cross-check and
+   flag `corner_disagreement` when the two disagree by more than 3% of the
+   bbox diagonal (optimal Hungarian matching).
+2. Split a densely resampled (1024-pt) contour at the 4 corners into 4 arcs.
+3. Map the arcs to grid directions N/E/S/W: corners are ordered clockwise
+   from top-left, so with a clockwise-wound contour the arc corner0->corner1
+   is North, then East, South, West. All 944 photos have rotation 0
+   (verified from metadata); a nonzero rotation would shift the mapping.
+4. Classify each arc by its dominant signed perpendicular deviation from the
+   corner-to-corner chord (positive = away from the piece centroid):
+   |dominant| < FLAT_THRESHOLD -> flat, positive -> tab, negative -> blank.
+
+Writes one JSON per piece x background to
+`outputs/piece_records/{puzzle_id}/{piece_stem}.json`, appends
+`outputs/edge_summary.csv`, and prints a histogram of |dominant deviation|
+across all edges (used to place FLAT_THRESHOLD in the bimodal gap).
+
+Usage:
+    cd network
+    uv run python experiments/exp28_piece_geometry/edge_split.py
+    uv run python experiments/exp28_piece_geometry/edge_split.py --puzzle bambi
+"""
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+from common import PieceRecord, load_metadata, resample_contour, resample_polyline
+from corner_detect import (
+    CornerResult,
+    InsufficientCornersError,
+    _bbox_diagonal,
+    _nearest_contour_index,
+    detect_corners_curvature,
+    detect_corners_polydp,
+)
+from scipy.optimize import linear_sum_assignment
+
+DEFAULT_DATASET_ROOT = Path("/Users/claus/Repos/pussel/network/datasets/north_star/v1")
+
+# Dense resampling used for edge splitting (finer than the detectors' 512).
+SPLIT_RESAMPLE_POINTS = 1024
+
+# Each edge arc is stored resampled to this many equidistant points.
+EDGE_POLYLINE_POINTS = 100
+
+# Corner cross-check: polydp vs curvature max matched-corner distance (as a
+# fraction of the bbox diagonal) above which the piece is flagged.
+CORNER_DISAGREEMENT_FRAC = 0.03
+
+# Tab/blank/flat threshold on |dominant deviation| / chord length. The
+# measured distribution across all 3,664 clean edges is strongly bimodal:
+# grid-truth flat edges cluster in [0, 0.04] (median 0.009, p90 0.021) and
+# tab/blank features in [0.11, 0.42] (median 0.292, p1 0.109; the shallow
+# tail is the big-piece toddler puzzles, where tab height is small relative
+# to the chord). 0.07 sits mid-gap and maximizes measured flat-vs-nonflat
+# accuracy; the residual errors are outliers (corner/segmentation faults),
+# not threshold placement.
+FLAT_THRESHOLD = 0.07
+
+DIRECTIONS = ("N", "E", "S", "W")
+
+
+def _signed_area(contour: np.ndarray) -> float:
+    """Shoelace signed area of a closed contour in image coordinates.
+
+    In image coordinates (y down), a visually-clockwise polygon (the order
+    TL -> TR -> BR -> BL) has POSITIVE signed area.
+
+    Args:
+        contour: Nx2 contour points.
+
+    Returns:
+        The signed area.
+    """
+    x = contour[:, 0]
+    y = contour[:, 1]
+    return 0.5 * float(np.dot(x, np.roll(y, -1)) - np.dot(y, np.roll(x, -1)))
+
+
+def _corner_max_distance_frac(a: np.ndarray, b: np.ndarray, diagonal: float) -> float:
+    """Max matched-corner distance between two 4-corner sets, as a fraction of the diagonal.
+
+    Args:
+        a: 4x2 corner set.
+        b: 4x2 corner set.
+        diagonal: Piece bbox diagonal for normalization.
+
+    Returns:
+        Max distance over the optimal (Hungarian) corner assignment, divided
+        by `diagonal`.
+    """
+    dist_matrix = np.linalg.norm(a[:, None, :] - b[None, :, :], axis=2)
+    row_ind, col_ind = linear_sum_assignment(dist_matrix)
+    return float(dist_matrix[row_ind, col_ind].max()) / max(diagonal, 1e-8)
+
+
+def _arc_slice(resampled: np.ndarray, start: int, end: int) -> np.ndarray:
+    """Extract the cyclic slice start..end (inclusive) from a closed contour.
+
+    Args:
+        resampled: Nx2 closed contour points.
+        start: Start index.
+        end: End index (may be cyclically before `start`).
+
+    Returns:
+        The arc points from `start` to `end` inclusive, in contour order.
+    """
+    if end >= start:
+        return resampled[start : end + 1]
+    return np.vstack([resampled[start:], resampled[: end + 1]])
+
+
+def classify_arc(arc: np.ndarray, centroid: np.ndarray) -> Tuple[str, float, float, float, float]:
+    """Classify one edge arc as tab/blank/flat from its chord deviation profile.
+
+    The chord runs between the arc's two endpoint corners. Every arc point
+    gets a signed perpendicular deviation from the chord, with positive
+    meaning away from the piece centroid. The dominant deviation (larger
+    magnitude of max/min) decides the type.
+
+    Args:
+        arc: Mx2 arc points, endpoints being the two corners.
+        centroid: The piece centroid (for the away-from-piece sign convention).
+
+    Returns:
+        Tuple of (edge type, dominant_dev, max_dev, min_dev, chord_length),
+        deviations normalized by chord length.
+    """
+    corner_a = arc[0]
+    corner_b = arc[-1]
+    chord = corner_b - corner_a
+    chord_length = float(np.linalg.norm(chord))
+    if chord_length < 1e-8:
+        return "flat", 0.0, 0.0, 0.0, chord_length
+    u = chord / chord_length
+
+    def cross_with_u(points: np.ndarray) -> np.ndarray:
+        rel = points - corner_a
+        return u[0] * rel[:, 1] - u[1] * rel[:, 0]
+
+    centroid_side = float(cross_with_u(centroid.reshape(1, 2))[0])
+    away_sign = -1.0 if centroid_side > 0 else 1.0
+
+    devs = cross_with_u(arc) * away_sign / chord_length
+    max_dev = float(devs.max())
+    min_dev = float(devs.min())
+    dominant_dev = max_dev if abs(max_dev) >= abs(min_dev) else min_dev
+
+    if abs(dominant_dev) < FLAT_THRESHOLD:
+        edge_type = "flat"
+    elif dominant_dev > 0:
+        edge_type = "tab"
+    else:
+        edge_type = "blank"
+    return edge_type, dominant_dev, max_dev, min_dev, chord_length
+
+
+def split_piece(contour: np.ndarray, rotation: int) -> Optional[Tuple[Dict[str, Dict[str, Any]], CornerResult, bool]]:
+    """Split one clean contour into 4 classified, direction-mapped edges.
+
+    Args:
+        contour: Nx2 contour in original image coordinates.
+        rotation: The piece's photographed rotation label in degrees
+            (0/90/180/270); nonzero values shift the arc -> direction mapping.
+
+    Returns:
+        Tuple of (per-direction edge dicts, the polydp corner result, the
+        corner_disagreement flag), or None when corner detection fails or
+        corners collapse onto each other on the resampled contour.
+    """
+    try:
+        primary = detect_corners_polydp(contour)
+    except InsufficientCornersError:
+        return None
+
+    disagreement = True
+    try:
+        cross_check = detect_corners_curvature(contour)
+        diagonal = _bbox_diagonal(contour)
+        frac = _corner_max_distance_frac(primary.corners, cross_check.corners, diagonal)
+        disagreement = frac > CORNER_DISAGREEMENT_FRAC
+    except InsufficientCornersError:
+        pass  # keep disagreement=True: no cross-check available
+
+    resampled = resample_contour(contour, SPLIT_RESAMPLE_POINTS)
+    # Enforce visually-clockwise winding (positive shoelace area in image
+    # coordinates) so traversal order matches the clockwise corner order.
+    if _signed_area(resampled) < 0:
+        resampled = resampled[::-1]
+
+    corner_idx = [_nearest_contour_index(resampled, (float(c[0]), float(c[1]))) for c in primary.corners]
+    if len(set(corner_idx)) < 4:
+        return None
+
+    # Corners are clockwise from top-left; verify the snapped indices advance
+    # cyclically in contour order (they must, given the winding fix).
+    forward = [(corner_idx[(j + 1) % 4] - corner_idx[j]) % SPLIT_RESAMPLE_POINTS for j in range(4)]
+    if sum(forward) != SPLIT_RESAMPLE_POINTS:
+        return None
+
+    centroid = resampled.mean(axis=0)
+    rot_steps = (rotation // 90) % 4
+
+    edges: Dict[str, Dict[str, Any]] = {}
+    for j in range(4):
+        arc = _arc_slice(resampled, corner_idx[j], corner_idx[(j + 1) % 4])
+        # Image-frame arc j (N,E,S,W for an upright piece); a piece
+        # photographed rotated clockwise by rot_steps has its grid-frame
+        # directions shifted back by the same amount.
+        direction = DIRECTIONS[(j - rot_steps) % 4]
+        edge_type, dominant_dev, max_dev, min_dev, chord_length = classify_arc(arc, centroid)
+        polyline = resample_polyline(arc, EDGE_POLYLINE_POINTS)
+        edges[direction] = {
+            "type": edge_type,
+            "dominant_dev": dominant_dev,
+            "max_dev": max_dev,
+            "min_dev": min_dev,
+            "chord_length_px": chord_length,
+            "polyline": polyline.tolist(),
+        }
+
+    return edges, primary, disagreement
+
+
+def _print_histogram(values: List[float], bin_width: float = 0.02) -> None:
+    """Print an ASCII histogram of |dominant deviation| values.
+
+    Args:
+        values: The |dominant_dev| values across all edges.
+        bin_width: Histogram bin width.
+    """
+    arr = np.array(values)
+    top = float(arr.max()) if len(arr) else 0.0
+    n_bins = int(np.ceil(top / bin_width)) + 1
+    counts, _ = np.histogram(arr, bins=n_bins, range=(0.0, n_bins * bin_width))
+    peak = counts.max() if counts.max() > 0 else 1
+    print(f"\n|dominant_dev| distribution across {len(arr)} edges (bin width {bin_width}):")
+    for b, count in enumerate(counts):
+        lo = b * bin_width
+        bar = "#" * int(round(50 * count / peak))
+        print(f"  {lo:5.2f}-{lo + bin_width:4.2f}  {count:5d}  {bar}")
+
+
+def _load_clean_contour(contours_dir: Path, puzzle_id: str, piece_stem: str) -> Optional[np.ndarray]:
+    """Load a piece's clean rembg contour from the M1 outputs, if it exists.
+
+    Args:
+        contours_dir: The `outputs/contours` directory.
+        puzzle_id: The piece's puzzle id.
+        piece_stem: The piece's filename stem.
+
+    Returns:
+        Nx2 contour array in original image coordinates, or None when the
+        contour JSON is missing, has no rembg contour, or is not clean.
+    """
+    contour_path = contours_dir / puzzle_id / f"{piece_stem}.json"
+    if not contour_path.exists():
+        return None
+    with open(contour_path, encoding="utf-8") as handle:
+        data = json.load(handle)
+    rembg = data["methods"].get("rembg")
+    if not rembg or not rembg.get("contour") or not rembg["quality"]["is_clean"]:
+        return None
+    return np.array(rembg["contour"], dtype=np.float64)
+
+
+def _write_piece_record(
+    records_dir: Path,
+    record: PieceRecord,
+    edges: Dict[str, Dict[str, Any]],
+    corner_result: CornerResult,
+    disagreement: bool,
+) -> None:
+    """Write one piece-record JSON.
+
+    Args:
+        records_dir: The `outputs/piece_records` directory.
+        record: The piece's metadata row (`PieceRecord`).
+        edges: Per-direction edge dicts from `split_piece`.
+        corner_result: The polydp corner result.
+        disagreement: The corner_disagreement flag.
+    """
+    piece_record = {
+        "puzzle_id": record.puzzle_id,
+        "piece_file": record.piece_file,
+        "row": record.row,
+        "col": record.col,
+        "rows": record.rows,
+        "cols": record.cols,
+        "background": record.background,
+        "rotation": record.rotation,
+        "corners": corner_result.corners.tolist(),
+        "corner_confidences": corner_result.confidences,
+        "corner_disagreement": disagreement,
+        "edges": edges,
+    }
+    puzzle_dir = records_dir / record.puzzle_id
+    puzzle_dir.mkdir(parents=True, exist_ok=True)
+    with open(puzzle_dir / f"{record.piece_stem}.json", "w", encoding="utf-8") as handle:
+        json.dump(piece_record, handle)
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Split clean contours into classified N/E/S/W edges.")
+    parser.add_argument("--dataset-root", type=Path, default=DEFAULT_DATASET_ROOT)
+    parser.add_argument("--contours-dir", type=Path, default=Path(__file__).parent / "outputs" / "contours")
+    parser.add_argument("--output-dir", type=Path, default=Path(__file__).parent / "outputs")
+    parser.add_argument("--puzzle", type=str, default=None, help="Substring filter on puzzle_id")
+    parser.add_argument("--background", type=str, default=None, help="Exact filter on background")
+    args = parser.parse_args()
+
+    records = load_metadata(args.dataset_root)
+    if args.puzzle:
+        records = [r for r in records if args.puzzle in r.puzzle_id]
+    if args.background:
+        records = [r for r in records if r.background == args.background]
+
+    nonzero_rotations = [r for r in records if r.rotation != 0]
+    if nonzero_rotations:
+        print(f"NOTE: {len(nonzero_rotations)} pieces have rotation != 0; direction mapping is shifted for them.")
+
+    records_dir = args.output_dir / "piece_records"
+    records_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = args.output_dir / "edge_summary.csv"
+
+    n_processed = 0
+    n_skipped_dirty = 0
+    n_failed = 0
+    n_disagreement = 0
+    dominant_values: List[float] = []
+
+    with open(summary_path, "w", newline="", encoding="utf-8") as summary_file:
+        writer = csv.DictWriter(
+            summary_file,
+            fieldnames=["puzzle", "piece", "background", "direction", "type", "dominant_dev", "corner_disagreement"],
+        )
+        writer.writeheader()
+
+        for record in records:
+            contour = _load_clean_contour(args.contours_dir, record.puzzle_id, record.piece_stem)
+            if contour is None:
+                n_skipped_dirty += 1
+                continue
+
+            result = split_piece(contour, record.rotation)
+            if result is None:
+                n_failed += 1
+                continue
+            edges, corner_result, disagreement = result
+            n_disagreement += int(disagreement)
+
+            _write_piece_record(records_dir, record, edges, corner_result, disagreement)
+            for direction in DIRECTIONS:
+                edge = edges[direction]
+                dominant_values.append(abs(edge["dominant_dev"]))
+                writer.writerow(
+                    {
+                        "puzzle": record.puzzle_id,
+                        "piece": record.piece_stem,
+                        "background": record.background,
+                        "direction": direction,
+                        "type": edge["type"],
+                        "dominant_dev": f"{edge['dominant_dev']:.4f}",
+                        "corner_disagreement": disagreement,
+                    }
+                )
+
+            n_processed += 1
+            if n_processed % 100 == 0:
+                print(f"  ...{n_processed} pieces split")
+
+    print(
+        f"\nDone. {n_processed} pieces split, {n_skipped_dirty} skipped (no clean contour), "
+        f"{n_failed} failed (corner detection/splitting), {n_disagreement} flagged corner_disagreement."
+    )
+    print(f"Records in {records_dir}, summary in {summary_path}")
+    _print_histogram(dominant_values)
+    print(f"\nFLAT_THRESHOLD = {FLAT_THRESHOLD}")
+
+
+if __name__ == "__main__":
+    main()

--- a/network/experiments/exp28_piece_geometry/edge_split.py
+++ b/network/experiments/exp28_piece_geometry/edge_split.py
@@ -45,7 +45,9 @@ from corner_detect import (
 )
 from scipy.optimize import linear_sum_assignment
 
-DEFAULT_DATASET_ROOT = Path("/Users/claus/Repos/pussel/network/datasets/north_star/v1")
+# Repo-relative default (this script lives in network/experiments/exp28_piece_geometry/,
+# so parents[2] is the network/ dir); override with --dataset-root.
+DEFAULT_DATASET_ROOT = Path(__file__).resolve().parents[2] / "datasets" / "north_star" / "v1"
 
 # Dense resampling used for edge splitting (finer than the detectors' 512).
 SPLIT_RESAMPLE_POINTS = 1024

--- a/network/experiments/exp28_piece_geometry/eval_corners.py
+++ b/network/experiments/exp28_piece_geometry/eval_corners.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""M2 evaluation + review: run corner detectors on real photos and (optionally) score them.
+
+For every piece with a clean rembg contour (from `extract_contours.py`
+output), runs the requested corner detector(s) and renders a per-puzzle x
+background contact sheet with the contour and each method's predicted
+corners overlaid, to `outputs/review_corners/{puzzle}_{background}.png`.
+
+When `--labels-file` (see `label_corners.py`) exists, also scores each
+method's predictions against the hand-labeled ground truth (same
+max-corner-error-over-diagonal metric as `synth_benchmark.py`) and writes
+`outputs/corner_eval.csv`.
+
+Usage:
+    cd network
+    uv run python experiments/exp28_piece_geometry/eval_corners.py --limit 8
+    uv run python experiments/exp28_piece_geometry/eval_corners.py \
+        --labels-file outputs/corner_labels.json --method all
+"""
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import cv2
+import numpy as np
+from common import PieceRecord, crop_with_margin, load_metadata
+from corner_detect import (
+    CornerResult,
+    InsufficientCornersError,
+    detect_corners_curvature,
+    detect_corners_polydp,
+    detect_corners_shitomasi,
+)
+from synth_benchmark import score_corners
+
+DEFAULT_DATASET_ROOT = Path("/Users/claus/Repos/pussel/network/datasets/north_star/v1")
+ALL_METHODS = ("curvature", "polydp", "shitomasi")
+METHOD_COLORS = {  # BGR
+    "curvature": (0, 0, 255),
+    "polydp": (255, 128, 0),
+    "shitomasi": (255, 0, 255),
+}
+CELL_WIDTH = 260
+HEADER_HEIGHT = 24
+TITLE_HEIGHT = 18
+
+
+def _run_detector(method: str, contour: np.ndarray, image_shape: Tuple[int, int]) -> Optional[CornerResult]:
+    """Run one named detector on a contour, returning None on failure.
+
+    Args:
+        method: One of "curvature", "polydp", "shitomasi".
+        contour: Nx2 contour points in original image coordinates.
+        image_shape: (height, width) of the source photo, used by "shitomasi".
+
+    Returns:
+        The `CornerResult`, or None when the detector could not find 4 corners.
+    """
+    try:
+        if method == "curvature":
+            return detect_corners_curvature(contour)
+        if method == "polydp":
+            return detect_corners_polydp(contour)
+        if method == "shitomasi":
+            return detect_corners_shitomasi(contour, image_shape)
+    except InsufficientCornersError:
+        return None
+    raise ValueError(f"Unknown method: {method}")
+
+
+def _order_by_angle(pts: np.ndarray) -> np.ndarray:
+    """Order 4 points around their centroid so opposite indices (0,2) are true diagonal corners.
+
+    Hand-labeled clicks arrive in whatever order the user clicked them; this
+    makes the ordering consistent (like the detectors' clockwise ordering) so
+    `score_corners`'s diagonal-distance computation is meaningful.
+
+    Args:
+        pts: 4x2 array of points, any order.
+
+    Returns:
+        4x2 array, reordered by angle around the centroid.
+    """
+    centroid = pts.mean(axis=0)
+    angles = np.arctan2(pts[:, 1] - centroid[1], pts[:, 0] - centroid[0])
+    return pts[np.argsort(angles)]
+
+
+def _load_piece_json(contours_dir: Path, record: PieceRecord) -> Optional[Dict[str, Any]]:
+    """Load a piece's saved contour JSON, if present.
+
+    Args:
+        contours_dir: The `outputs/contours` directory.
+        record: The piece's metadata row.
+
+    Returns:
+        The parsed JSON dict, or None.
+    """
+    path = contours_dir / record.puzzle_id / f"{record.piece_stem}.json"
+    if not path.exists():
+        return None
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _render_cell(
+    dataset_root: Path,
+    record: PieceRecord,
+    margin_frac: float,
+    contour: Optional[np.ndarray],
+    predictions: Dict[str, Optional[CornerResult]],
+) -> np.ndarray:
+    """Render one contact-sheet cell: piece crop, contour, and per-method corner dots.
+
+    Args:
+        dataset_root: The north_star dataset root.
+        record: The piece's metadata row.
+        margin_frac: Crop margin fraction matching `extract_contours.py`.
+        contour: The piece's rembg contour in original image coordinates, or
+            None if unavailable.
+        predictions: Per-method `CornerResult` (original image coordinates),
+            or None per method when detection failed.
+
+    Returns:
+        A fixed-size BGR image cell, including a title strip.
+    """
+    image = cv2.imread(str(dataset_root / record.piece_file))
+    crop, offset = crop_with_margin(image, record.bbox, margin_frac=margin_frac)
+    offset_arr = np.array(offset)
+
+    scale = CELL_WIDTH / crop.shape[1]
+    resized = cv2.resize(crop, (CELL_WIDTH, max(1, round(crop.shape[0] * scale))))
+
+    if contour is not None:
+        local = (contour - offset_arr) * scale
+        cv2.polylines(resized, [local.astype(np.int32)], isClosed=True, color=(200, 200, 200), thickness=1)
+
+    for method, result in predictions.items():
+        if result is None:
+            continue
+        color = METHOD_COLORS[method]
+        local_corners = (result.corners - offset_arr) * scale
+        for pt in local_corners.astype(np.int32):
+            cv2.circle(resized, tuple(pt), 5, color, -1, lineType=cv2.LINE_AA)
+
+    title = np.full((TITLE_HEIGHT, CELL_WIDTH, 3), 255, dtype=np.uint8)
+    label = f"r{record.row:02d}c{record.col:02d}"
+    cv2.putText(title, label, (2, TITLE_HEIGHT - 5), cv2.FONT_HERSHEY_SIMPLEX, 0.4, (0, 0, 0), 1, cv2.LINE_AA)
+
+    cell = np.full((TITLE_HEIGHT + resized.shape[0], CELL_WIDTH, 3), 255, dtype=np.uint8)
+    cell[:TITLE_HEIGHT] = title
+    cell[TITLE_HEIGHT : TITLE_HEIGHT + resized.shape[0]] = resized
+    return cell
+
+
+def _legend_header(width: int, methods: List[str]) -> np.ndarray:
+    """Render a header strip listing each method's marker color.
+
+    Args:
+        width: Header width in pixels (matches the sheet width).
+        methods: Method names to show in the legend.
+
+    Returns:
+        A BGR header image of shape (HEADER_HEIGHT, width, 3).
+    """
+    header = np.full((HEADER_HEIGHT, width, 3), 255, dtype=np.uint8)
+    x = 8
+    for method in methods:
+        color = METHOD_COLORS[method]
+        cv2.circle(header, (x, HEADER_HEIGHT // 2), 5, color, -1)
+        cv2.putText(
+            header, method, (x + 10, HEADER_HEIGHT // 2 + 5), cv2.FONT_HERSHEY_SIMPLEX, 0.45, (0, 0, 0), 1, cv2.LINE_AA
+        )
+        x += 12 * len(method) + 30
+    return header
+
+
+def build_corner_sheet(
+    dataset_root: Path,
+    contours_dir: Path,
+    records: List[PieceRecord],
+    methods: List[str],
+) -> np.ndarray:
+    """Build one puzzle x background corner-detection contact sheet.
+
+    Args:
+        dataset_root: The north_star dataset root.
+        contours_dir: The `outputs/contours` directory.
+        records: All piece records for this puzzle x background (one per grid cell).
+        methods: Detector methods to run and draw.
+
+    Returns:
+        The assembled BGR contact sheet image, including a legend header.
+    """
+    rows = records[0].rows
+    cols = records[0].cols
+    by_pos: Dict[Tuple[int, int], PieceRecord] = {(r.row, r.col): r for r in records}
+
+    cells: List[List[np.ndarray]] = []
+    cell_h = 0
+    for row in range(rows):
+        row_cells = []
+        for col in range(cols):
+            record = by_pos.get((row, col))
+            if record is None:
+                row_cells.append(np.full((TITLE_HEIGHT + CELL_WIDTH, CELL_WIDTH, 3), 128, dtype=np.uint8))
+                continue
+            data = _load_piece_json(contours_dir, record)
+            rembg = data["methods"].get("rembg") if data else None
+            margin_frac = data["piece"]["margin_frac"] if data else 0.15
+            contour = np.array(rembg["contour"]) if rembg and rembg.get("contour") else None
+            predictions: Dict[str, Optional[CornerResult]] = {}
+            if contour is not None and rembg["quality"]["is_clean"]:
+                image = cv2.imread(str(dataset_root / record.piece_file))
+                for method in methods:
+                    predictions[method] = _run_detector(method, contour, image.shape[:2])
+            cell = _render_cell(dataset_root, record, margin_frac, contour, predictions)
+            cell_h = max(cell_h, cell.shape[0])
+            row_cells.append(cell)
+        cells.append(row_cells)
+
+    sheet_rows = []
+    for row_cells in cells:
+        padded = []
+        for cell in row_cells:
+            if cell.shape[0] < cell_h:
+                pad = np.full((cell_h - cell.shape[0], CELL_WIDTH, 3), 255, dtype=np.uint8)
+                cell = np.vstack([cell, pad])
+            padded.append(cell)
+        sheet_rows.append(np.hstack(padded))
+
+    grid = np.vstack(sheet_rows)
+    header = _legend_header(grid.shape[1], methods)
+    return np.vstack([header, grid])
+
+
+def evaluate_against_labels(
+    dataset_root: Path,
+    contours_dir: Path,
+    records: List[PieceRecord],
+    methods: List[str],
+    labels: Dict[str, Any],
+) -> Dict[Tuple[str, str], List[float]]:
+    """Score each method's predictions against hand-labeled ground truth.
+
+    Args:
+        dataset_root: The north_star dataset root.
+        contours_dir: The `outputs/contours` directory.
+        records: Pieces to evaluate.
+        methods: Detector methods to score.
+        labels: The loaded labels dict, keyed by piece_file.
+
+    Returns:
+        Dict mapping (method, background) to a list of per-piece max-error percentages.
+    """
+    errors: Dict[Tuple[str, str], List[float]] = defaultdict(list)
+    for record in records:
+        label = labels.get(record.piece_file)
+        if label is None:
+            continue
+        data = _load_piece_json(contours_dir, record)
+        rembg = data["methods"].get("rembg") if data else None
+        if not rembg or not rembg.get("contour") or not rembg["quality"]["is_clean"]:
+            continue
+        contour = np.array(rembg["contour"])
+        image = cv2.imread(str(dataset_root / record.piece_file))
+        gt_corners = _order_by_angle(np.array(label["corners"], dtype=np.float64))
+
+        for method in methods:
+            result = _run_detector(method, contour, image.shape[:2])
+            if result is None:
+                continue
+            error_pct = score_corners(result.corners, gt_corners)
+            errors[(method, record.background)].append(error_pct)
+    return errors
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Evaluate and review corner detectors on real piece photos.")
+    parser.add_argument("--contours-dir", type=Path, default=Path(__file__).parent / "outputs" / "contours")
+    parser.add_argument("--dataset-root", type=Path, default=DEFAULT_DATASET_ROOT)
+    parser.add_argument("--method", choices=[*ALL_METHODS, "all"], default="all")
+    parser.add_argument("--labels-file", type=Path, default=None)
+    parser.add_argument("--output-dir", type=Path, default=Path(__file__).parent / "outputs")
+    parser.add_argument("--puzzle", type=str, default=None, help="Substring filter on puzzle_id")
+    parser.add_argument("--background", type=str, default=None, help="Exact filter on background")
+    parser.add_argument("--max-sheets", type=int, default=None)
+    args = parser.parse_args()
+
+    methods = list(ALL_METHODS) if args.method == "all" else [args.method]
+
+    records = load_metadata(args.dataset_root)
+    if args.puzzle:
+        records = [r for r in records if args.puzzle in r.puzzle_id]
+    if args.background:
+        records = [r for r in records if r.background == args.background]
+
+    groups: Dict[Tuple[str, str], List[PieceRecord]] = defaultdict(list)
+    for record in records:
+        groups[(record.puzzle_id, record.background)].append(record)
+
+    review_dir = args.output_dir / "review_corners"
+    review_dir.mkdir(parents=True, exist_ok=True)
+
+    n_sheets = 0
+    for (puzzle_id, background), group_records in sorted(groups.items()):
+        if args.max_sheets is not None and n_sheets >= args.max_sheets:
+            break
+        sheet = build_corner_sheet(args.dataset_root, args.contours_dir, group_records, methods)
+        out_path = review_dir / f"{puzzle_id}_{background}.png"
+        cv2.imwrite(str(out_path), sheet)
+        print(f"Wrote {out_path} ({sheet.shape[1]}x{sheet.shape[0]}, {len(group_records)} pieces)")
+        n_sheets += 1
+
+    if args.labels_file is None or not args.labels_file.exists():
+        print("\nNo labels file given (or not found yet) -- skipping quantitative evaluation.")
+        return
+
+    with open(args.labels_file, encoding="utf-8") as handle:
+        labels = json.load(handle)
+
+    errors = evaluate_against_labels(args.dataset_root, args.contours_dir, records, methods, labels)
+
+    csv_path = args.output_dir / "corner_eval.csv"
+    with open(csv_path, "w", encoding="utf-8") as handle:
+        handle.write("method,background,n,median_error_pct,mean_error_pct,pct_le_3\n")
+        print(f"\n{'method':<12}{'background':<14}{'n':<6}{'median err%':<14}{'mean err%':<14}{'<=3% err':<10}")
+        for (method, background), values in sorted(errors.items()):
+            if not values:
+                continue
+            median_err = float(np.median(values))
+            mean_err = float(np.mean(values))
+            pct_le_3 = 100.0 * sum(1 for v in values if v <= 3.0) / len(values)
+            print(f"{method:<12}{background:<14}{len(values):<6}{median_err:<14.2f}{mean_err:<14.2f}{pct_le_3:<10.1f}")
+            handle.write(f"{method},{background},{len(values)},{median_err:.3f},{mean_err:.3f},{pct_le_3:.1f}\n")
+    print(f"\nWrote {csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/network/experiments/exp28_piece_geometry/eval_corners.py
+++ b/network/experiments/exp28_piece_geometry/eval_corners.py
@@ -36,7 +36,9 @@ from corner_detect import (
 )
 from synth_benchmark import score_corners
 
-DEFAULT_DATASET_ROOT = Path("/Users/claus/Repos/pussel/network/datasets/north_star/v1")
+# Repo-relative default (this script lives in network/experiments/exp28_piece_geometry/,
+# so parents[2] is the network/ dir); override with --dataset-root.
+DEFAULT_DATASET_ROOT = Path(__file__).resolve().parents[2] / "datasets" / "north_star" / "v1"
 ALL_METHODS = ("curvature", "polydp", "shitomasi")
 METHOD_COLORS = {  # BGR
     "curvature": (0, 0, 255),

--- a/network/experiments/exp28_piece_geometry/eval_edges.py
+++ b/network/experiments/exp28_piece_geometry/eval_edges.py
@@ -33,7 +33,9 @@ import cv2
 import numpy as np
 from common import PieceRecord, assemble_grid_sheet, crop_with_margin, load_metadata, make_titled_cell
 
-DEFAULT_DATASET_ROOT = Path("/Users/claus/Repos/pussel/network/datasets/north_star/v1")
+# Repo-relative default (this script lives in network/experiments/exp28_piece_geometry/,
+# so parents[2] is the network/ dir); override with --dataset-root.
+DEFAULT_DATASET_ROOT = Path(__file__).resolve().parents[2] / "datasets" / "north_star" / "v1"
 DIRECTIONS = ("N", "E", "S", "W")
 EDGE_COLORS = {  # BGR
     "flat": (0, 255, 255),

--- a/network/experiments/exp28_piece_geometry/eval_edges.py
+++ b/network/experiments/exp28_piece_geometry/eval_edges.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""M3 evaluation: score edge classifications against near-free grid ground truth.
+
+Evaluates the `edge_split.py` piece records three ways:
+
+1. **Flat accuracy** (absolute GT): an edge is truly flat iff it faces the
+   puzzle border (row 0 -> N, last row -> S, col 0 -> W, last col -> E).
+   Reports the flat-vs-nonflat confusion overall, per background, and per
+   puzzle. This is the headline >=98% criterion.
+2. **Cross-background consistency**: a physical piece's 4-edge type
+   signature (N,E,S,W) must be identical across its clean records.
+3. **Neighbor complementarity** (within each background): (r,c) East must
+   complement (r,c+1) West (tab<->blank), and (r,c) South <-> (r+1,c) North.
+
+Also renders per-puzzle x background review sheets (flat=yellow, tab=green,
+blank=red arcs, white corner dots, red cell border on corner_disagreement)
+to `outputs/review_edges/`, prints a final summary block, and writes the
+same numbers to `outputs/edge_eval.json`.
+
+Usage:
+    cd network
+    uv run python experiments/exp28_piece_geometry/eval_edges.py
+    uv run python experiments/exp28_piece_geometry/eval_edges.py --puzzle bambi --max-sheets 2
+"""
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import cv2
+import numpy as np
+from common import PieceRecord, assemble_grid_sheet, crop_with_margin, load_metadata, make_titled_cell
+
+DEFAULT_DATASET_ROOT = Path("/Users/claus/Repos/pussel/network/datasets/north_star/v1")
+DIRECTIONS = ("N", "E", "S", "W")
+EDGE_COLORS = {  # BGR
+    "flat": (0, 255, 255),
+    "tab": (0, 200, 0),
+    "blank": (0, 0, 220),
+}
+CELL_WIDTH = 260
+DISAGREEMENT_BORDER = (0, 0, 255)
+
+
+def _gt_flat(record: Dict[str, Any], direction: str) -> bool:
+    """Whether an edge is truly flat, from the piece's grid position.
+
+    Args:
+        record: A piece record (needs row/col/rows/cols).
+        direction: One of N/E/S/W.
+
+    Returns:
+        True iff the edge faces the puzzle border.
+    """
+    if direction == "N":
+        return record["row"] == 0
+    if direction == "S":
+        return record["row"] == record["rows"] - 1
+    if direction == "W":
+        return record["col"] == 0
+    return record["col"] == record["cols"] - 1
+
+
+def load_piece_records(records_dir: Path, puzzle: Optional[str]) -> List[Dict[str, Any]]:
+    """Load all piece-record JSONs written by edge_split.py.
+
+    Args:
+        records_dir: The `outputs/piece_records` directory.
+        puzzle: Optional substring filter on puzzle_id.
+
+    Returns:
+        The parsed records.
+    """
+    records: List[Dict[str, Any]] = []
+    for path in sorted(records_dir.glob("*/*.json")):
+        with open(path, encoding="utf-8") as handle:
+            record = json.load(handle)
+        if puzzle and puzzle not in record["puzzle_id"]:
+            continue
+        records.append(record)
+    return records
+
+
+def flat_confusion(records: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    """Compute the flat-vs-nonflat confusion, overall / per background / per puzzle.
+
+    Args:
+        records: All piece records.
+
+    Returns:
+        Dict mapping scope name ("overall", "bg:<background>", "puzzle:<id>")
+        to {tp, fn, fp, tn, accuracy}.
+    """
+    counters: Dict[str, Counter] = defaultdict(Counter)
+    for record in records:
+        for direction in DIRECTIONS:
+            gt = _gt_flat(record, direction)
+            pred = record["edges"][direction]["type"] == "flat"
+            key = ("tp" if pred else "fn") if gt else ("fp" if pred else "tn")
+            counters["overall"][key] += 1
+            counters[f"bg:{record['background']}"][key] += 1
+            counters[f"puzzle:{record['puzzle_id']}"][key] += 1
+
+    out: Dict[str, Dict[str, Any]] = {}
+    for scope, counts in counters.items():
+        total = sum(counts.values())
+        correct = counts["tp"] + counts["tn"]
+        out[scope] = {**{k: counts[k] for k in ("tp", "fn", "fp", "tn")}, "accuracy": correct / total}
+    return out
+
+
+def cross_background_consistency(records: List[Dict[str, Any]]) -> Tuple[float, int, int, List[Tuple[str, int]]]:
+    """Check that each physical piece's edge-type signature agrees across backgrounds.
+
+    Args:
+        records: All piece records.
+
+    Returns:
+        Tuple of (fraction of multi-record pieces fully consistent, number of
+        consistent pieces, number of pieces compared, most common
+        inconsistency patterns as (description, count)).
+    """
+    by_piece: Dict[Tuple[str, int, int], List[Tuple[str, ...]]] = defaultdict(list)
+    for record in records:
+        signature = tuple(record["edges"][d]["type"] for d in DIRECTIONS)
+        by_piece[(record["puzzle_id"], record["row"], record["col"])].append(signature)
+
+    n_compared = 0
+    n_consistent = 0
+    patterns: Counter = Counter()
+    for signatures in by_piece.values():
+        if len(signatures) < 2:
+            continue
+        n_compared += 1
+        if len(set(signatures)) == 1:
+            n_consistent += 1
+            continue
+        majority = Counter(signatures).most_common(1)[0][0]
+        for sig in set(signatures):
+            if sig == majority:
+                continue
+            for d, (a, b) in zip(DIRECTIONS, zip(majority, sig)):
+                if a != b:
+                    patterns[f"{d}: {a}->{b}"] += 1
+    rate = n_consistent / n_compared if n_compared else 1.0
+    return rate, n_consistent, n_compared, patterns.most_common(5)
+
+
+COMPLEMENT = {("tab", "blank"), ("blank", "tab")}
+
+
+def neighbor_complementarity(records: List[Dict[str, Any]]) -> Dict[str, Tuple[int, int]]:
+    """Check tab<->blank complementarity between adjacent pieces, per background.
+
+    Args:
+        records: All piece records.
+
+    Returns:
+        Dict mapping background to (complementary pairs, compared pairs).
+    """
+    by_key: Dict[Tuple[str, str], Dict[Tuple[int, int], Dict[str, Any]]] = defaultdict(dict)
+    for record in records:
+        by_key[(record["puzzle_id"], record["background"])][(record["row"], record["col"])] = record
+
+    results: Dict[str, List[int]] = defaultdict(lambda: [0, 0])
+    for (_puzzle_id, background), grid in by_key.items():
+        for (row, col), record in grid.items():
+            east_neighbor = grid.get((row, col + 1))
+            if east_neighbor is not None:
+                pair = (record["edges"]["E"]["type"], east_neighbor["edges"]["W"]["type"])
+                results[background][1] += 1
+                if pair in COMPLEMENT:
+                    results[background][0] += 1
+            south_neighbor = grid.get((row + 1, col))
+            if south_neighbor is not None:
+                pair = (record["edges"]["S"]["type"], south_neighbor["edges"]["N"]["type"])
+                results[background][1] += 1
+                if pair in COMPLEMENT:
+                    results[background][0] += 1
+    return {bg: (v[0], v[1]) for bg, v in results.items()}
+
+
+def render_sheets(
+    dataset_root: Path,
+    records: List[Dict[str, Any]],
+    meta_by_file: Dict[str, PieceRecord],
+    output_dir: Path,
+    max_sheets: Optional[int],
+) -> None:
+    """Render per-puzzle x background edge-type review sheets.
+
+    Args:
+        dataset_root: The north_star dataset root.
+        records: All piece records.
+        meta_by_file: Metadata rows keyed by piece_file (for bbox/margin crop).
+        output_dir: The experiment outputs directory.
+        max_sheets: Optional cap on the number of sheets rendered.
+    """
+    review_dir = output_dir / "review_edges"
+    review_dir.mkdir(parents=True, exist_ok=True)
+
+    groups: Dict[Tuple[str, str], List[Dict[str, Any]]] = defaultdict(list)
+    for record in records:
+        groups[(record["puzzle_id"], record["background"])].append(record)
+
+    n_sheets = 0
+    for (puzzle_id, background), group in sorted(groups.items()):
+        if max_sheets is not None and n_sheets >= max_sheets:
+            break
+        cells: Dict[Tuple[int, int], np.ndarray] = {}
+        for record in group:
+            meta = meta_by_file[record["piece_file"]]
+            image = cv2.imread(str(dataset_root / record["piece_file"]))
+            crop, offset = crop_with_margin(image, meta.bbox, margin_frac=0.15)
+            offset_arr = np.array(offset, dtype=np.float64)
+
+            for direction in DIRECTIONS:
+                edge = record["edges"][direction]
+                polyline = (np.array(edge["polyline"]) - offset_arr).astype(np.int32)
+                cv2.polylines(crop, [polyline], isClosed=False, color=EDGE_COLORS[edge["type"]], thickness=3)
+            for corner in np.array(record["corners"]) - offset_arr:
+                cv2.circle(crop, (int(corner[0]), int(corner[1])), 6, (255, 255, 255), -1, lineType=cv2.LINE_AA)
+            if record["corner_disagreement"]:
+                cv2.rectangle(crop, (0, 0), (crop.shape[1] - 1, crop.shape[0] - 1), DISAGREEMENT_BORDER, 6)
+
+            label = f"r{record['row']:02d}c{record['col']:02d}"
+            cells[(record["row"], record["col"])] = make_titled_cell(crop, label, CELL_WIDTH)
+
+        rows = group[0]["rows"]
+        cols = group[0]["cols"]
+        sheet = assemble_grid_sheet(cells, rows, cols, CELL_WIDTH)
+        out_path = review_dir / f"{puzzle_id}_{background}.png"
+        cv2.imwrite(str(out_path), sheet)
+        print(f"Wrote {out_path} ({sheet.shape[1]}x{sheet.shape[0]}, {len(group)} pieces)")
+        n_sheets += 1
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Evaluate edge classifications against grid ground truth.")
+    parser.add_argument("--dataset-root", type=Path, default=DEFAULT_DATASET_ROOT)
+    parser.add_argument("--records-dir", type=Path, default=Path(__file__).parent / "outputs" / "piece_records")
+    parser.add_argument("--output-dir", type=Path, default=Path(__file__).parent / "outputs")
+    parser.add_argument("--puzzle", type=str, default=None, help="Substring filter on puzzle_id")
+    parser.add_argument("--max-sheets", type=int, default=None)
+    parser.add_argument("--no-sheets", action="store_true", help="Skip rendering review sheets")
+    args = parser.parse_args()
+
+    records = load_piece_records(args.records_dir, args.puzzle)
+    if not records:
+        print("No piece records found - run edge_split.py first.")
+        return
+    print(f"Loaded {len(records)} piece records ({4 * len(records)} edges)")
+
+    metadata = load_metadata(args.dataset_root)
+    meta_by_file = {m.piece_file: m for m in metadata}
+
+    if not args.no_sheets:
+        render_sheets(args.dataset_root, records, meta_by_file, args.output_dir, args.max_sheets)
+
+    confusion = flat_confusion(records)
+    consistency_rate, n_consistent, n_compared, patterns = cross_background_consistency(records)
+    complementarity = neighbor_complementarity(records)
+
+    print("\n================ M3 edge evaluation summary ================")
+    overall = confusion["overall"]
+    print(
+        f"Flat accuracy (overall): {overall['accuracy'] * 100:.2f}%  "
+        f"[tp={overall['tp']} fn={overall['fn']} fp={overall['fp']} tn={overall['tn']}]"
+    )
+    print("Flat accuracy per background:")
+    for scope in sorted(s for s in confusion if s.startswith("bg:")):
+        c = confusion[scope]
+        print(f"  {scope[3:]:<12} {c['accuracy'] * 100:6.2f}%  [tp={c['tp']} fn={c['fn']} fp={c['fp']} tn={c['tn']}]")
+    print("Flat accuracy per puzzle:")
+    for scope in sorted(s for s in confusion if s.startswith("puzzle:")):
+        c = confusion[scope]
+        print(f"  {scope[7:]:<24} {c['accuracy'] * 100:6.2f}%  [fn={c['fn']} fp={c['fp']}]")
+    print(
+        f"Cross-background consistency: {consistency_rate * 100:.2f}% "
+        f"({n_consistent}/{n_compared} pieces fully consistent)"
+    )
+    if patterns:
+        print(f"  Most common inconsistencies (majority->minority): {patterns}")
+    print("Neighbor complementarity per background:")
+    comp_summary = {}
+    for background, (good, total) in sorted(complementarity.items()):
+        pct = 100.0 * good / total if total else 0.0
+        comp_summary[background] = {"complementary": good, "pairs": total, "rate": good / total if total else None}
+        print(f"  {background:<12} {pct:6.2f}%  ({good}/{total} adjacent pairs)")
+    print("=============================================================")
+
+    eval_path = args.output_dir / "edge_eval.json"
+    with open(eval_path, "w", encoding="utf-8") as handle:
+        json.dump(
+            {
+                "n_records": len(records),
+                "flat_confusion": confusion,
+                "cross_background_consistency": {
+                    "rate": consistency_rate,
+                    "consistent": n_consistent,
+                    "compared": n_compared,
+                    "top_inconsistencies": patterns,
+                },
+                "neighbor_complementarity": comp_summary,
+            },
+            handle,
+            indent=2,
+        )
+    print(f"Wrote {eval_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/network/experiments/exp28_piece_geometry/eval_matching.py
+++ b/network/experiments/exp28_piece_geometry/eval_matching.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+"""M4 evaluation: rank the true mating edge among all type-compatible edges.
+
+Protocol, per puzzle x background (within one background only):
+- Queries: every interior edge (grid position says it has a true neighbor)
+  of every piece with a clean M3 record.
+- Candidate pool: ALL type-compatible edges of all OTHER pieces in the same
+  puzzle x background (not restricted to the mating compass direction).
+- True mate: the neighboring piece's facing edge (E of (r,c) <-> W of
+  (r,c+1), S <-> N of (r+1,c)). Queries whose neighbor record is missing are
+  skipped and counted separately; a true mate excluded by the tab<->blank
+  type gate counts as rank = pool size + 1.
+
+Reports per metric (l2, chamfer, scalar6, l2_chord): top-1/3/5 %, median
+rank, mean pool size - overall, per background, per puzzle. The main
+configuration EXCLUDES records flagged corner_disagreement; a second pass
+INCLUDES them to quantify the quality gate. Also reports genuine vs
+impostor distance stats and the median best-impostor/true-mate margin for
+the best metric, renders review sheets to `outputs/review_matching/`, and
+writes everything to `outputs/matching_eval.json`.
+
+Usage:
+    cd network
+    uv run python experiments/exp28_piece_geometry/eval_matching.py
+    uv run python experiments/exp28_piece_geometry/eval_matching.py --puzzle bambi --max-sheets 2
+"""
+
+import argparse
+import json
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402  (backend must be set first)
+import numpy as np  # noqa: E402
+from edge_match import (  # noqa: E402
+    COMPATIBLE_TYPES,
+    canonicalize_edge,
+    chord_penalty,
+    dist_chamfer,
+    dist_l2,
+    dist_scalar6,
+    edge_features,
+    flip_edge,
+    mirror_features,
+)
+
+DIRECTIONS = ("N", "E", "S", "W")
+NEIGHBOR_OF = {"N": (-1, 0, "S"), "E": (0, 1, "W"), "S": (1, 0, "N"), "W": (0, -1, "E")}
+METRICS = ("l2", "chamfer", "scalar6", "l2_chord")
+MAX_QUERIES_PER_SHEET = 12
+
+
+@dataclass
+class EdgeEntry:
+    """One edge of one piece record, with all match-ready representations.
+
+    Attributes:
+        puzzle_id: The puzzle this edge belongs to.
+        background: The background of the photo.
+        row: Piece grid row.
+        col: Piece grid column.
+        direction: Edge direction (N/E/S/W).
+        edge_type: Predicted type (tab/blank/flat).
+        chord_px: Chord length in original-image pixels.
+        canonical: 100x2 canonical polyline.
+        flipped: 100x2 mate-frame polyline (`flip_edge` of `canonical`).
+        features: 6-feature vector.
+        features_mirrored: Mirrored 6-feature vector.
+        disagreement: The piece's corner_disagreement flag.
+    """
+
+    puzzle_id: str
+    background: str
+    row: int
+    col: int
+    direction: str
+    edge_type: str
+    chord_px: float
+    canonical: np.ndarray
+    flipped: np.ndarray
+    features: np.ndarray
+    features_mirrored: np.ndarray
+    disagreement: bool
+
+
+@dataclass
+class QueryResult:
+    """Outcome of ranking one query edge's true mate.
+
+    Attributes:
+        query: The query edge.
+        mate: The true mate edge.
+        pool_size: Number of candidates scored.
+        ranks: Per-metric rank of the true mate (1-based; pool_size + 1 when
+            the mate was gated out of the pool).
+        mate_distances: Per-metric distance to the true mate (None when gated out).
+        best_impostor_distances: Per-metric best (lowest) impostor distance.
+        best_impostors: Per-metric best-scoring impostor entry.
+    """
+
+    query: EdgeEntry
+    mate: EdgeEntry
+    pool_size: int
+    ranks: Dict[str, int]
+    mate_distances: Dict[str, Optional[float]]
+    best_impostor_distances: Dict[str, Optional[float]]
+    best_impostors: Dict[str, Optional[EdgeEntry]]
+
+
+def load_edge_entries(records_dir: Path, puzzle: Optional[str]) -> Tuple[List[EdgeEntry], Dict[str, Any]]:
+    """Load M3 piece records and precompute match representations for every edge.
+
+    Args:
+        records_dir: The `outputs/piece_records` directory.
+        puzzle: Optional substring filter on puzzle_id.
+
+    Returns:
+        Tuple of (all edge entries, {puzzle_id: (rows, cols)}).
+    """
+    entries: List[EdgeEntry] = []
+    grid_dims: Dict[str, Any] = {}
+    for path in sorted(records_dir.glob("*/*.json")):
+        with open(path, encoding="utf-8") as handle:
+            record = json.load(handle)
+        if puzzle and puzzle not in record["puzzle_id"]:
+            continue
+        grid_dims[record["puzzle_id"]] = (record["rows"], record["cols"])
+        for direction in DIRECTIONS:
+            edge = record["edges"][direction]
+            polyline = np.array(edge["polyline"], dtype=np.float64)
+            canonical = canonicalize_edge(polyline)
+            features = edge_features(canonical, edge["chord_length_px"])
+            entries.append(
+                EdgeEntry(
+                    puzzle_id=record["puzzle_id"],
+                    background=record["background"],
+                    row=record["row"],
+                    col=record["col"],
+                    direction=direction,
+                    edge_type=edge["type"],
+                    chord_px=edge["chord_length_px"],
+                    canonical=canonical,
+                    flipped=flip_edge(canonical),
+                    features=features,
+                    features_mirrored=mirror_features(features),
+                    disagreement=record["corner_disagreement"],
+                )
+            )
+    return entries, grid_dims
+
+
+def _distance(metric: str, query: EdgeEntry, candidate: EdgeEntry) -> float:
+    """Compute one metric's distance from a query edge to a candidate edge.
+
+    Args:
+        metric: One of `METRICS`.
+        query: The query edge.
+        candidate: The candidate edge (its flipped/mirrored forms are used).
+
+    Returns:
+        The distance.
+    """
+    if metric == "l2":
+        return dist_l2(query.canonical, candidate.flipped)
+    if metric == "chamfer":
+        return dist_chamfer(query.canonical, candidate.flipped)
+    if metric == "scalar6":
+        return dist_scalar6(query.features, candidate.features_mirrored)
+    if metric == "l2_chord":
+        return dist_l2(query.canonical, candidate.flipped) + chord_penalty(query.chord_px, candidate.chord_px)
+    raise ValueError(f"Unknown metric: {metric}")
+
+
+def _is_interior(direction: str, row: int, col: int, rows: int, cols: int) -> bool:
+    """Whether an edge has a true neighbor per the grid position.
+
+    Args:
+        direction: Edge direction.
+        row: Piece row.
+        col: Piece col.
+        rows: Puzzle row count.
+        cols: Puzzle col count.
+
+    Returns:
+        True when the edge is interior.
+    """
+    dr, dc, _ = NEIGHBOR_OF[direction]
+    return 0 <= row + dr < rows and 0 <= col + dc < cols
+
+
+def run_queries(entries: List[EdgeEntry], grid_dims: Dict[str, Any]) -> Tuple[List[QueryResult], int, int]:
+    """Rank every interior query edge's true mate within its puzzle x background pool.
+
+    Args:
+        entries: All edge entries for this configuration.
+        grid_dims: {puzzle_id: (rows, cols)}.
+
+    Returns:
+        Tuple of (query results, queries skipped because the neighbor record
+        is missing, queries whose mate was type-gated out of the pool).
+    """
+    by_group: Dict[Tuple[str, str], Dict[Tuple[int, int, str], EdgeEntry]] = defaultdict(dict)
+    for entry in entries:
+        by_group[(entry.puzzle_id, entry.background)][(entry.row, entry.col, entry.direction)] = entry
+
+    results: List[QueryResult] = []
+    n_skipped_missing = 0
+    n_gated_out = 0
+
+    for (puzzle_id, _background), group in sorted(by_group.items()):
+        rows, cols = grid_dims[puzzle_id]
+        for (row, col, direction), query in sorted(group.items()):
+            if not _is_interior(direction, row, col, rows, cols):
+                continue
+            dr, dc, mate_dir = NEIGHBOR_OF[direction]
+            mate = group.get((row + dr, col + dc, mate_dir))
+            if mate is None:
+                n_skipped_missing += 1
+                continue
+
+            compatible = COMPATIBLE_TYPES[query.edge_type]
+            pool = [
+                entry
+                for entry in group.values()
+                if (entry.row, entry.col) != (row, col) and entry.edge_type in compatible
+            ]
+            mate_in_pool = any(entry is mate for entry in pool)
+            if not mate_in_pool:
+                n_gated_out += 1
+
+            ranks: Dict[str, int] = {}
+            mate_distances: Dict[str, Optional[float]] = {}
+            best_impostor_distances: Dict[str, Optional[float]] = {}
+            best_impostors: Dict[str, Optional[EdgeEntry]] = {}
+            for metric in METRICS:
+                distances = [(_distance(metric, query, entry), entry) for entry in pool]
+                impostors = [(d, e) for d, e in distances if e is not mate]
+                best_imp = min(impostors, key=lambda pair: pair[0]) if impostors else None
+                best_impostor_distances[metric] = best_imp[0] if best_imp else None
+                best_impostors[metric] = best_imp[1] if best_imp else None
+                if mate_in_pool:
+                    d_mate = next(d for d, e in distances if e is mate)
+                    mate_distances[metric] = d_mate
+                    ranks[metric] = 1 + sum(1 for d, e in distances if e is not mate and d < d_mate)
+                else:
+                    mate_distances[metric] = None
+                    ranks[metric] = len(pool) + 1
+
+            results.append(
+                QueryResult(
+                    query=query,
+                    mate=mate,
+                    pool_size=len(pool),
+                    ranks=ranks,
+                    mate_distances=mate_distances,
+                    best_impostor_distances=best_impostor_distances,
+                    best_impostors=best_impostors,
+                )
+            )
+
+    return results, n_skipped_missing, n_gated_out
+
+
+def summarize(results: List[QueryResult], key_fn: Callable[[QueryResult], str]) -> Dict[str, Dict[str, Any]]:
+    """Aggregate rank statistics per metric, grouped by a scope key.
+
+    Args:
+        results: Query results.
+        key_fn: Maps a result to its scope name ("overall", background, puzzle...).
+
+    Returns:
+        {scope: {metric: {top1, top3, top5, median_rank, n}, pool: mean pool size}}.
+    """
+    by_scope: Dict[str, List[QueryResult]] = defaultdict(list)
+    for result in results:
+        by_scope[key_fn(result)].append(result)
+
+    out: Dict[str, Dict[str, Any]] = {}
+    for scope, scoped in by_scope.items():
+        scope_stats: Dict[str, Any] = {
+            "n_queries": len(scoped),
+            "mean_pool": float(np.mean([r.pool_size for r in scoped])),
+        }
+        for metric in METRICS:
+            ranks = np.array([r.ranks[metric] for r in scoped])
+            scope_stats[metric] = {
+                "top1": float(np.mean(ranks <= 1)),
+                "top3": float(np.mean(ranks <= 3)),
+                "top5": float(np.mean(ranks <= 5)),
+                "median_rank": float(np.median(ranks)),
+            }
+        out[scope] = scope_stats
+    return out
+
+
+def genuine_impostor_stats(results: List[QueryResult], metric: str) -> Dict[str, Any]:
+    """Genuine vs impostor distance distributions for one metric.
+
+    Args:
+        results: Query results.
+        metric: The metric to analyze.
+
+    Returns:
+        Dict with genuine/impostor medians, the impostor 5th percentile,
+        overlap (% genuine above that percentile), and the median
+        best-impostor/true-mate distance margin.
+    """
+    genuine = np.array([r.mate_distances[metric] for r in results if r.mate_distances[metric] is not None])
+    impostor_best = np.array(
+        [r.best_impostor_distances[metric] for r in results if r.best_impostor_distances[metric] is not None]
+    )
+    margins = np.array(
+        [
+            r.best_impostor_distances[metric] / r.mate_distances[metric]
+            for r in results
+            if r.mate_distances[metric] and r.best_impostor_distances[metric] is not None
+        ]
+    )
+    impostor_p5 = float(np.percentile(impostor_best, 5)) if len(impostor_best) else float("nan")
+    overlap = float(np.mean(genuine > impostor_p5)) if len(genuine) else float("nan")
+    return {
+        "median_genuine": float(np.median(genuine)) if len(genuine) else None,
+        "median_best_impostor": float(np.median(impostor_best)) if len(impostor_best) else None,
+        "impostor_p5": impostor_p5,
+        "overlap_frac": overlap,
+        "median_margin": float(np.median(margins)) if len(margins) else None,
+    }
+
+
+def render_sheets(results: List[QueryResult], metric: str, output_dir: Path, max_sheets: Optional[int]) -> None:
+    """Render review sheets: query vs flipped true mate vs flipped best impostor.
+
+    Args:
+        results: Query results (main configuration).
+        metric: The metric whose best impostor is drawn.
+        output_dir: The experiment outputs directory.
+        max_sheets: Optional cap on sheets rendered.
+    """
+    review_dir = output_dir / "review_matching"
+    review_dir.mkdir(parents=True, exist_ok=True)
+
+    by_group: Dict[Tuple[str, str], List[QueryResult]] = defaultdict(list)
+    for result in results:
+        by_group[(result.query.puzzle_id, result.query.background)].append(result)
+
+    n_sheets = 0
+    for (puzzle_id, background), group in sorted(by_group.items()):
+        if max_sheets is not None and n_sheets >= max_sheets:
+            break
+        shown = group[:MAX_QUERIES_PER_SHEET]
+        fig, axes = plt.subplots(3, 4, figsize=(16, 10))
+        fig.suptitle(f"{puzzle_id} / {background} - metric {metric}")
+        for ax in axes.flat:
+            ax.axis("off")
+        for ax, result in zip(axes.flat, shown):
+            query = result.query
+            ax.plot(query.canonical[:, 0], query.canonical[:, 1], "b-", linewidth=2, label="query")
+            ax.plot(result.mate.flipped[:, 0], result.mate.flipped[:, 1], "g-", linewidth=1.5, label="true mate")
+            impostor = result.best_impostors[metric]
+            if impostor is not None:
+                ax.plot(impostor.flipped[:, 0], impostor.flipped[:, 1], "r--", linewidth=1.2, label="best impostor")
+            d_mate = result.mate_distances[metric]
+            d_imp = result.best_impostor_distances[metric]
+            title = (
+                f"r{query.row}c{query.col} {query.direction} rank={result.ranks[metric]}\n"
+                f"mate={d_mate:.3f} imp={d_imp:.3f}"
+                if d_mate is not None and d_imp is not None
+                else f"r{query.row}c{query.col} {query.direction} rank={result.ranks[metric]}"
+            )
+            ax.set_title(title, fontsize=8)
+            ax.set_aspect("equal")
+            ax.invert_yaxis()  # image convention: tabs (outward) point up visually
+            ax.axis("on")
+        handles, labels = axes.flat[0].get_legend_handles_labels()
+        fig.legend(handles, labels, loc="lower center", ncol=3)
+        out_path = review_dir / f"{puzzle_id}_{background}.png"
+        fig.savefig(out_path, dpi=90, bbox_inches="tight")
+        plt.close(fig)
+        print(f"Wrote {out_path} ({len(shown)} queries)")
+        n_sheets += 1
+
+
+def _print_metric_table(title: str, stats: Dict[str, Dict[str, Any]], scopes: List[str]) -> None:
+    """Print a per-scope x per-metric rank table.
+
+    Args:
+        title: Table heading.
+        stats: Output of `summarize`.
+        scopes: Scope names to print, in order.
+    """
+    print(f"\n{title}")
+    print(f"{'scope':<26}{'metric':<10}{'top1':>7}{'top3':>7}{'top5':>7}{'med.rank':>10}{'pool':>7}{'n':>6}")
+    for scope in scopes:
+        if scope not in stats:
+            continue
+        scope_stats = stats[scope]
+        for metric in METRICS:
+            m = scope_stats[metric]
+            print(
+                f"{scope:<26}{metric:<10}{m['top1'] * 100:6.1f}%{m['top3'] * 100:6.1f}%{m['top5'] * 100:6.1f}%"
+                f"{m['median_rank']:10.1f}{scope_stats['mean_pool']:7.1f}{scope_stats['n_queries']:6d}"
+            )
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Evaluate edge-mate ranking within puzzle x background pools.")
+    parser.add_argument("--records-dir", type=Path, default=Path(__file__).parent / "outputs" / "piece_records")
+    parser.add_argument("--output-dir", type=Path, default=Path(__file__).parent / "outputs")
+    parser.add_argument("--puzzle", type=str, default=None, help="Substring filter on puzzle_id")
+    parser.add_argument("--max-sheets", type=int, default=None)
+    parser.add_argument("--no-sheets", action="store_true", help="Skip rendering review sheets")
+    args = parser.parse_args()
+
+    entries, grid_dims = load_edge_entries(args.records_dir, args.puzzle)
+    if not entries:
+        print("No piece records found - run edge_split.py first.")
+        return
+
+    clean_entries = [e for e in entries if not e.disagreement]
+    print(f"Loaded {len(entries)} edges ({len(clean_entries)} from records without corner_disagreement)")
+
+    results, n_missing, n_gated = run_queries(clean_entries, grid_dims)
+    print(
+        f"Main config (exclude disagreement): {len(results)} queries, "
+        f"{n_missing} skipped (neighbor record missing), {n_gated} mates type-gated out"
+    )
+
+    overall = summarize(results, lambda r: "overall")
+    per_bg = summarize(results, lambda r: r.query.background)
+    per_puzzle = summarize(results, lambda r: f"{r.query.puzzle_id}|{r.query.background}")
+
+    _print_metric_table("=== Overall (exclude corner_disagreement) ===", overall, ["overall"])
+    _print_metric_table("=== Per background ===", per_bg, sorted(per_bg))
+
+    best_metric = max(METRICS, key=lambda m: overall["overall"][m]["top1"])
+    print(f"\nBest metric by overall top-1: {best_metric}")
+
+    print(f"\n=== Per puzzle x background ({best_metric}) ===")
+    print(f"{'puzzle|background':<44}{'top1':>7}{'top3':>7}{'med.rank':>10}{'pool':>7}{'n':>6}")
+    for scope in sorted(per_puzzle):
+        s = per_puzzle[scope]
+        m = s[best_metric]
+        print(
+            f"{scope:<44}{m['top1'] * 100:6.1f}%{m['top3'] * 100:6.1f}%{m['median_rank']:10.1f}"
+            f"{s['mean_pool']:7.1f}{s['n_queries']:6d}"
+        )
+
+    gi_stats = genuine_impostor_stats(results, best_metric)
+    print(
+        f"\nGenuine vs impostor ({best_metric}): median genuine={gi_stats['median_genuine']:.4f}, "
+        f"median best-impostor={gi_stats['median_best_impostor']:.4f}, impostor p5={gi_stats['impostor_p5']:.4f}, "
+        f"overlap={gi_stats['overlap_frac'] * 100:.1f}% of genuine above impostor p5, "
+        f"median margin (best impostor / true mate) = {gi_stats['median_margin']:.2f}x"
+    )
+
+    results_incl, n_missing_i, n_gated_i = run_queries(entries, grid_dims)
+    overall_incl = summarize(results_incl, lambda r: "overall")
+    print("\n=== Disagreement-gate delta (overall top-1) ===")
+    for metric in METRICS:
+        excl = overall["overall"][metric]["top1"] * 100
+        incl = overall_incl["overall"][metric]["top1"] * 100
+        print(
+            f"  {metric:<10} exclude: {excl:5.1f}% ({overall['overall']['n_queries']} q)   "
+            f"include: {incl:5.1f}% ({overall_incl['overall']['n_queries']} q)   delta: {incl - excl:+.1f}"
+        )
+
+    if not args.no_sheets:
+        render_sheets(results, best_metric, args.output_dir, args.max_sheets)
+
+    eval_path = args.output_dir / "matching_eval.json"
+    with open(eval_path, "w", encoding="utf-8") as handle:
+        json.dump(
+            {
+                "config_exclude_disagreement": {
+                    "n_queries": len(results),
+                    "skipped_missing_neighbor": n_missing,
+                    "mates_type_gated_out": n_gated,
+                    "overall": overall,
+                    "per_background": per_bg,
+                    "per_puzzle_background": per_puzzle,
+                },
+                "config_include_disagreement": {
+                    "n_queries": len(results_incl),
+                    "skipped_missing_neighbor": n_missing_i,
+                    "mates_type_gated_out": n_gated_i,
+                    "overall": overall_incl,
+                    "per_background": summarize(results_incl, lambda r: r.query.background),
+                },
+                "best_metric": best_metric,
+                "genuine_impostor": gi_stats,
+            },
+            handle,
+            indent=2,
+        )
+    print(f"\nWrote {eval_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/network/experiments/exp28_piece_geometry/eval_reid.py
+++ b/network/experiments/exp28_piece_geometry/eval_reid.py
@@ -1,0 +1,879 @@
+#!/usr/bin/env python3
+"""M6 evaluation: cross-background piece re-identification via shape + color rank fusion.
+
+Protocol: enroll every clean (non `corner_disagreement`) piece from ONE
+background (the gallery), then query with the SAME physical pieces
+photographed on each OTHER background - 4 x 3 = 12 (enroll, query) cells.
+For each query, nearest neighbor is found over the entire cross-puzzle
+gallery (the hard, primary setting; a secondary pass restricts the
+candidate pool to the query's own puzzle).
+
+Fingerprint fusion: M6's first iteration showed a linear z-score blend of
+shape and color distances degenerates to shape-only (the sweep chose w=1);
+iteration 2 fixed the combiner (reciprocal rank fusion) and the illuminant
+sensitivity (gray-world a*b*), reaching 86.1% headline top-1 with the
+residual failures dominated by rank-2/3 near-misses among same-palette
+pieces - which a GLOBAL histogram cannot separate. This iteration adds a
+SPATIAL color descriptor (3x3 grid of per-cell gray-world a*b* histograms
+over the piece bbox, rotation-consistent with the shape edge shift k) and
+compares three fusions:
+
+- "rrf_ab": RRF(shape, global ab_gw), c=5 - iteration 2's frozen champion,
+  the baseline to beat.
+- "rrf_sp": RRF(shape, spatial color), c swept over {5, 10}.
+- "rrf3": RRF(shape, global ab_gw, spatial color), same c for all terms,
+  c swept over {5, 10}.
+
+(rerank with K=5, iteration 2's frozen shortlist re-ranker, stays as an
+ablation row.) All hyperparameters are chosen ONCE using only the 3
+validation cells where the query background is "cardboard", then frozen -
+the 9 remaining cells are the headline, leakage-free numbers.
+
+Reports (print + `outputs/reid_eval.json`):
+    a. Ablation (shape-only, color variants incl. spatial, rerank, all RRF
+       fusions): top-1/top-5, aggregated over all 12 cells and over the 9
+       non-validation cells.
+    b. 12-cell (enroll x query) top-1 matrix for the winning fusion method.
+    c. Fixed-orientation vs rotation-invariant shape base, winner top-1.
+    d. Genuine/impostor stats for the winner + failure concentration by
+       query background and puzzle; plus an easier-context line excluding
+       wood-as-query cells (the real app scans on a gray mat).
+    e. Failure review sheet for the winner's worst cell:
+       `outputs/review_reid/failures_{enroll}_{query}.png`.
+    A secondary ablation table restricted to within-puzzle galleries.
+
+Usage:
+    cd network
+    uv run python experiments/exp28_piece_geometry/fingerprint.py   # build galleries first
+    uv run python experiments/exp28_piece_geometry/eval_reid.py
+"""
+
+import argparse
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import cv2
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402  (backend must be set first)
+import numpy as np  # noqa: E402
+from common import crop_with_margin, load_metadata  # noqa: E402
+from fingerprint import (  # noqa: E402
+    BACKGROUNDS,
+    PieceFingerprint,
+    build_gallery,
+    chi_square_distance_matrix,
+    load_gallery,
+    save_fingerprints,
+    shape_distance_matrix,
+    spatial_color_distance_matrix,
+)
+
+# Frozen from iteration 2's validation sweep: the rerank shortlist size and
+# the champion RRF(shape, ab_gw) c - the baseline the new candidates must beat.
+RERANK_K = 5.0
+RRF_AB_C = 5.0
+# Iteration 3 fusion candidates (validated on cardboard-as-query cells only).
+RRF_SPATIAL_C_SWEEP = (5.0, 10.0)
+COLOR_VARIANTS = ("ab", "ab_gw")
+VALIDATION_QUERY_BACKGROUND = "cardboard"
+
+# Scalar offset placed on out-of-top-K candidates in the rerank fusion
+# distance; chi-square color distances are <= 1, so any offset > 1 keeps
+# every out-of-K candidate strictly behind every in-K candidate.
+RERANK_OUT_OF_K_OFFSET = 10.0
+
+MAX_FAILURES_PER_SHEET = 12
+ABLATION_ROWS = (
+    ("shape_ri", "shape-only"),
+    ("color_lab", "color-lab"),
+    ("color_ab", "color-ab"),
+    ("color_ab_gw", "color-ab-gw"),
+    ("color_spatial", "spatial-color"),
+    ("fused_rerank", "shape+color-rerank"),
+    ("fused_rrf_ab", "RRF(shape,ab_gw)"),
+    ("fused_rrf_sp", "RRF(shape,spatial)"),
+    ("fused_rrf3", "RRF(shape,ab_gw,spatial)"),
+)
+
+FUSION_DISPLAY = {
+    "rerank": "shape+color-rerank",
+    "rrf_ab": "RRF(shape,ab_gw)",
+    "rrf_sp": "RRF(shape,spatial)",
+    "rrf3": "RRF(shape,ab_gw,spatial)",
+}
+
+
+@dataclass
+class GalleryArrays:
+    """Stacked, vectorization-ready arrays for one background's enrolled gallery.
+
+    Attributes:
+        identities: (puzzle_id, row, col) per gallery piece, aligned with all other arrays.
+        puzzle_ids: Puzzle id per gallery piece, as a numpy string array (for puzzle-restricted pooling).
+        piece_files: Photo path (relative to dataset root) per gallery piece.
+        edges: (N, 4, 100, 2) canonical edge polylines.
+        types: (N, 4) string array of edge types, N/E/S/W order.
+        hist_lab: (N, 512) L*a*b* joint histograms.
+        hist_ab: (N, 256) a*b*-only histograms.
+        hist_ab_gw: (N, 256) gray-world a*b* histograms.
+        spatial_hists: (N, 9, 64) per-cell spatial gray-world a*b* histograms.
+        spatial_nonempty: (N, 9) spatial-cell non-empty flags.
+    """
+
+    identities: List[Tuple[str, int, int]]
+    puzzle_ids: np.ndarray
+    piece_files: List[str]
+    edges: np.ndarray
+    types: np.ndarray
+    hist_lab: np.ndarray
+    hist_ab: np.ndarray
+    hist_ab_gw: np.ndarray
+    spatial_hists: np.ndarray
+    spatial_nonempty: np.ndarray
+
+
+@dataclass
+class QueryBase:
+    """Cached raw distance arrays from one query to one cell's candidate pool.
+
+    Attributes:
+        query: The query fingerprint.
+        true_local: Index of the true identity within the pool arrays.
+        pool_idx: Pool indices into the gallery's global arrays.
+        d_shape_ri: (P,) rotation-invariant shape distances.
+        d_shape_fixed: (P,) fixed-orientation (k=0) shape distances.
+        d_color: {"lab"/"ab"/"ab_gw": (P,) chi-square color distances}.
+        d_spatial: (P,) spatial color distances, each candidate's grid
+            rotated by the rotation-invariant shape distance's winning k.
+        d_spatial_fixed: (P,) spatial color distances at k=0 everywhere
+            (the fixed-orientation protocol).
+    """
+
+    query: PieceFingerprint
+    true_local: int
+    pool_idx: np.ndarray
+    d_shape_ri: np.ndarray
+    d_shape_fixed: np.ndarray
+    d_color: Dict[str, np.ndarray]
+    d_spatial: np.ndarray
+    d_spatial_fixed: np.ndarray
+
+
+@dataclass
+class CellBase:
+    """All cached query bases for one (enroll, query) cell.
+
+    Attributes:
+        enroll_bg: Gallery background.
+        query_bg: Query background.
+        queries: One `QueryBase` per query whose identity exists in the gallery.
+        n_skipped: Queries skipped because their identity is not enrolled.
+    """
+
+    enroll_bg: str
+    query_bg: str
+    queries: List[QueryBase]
+    n_skipped: int
+
+
+@dataclass
+class QueryOutcome:
+    """Final per-query ranks and winner-fusion stats for one cell.
+
+    Attributes:
+        identity: The query's (puzzle_id, row, col) identity.
+        enroll_bg: Gallery background.
+        query_bg: Query background.
+        pool_size: Number of gallery candidates scored.
+        ranks: Per-metric 1-based rank of the true identity (keys: the
+            `ABLATION_ROWS` metrics plus shape_fixed, fused_winner, and
+            fused_winner_fixed).
+        winner_true_dist: Winner-fusion distance to the true gallery match.
+        winner_best_impostor_dist: Winner-fusion distance to the best impostor.
+        query_piece_file: Query photo path.
+        true_piece_file: True gallery match's photo path.
+        best_impostor_piece_file: Best-impostor gallery entry's photo path.
+        best_impostor_identity: Best-impostor gallery entry's identity.
+    """
+
+    identity: Tuple[str, int, int]
+    enroll_bg: str
+    query_bg: str
+    pool_size: int
+    ranks: Dict[str, int]
+    winner_true_dist: float
+    winner_best_impostor_dist: float
+    query_piece_file: str
+    true_piece_file: str
+    best_impostor_piece_file: str
+    best_impostor_identity: Tuple[str, int, int]
+
+
+def build_arrays(fingerprints: List[PieceFingerprint]) -> GalleryArrays:
+    """Stack a list of piece fingerprints into vectorization-ready arrays.
+
+    Args:
+        fingerprints: One background's enrolled gallery.
+
+    Returns:
+        The stacked `GalleryArrays`.
+    """
+    return GalleryArrays(
+        identities=[fp.identity for fp in fingerprints],
+        puzzle_ids=np.array([fp.puzzle_id for fp in fingerprints]),
+        piece_files=[fp.piece_file for fp in fingerprints],
+        edges=np.stack([fp.edges_canonical for fp in fingerprints], axis=0),
+        types=np.array([list(fp.edge_types) for fp in fingerprints]),
+        hist_lab=np.stack([fp.color_hist_lab for fp in fingerprints], axis=0),
+        hist_ab=np.stack([fp.color_hist_ab for fp in fingerprints], axis=0),
+        hist_ab_gw=np.stack([fp.color_hist_ab_gw for fp in fingerprints], axis=0),
+        spatial_hists=np.stack([fp.spatial_hists for fp in fingerprints], axis=0),
+        spatial_nonempty=np.stack([fp.spatial_nonempty for fp in fingerprints], axis=0),
+    )
+
+
+def compute_cell_base(
+    gallery: GalleryArrays,
+    query_fingerprints: List[PieceFingerprint],
+    enroll_bg: str,
+    query_bg: str,
+    restrict_puzzle: bool = False,
+) -> CellBase:
+    """Compute and cache every query's raw distance arrays for one cell.
+
+    All fusion variants and ablation metrics are pure functions of these
+    arrays, so the (comparatively expensive) shape/color distance
+    computation happens exactly once per cell regardless of how many
+    hyperparameter combinations are evaluated.
+
+    Args:
+        gallery: The enroll background's stacked gallery.
+        query_fingerprints: The query background's fingerprints.
+        enroll_bg: Enroll background name.
+        query_bg: Query background name.
+        restrict_puzzle: When True, restrict the candidate pool to the
+            query's own puzzle (the secondary, easier setting).
+
+    Returns:
+        The cell's cached `CellBase`.
+    """
+    identity_to_idx = {identity: i for i, identity in enumerate(gallery.identities)}
+    queries: List[QueryBase] = []
+    n_skipped = 0
+
+    for query in query_fingerprints:
+        if query.identity not in identity_to_idx:
+            n_skipped += 1
+            continue
+        true_idx = identity_to_idx[query.identity]
+
+        if restrict_puzzle:
+            pool_idx = np.where(gallery.puzzle_ids == query.puzzle_id)[0]
+        else:
+            pool_idx = np.arange(len(gallery.identities))
+        true_local = int(np.where(pool_idx == true_idx)[0][0])
+
+        edges_pool = gallery.edges[pool_idx]
+        types_pool = gallery.types[pool_idx]
+        spatial_pool = gallery.spatial_hists[pool_idx]
+        spatial_nonempty_pool = gallery.spatial_nonempty[pool_idx]
+
+        d_shape_ri, best_k_ri = shape_distance_matrix(
+            query.edges_canonical, query.edge_types, edges_pool, types_pool, True
+        )
+        d_shape_fixed, _ = shape_distance_matrix(query.edges_canonical, query.edge_types, edges_pool, types_pool, False)
+        queries.append(
+            QueryBase(
+                query=query,
+                true_local=true_local,
+                pool_idx=pool_idx,
+                d_shape_ri=d_shape_ri,
+                d_shape_fixed=d_shape_fixed,
+                d_color={
+                    "lab": chi_square_distance_matrix(query.color_hist_lab, gallery.hist_lab[pool_idx]),
+                    "ab": chi_square_distance_matrix(query.color_hist_ab, gallery.hist_ab[pool_idx]),
+                    "ab_gw": chi_square_distance_matrix(query.color_hist_ab_gw, gallery.hist_ab_gw[pool_idx]),
+                },
+                d_spatial=spatial_color_distance_matrix(
+                    query.spatial_hists, query.spatial_nonempty, spatial_pool, spatial_nonempty_pool, best_k_ri
+                ),
+                d_spatial_fixed=spatial_color_distance_matrix(
+                    query.spatial_hists,
+                    query.spatial_nonempty,
+                    spatial_pool,
+                    spatial_nonempty_pool,
+                    np.zeros(len(pool_idx), dtype=np.int64),
+                ),
+            )
+        )
+
+    return CellBase(enroll_bg=enroll_bg, query_bg=query_bg, queries=queries, n_skipped=n_skipped)
+
+
+def ranks_from_distances(distances: np.ndarray) -> np.ndarray:
+    """1-based rank of every candidate under ascending-distance ordering.
+
+    Args:
+        distances: (P,) candidate distances.
+
+    Returns:
+        (P,) integer ranks (1 = closest).
+    """
+    order = np.argsort(distances, kind="stable")
+    ranks = np.empty(len(distances), dtype=np.int64)
+    ranks[order] = np.arange(1, len(distances) + 1)
+    return ranks
+
+
+def fused_distance_array(
+    base: QueryBase, method: str, param: float, color_variant: str, fixed_shape: bool = False
+) -> np.ndarray:
+    """Compute a fused distance-like scalar per candidate for one fusion method.
+
+    Lower is better in all cases:
+    - "rerank": shape top-K candidates get their color distance (so color
+      alone orders the shortlist); everything else gets
+      `RERANK_OUT_OF_K_OFFSET` + its shape rank, preserving shape order
+      strictly behind the shortlist.
+    - "rrf_ab" / "rrf_sp" / "rrf3": the negated reciprocal-rank-fusion score
+      -(sum over terms of 1/(rank + c)), where the terms are shape + global
+      color, shape + spatial color, or all three respectively.
+
+    Args:
+        base: The query's cached distance arrays.
+        method: One of `FUSION_DISPLAY`'s keys.
+        param: K for "rerank", c for the RRF methods.
+        color_variant: Which global color distance feeds the fusion.
+        fixed_shape: When True, use the fixed-orientation shape (and
+            spatial-color) base.
+
+    Returns:
+        (P,) fused distances.
+    """
+    d_shape = base.d_shape_fixed if fixed_shape else base.d_shape_ri
+    d_spatial = base.d_spatial_fixed if fixed_shape else base.d_spatial
+    d_color = base.d_color[color_variant]
+    shape_ranks = ranks_from_distances(d_shape)
+
+    if method == "rerank":
+        in_k = shape_ranks <= param
+        return np.where(in_k, d_color, RERANK_OUT_OF_K_OFFSET + shape_ranks.astype(np.float64))
+
+    rrf_terms = {"rrf_ab": (d_color,), "rrf_sp": (d_spatial,), "rrf3": (d_color, d_spatial)}
+    if method not in rrf_terms:
+        raise ValueError(f"Unknown fusion method: {method}")
+    fused = -1.0 / (shape_ranks + param)
+    for term in rrf_terms[method]:
+        fused = fused - 1.0 / (ranks_from_distances(term) + param)
+    return fused
+
+
+def rank_of_true(distances: np.ndarray, true_idx: int) -> int:
+    """1-based rank of the true index under ascending-distance nearest-neighbor search.
+
+    Args:
+        distances: (P,) candidate distances.
+        true_idx: Index of the true match within `distances`.
+
+    Returns:
+        1 + the number of candidates strictly closer than the true match.
+    """
+    return 1 + int(np.sum(distances < distances[true_idx]))
+
+
+def fused_true_rank(base: QueryBase, method: str, param: float, color_variant: str, fixed_shape: bool = False) -> int:
+    """1-based fused rank of one query's true identity.
+
+    Args:
+        base: The query's cached distance arrays.
+        method: One of `FUSION_DISPLAY`'s keys.
+        param: K for "rerank", c for the RRF methods.
+        color_variant: Which global color distance feeds the fusion.
+        fixed_shape: When True, use the fixed-orientation shape base.
+
+    Returns:
+        The fused rank.
+    """
+    fused = fused_distance_array(base, method, param, color_variant, fixed_shape)
+    return rank_of_true(fused, base.true_local)
+
+
+def _top_k_ranks(ranks: List[int], k: int) -> float:
+    """Fraction of ranks within the top k.
+
+    Args:
+        ranks: 1-based ranks.
+        k: Rank cutoff.
+
+    Returns:
+        The top-k fraction, or nan for an empty list.
+    """
+    if not ranks:
+        return float("nan")
+    return float(np.mean(np.array(ranks) <= k))
+
+
+def validation_selection(
+    cells: Dict[Tuple[str, str], CellBase],
+) -> Tuple[str, str, float, Dict[str, float], Dict[str, float]]:
+    """Choose the color variant and the winning fusion on the validation cells only.
+
+    Validation cells = the 3 cells whose query background is
+    `VALIDATION_QUERY_BACKGROUND`. The global color variant ("ab" vs
+    "ab_gw") is chosen by color-only top-1; then the iteration 3 candidates
+    - the frozen baseline RRF(shape, ab_gw) c=5, RRF(shape, spatial) and
+    RRF(shape, ab_gw, spatial) with c swept - are scored with that variant
+    and the best combination wins.
+
+    Args:
+        cells: All 12 cells' cached bases, keyed by (enroll_bg, query_bg).
+
+    Returns:
+        Tuple of (chosen variant, chosen method, chosen param,
+        {variant: color-only top1} scores, {"method=param": top1} sweep curve).
+    """
+    validation = [cell for (_e, q), cell in cells.items() if q == VALIDATION_QUERY_BACKGROUND]
+    bases = [base for cell in validation for base in cell.queries]
+
+    variant_scores = {
+        variant: _top_k_ranks([rank_of_true(b.d_color[variant], b.true_local) for b in bases], 1)
+        for variant in COLOR_VARIANTS
+    }
+    chosen_variant = max(variant_scores, key=lambda v: variant_scores[v])
+
+    sweep: Dict[str, float] = {}
+    candidates: List[Tuple[str, float]] = [("rrf_ab", RRF_AB_C)]
+    candidates += [("rrf_sp", c) for c in RRF_SPATIAL_C_SWEEP]
+    candidates += [("rrf3", c) for c in RRF_SPATIAL_C_SWEEP]
+    for method, param in candidates:
+        ranks = [fused_true_rank(b, method, param, chosen_variant) for b in bases]
+        sweep[f"{method}={param:g}"] = _top_k_ranks(ranks, 1)
+
+    chosen_method, chosen_param = max(candidates, key=lambda mp: sweep[f"{mp[0]}={mp[1]:g}"])
+    return chosen_variant, chosen_method, chosen_param, variant_scores, sweep
+
+
+def finalize_outcomes(
+    cells: Dict[Tuple[str, str], CellBase],
+    gallery_arrays: Dict[str, GalleryArrays],
+    color_variant: str,
+    winner_method: str,
+    winner_param: float,
+    rrf_sp_c: float,
+    rrf3_c: float,
+) -> Dict[Tuple[str, str], List[QueryOutcome]]:
+    """Compute every cell's final per-query outcomes with frozen hyperparameters.
+
+    Args:
+        cells: All cells' cached bases.
+        gallery_arrays: enroll background -> stacked gallery arrays.
+        color_variant: The frozen global color variant.
+        winner_method: The frozen winning fusion method (a `FUSION_DISPLAY` key).
+        winner_param: The winner's frozen K/c.
+        rrf_sp_c: Frozen c for the ablation's RRF(shape,spatial) row.
+        rrf3_c: Frozen c for the ablation's RRF(shape,ab_gw,spatial) row.
+
+    Returns:
+        {(enroll_bg, query_bg): [QueryOutcome, ...]}.
+    """
+    outcomes: Dict[Tuple[str, str], List[QueryOutcome]] = {}
+    for key, cell in cells.items():
+        gallery = gallery_arrays[cell.enroll_bg]
+        cell_outcomes: List[QueryOutcome] = []
+        for base in cell.queries:
+            fused_winner = fused_distance_array(base, winner_method, winner_param, color_variant)
+            ranks = {
+                "shape_ri": rank_of_true(base.d_shape_ri, base.true_local),
+                "shape_fixed": rank_of_true(base.d_shape_fixed, base.true_local),
+                "color_lab": rank_of_true(base.d_color["lab"], base.true_local),
+                "color_ab": rank_of_true(base.d_color["ab"], base.true_local),
+                "color_ab_gw": rank_of_true(base.d_color["ab_gw"], base.true_local),
+                "color_spatial": rank_of_true(base.d_spatial, base.true_local),
+                "fused_rerank": fused_true_rank(base, "rerank", RERANK_K, color_variant),
+                "fused_rrf_ab": fused_true_rank(base, "rrf_ab", RRF_AB_C, color_variant),
+                "fused_rrf_sp": fused_true_rank(base, "rrf_sp", rrf_sp_c, color_variant),
+                "fused_rrf3": fused_true_rank(base, "rrf3", rrf3_c, color_variant),
+                "fused_winner": rank_of_true(fused_winner, base.true_local),
+                "fused_winner_fixed": fused_true_rank(base, winner_method, winner_param, color_variant, True),
+            }
+
+            masked = fused_winner.copy()
+            masked[base.true_local] = np.inf
+            best_imp_local = int(np.argmin(masked))
+            best_imp_global = int(base.pool_idx[best_imp_local])
+            true_global = int(base.pool_idx[base.true_local])
+
+            cell_outcomes.append(
+                QueryOutcome(
+                    identity=base.query.identity,
+                    enroll_bg=cell.enroll_bg,
+                    query_bg=cell.query_bg,
+                    pool_size=len(base.pool_idx),
+                    ranks=ranks,
+                    winner_true_dist=float(fused_winner[base.true_local]),
+                    winner_best_impostor_dist=float(fused_winner[best_imp_local]),
+                    query_piece_file=base.query.piece_file,
+                    true_piece_file=gallery.piece_files[true_global],
+                    best_impostor_piece_file=gallery.piece_files[best_imp_global],
+                    best_impostor_identity=gallery.identities[best_imp_global],
+                )
+            )
+        outcomes[key] = cell_outcomes
+    return outcomes
+
+
+def ablation_table(outcomes: List[QueryOutcome]) -> Dict[str, Dict[str, float]]:
+    """Aggregate top-1/top-5 per ablation metric over a pool of outcomes.
+
+    Args:
+        outcomes: Query outcomes (typically pooled across cells).
+
+    Returns:
+        {display_name: {"top1": ..., "top5": ...}}.
+    """
+    table: Dict[str, Dict[str, float]] = {}
+    for metric, display in ABLATION_ROWS:
+        ranks = [o.ranks[metric] for o in outcomes]
+        table[display] = {"top1": _top_k_ranks(ranks, 1), "top5": _top_k_ranks(ranks, 5)}
+    return table
+
+
+def genuine_impostor_stats(outcomes: List[QueryOutcome]) -> Dict[str, Optional[float]]:
+    """Genuine vs. best-impostor winner-fusion distance stats over a pool of outcomes.
+
+    Args:
+        outcomes: Query outcomes.
+
+    Returns:
+        Dict with median genuine, median best-impostor, the impostor 5th
+        percentile, and overlap (fraction of genuine distances above that
+        percentile) - the same shape as `eval_matching.genuine_impostor_stats`.
+    """
+    if not outcomes:
+        return {"median_genuine": None, "median_best_impostor": None, "impostor_p5": None, "overlap_frac": None}
+    genuine = np.array([o.winner_true_dist for o in outcomes])
+    impostor_best = np.array([o.winner_best_impostor_dist for o in outcomes])
+    impostor_p5 = float(np.percentile(impostor_best, 5))
+    overlap = float(np.mean(genuine > impostor_p5))
+    return {
+        "median_genuine": float(np.median(genuine)),
+        "median_best_impostor": float(np.median(impostor_best)),
+        "impostor_p5": impostor_p5,
+        "overlap_frac": overlap,
+    }
+
+
+def failure_concentration(outcomes: List[QueryOutcome], top_n: int = 8) -> Dict[str, object]:
+    """Break down winner-fusion top-1 failures by query background and by puzzle.
+
+    Args:
+        outcomes: Query outcomes (typically pooled across all 12 cells).
+        top_n: How many puzzles to report.
+
+    Returns:
+        Dict with failure counts by query background and puzzle plus totals.
+    """
+    failures = [o for o in outcomes if o.ranks["fused_winner"] != 1]
+    by_bg = Counter(o.query_bg for o in failures)
+    by_puzzle = Counter(o.identity[0] for o in failures)
+    return {
+        "by_query_background": sorted(by_bg.items(), key=lambda kv: -kv[1]),
+        "by_puzzle": sorted(by_puzzle.items(), key=lambda kv: -kv[1])[:top_n],
+        "n_failures": len(failures),
+        "n_total": len(outcomes),
+    }
+
+
+def load_bbox_lookup(dataset_root: Path) -> Dict[str, Tuple[int, int, int, int]]:
+    """Map each piece photo's relative path to its bounding box, from `metadata.csv`.
+
+    Args:
+        dataset_root: The north_star v1 dataset root.
+
+    Returns:
+        {piece_file: (x1, y1, x2, y2)}.
+    """
+    return {r.piece_file: r.bbox for r in load_metadata(dataset_root)}
+
+
+def render_failure_sheet(
+    outcomes: List[QueryOutcome],
+    enroll_bg: str,
+    query_bg: str,
+    dataset_root: Path,
+    bbox_lookup: Dict[str, Tuple[int, int, int, int]],
+    output_dir: Path,
+) -> Optional[Path]:
+    """Render a query/wrong-top-1/true-match crop comparison sheet for one cell's failures.
+
+    Args:
+        outcomes: This cell's query outcomes.
+        enroll_bg: Enroll background name.
+        query_bg: Query background name.
+        dataset_root: The north_star v1 dataset root (for photo pixels).
+        bbox_lookup: `load_bbox_lookup` output.
+        output_dir: The experiment outputs directory.
+
+    Returns:
+        The written PNG path, or None when the cell has no failures.
+    """
+    failures = [o for o in outcomes if o.ranks["fused_winner"] != 1][:MAX_FAILURES_PER_SHEET]
+    if not failures:
+        return None
+
+    def load_crop(piece_file: str) -> np.ndarray:
+        image = cv2.imread(str(dataset_root / piece_file))
+        crop, _ = crop_with_margin(image, bbox_lookup[piece_file])
+        return cv2.cvtColor(crop, cv2.COLOR_BGR2RGB)
+
+    n = len(failures)
+    fig, axes = plt.subplots(n, 3, figsize=(9, 3 * n), squeeze=False)
+    fig.suptitle(f"Worst-cell winner-fusion top-1 failures: enroll={enroll_bg}  query={query_bg}")
+    for row, outcome in enumerate(failures):
+        puzzle_id, piece_row, piece_col = outcome.identity
+        imp_puzzle, imp_row, imp_col = outcome.best_impostor_identity
+        cells = (
+            (outcome.query_piece_file, f"query\n{puzzle_id} r{piece_row}c{piece_col} ({query_bg})"),
+            (
+                outcome.best_impostor_piece_file,
+                f"wrong top-1\n{imp_puzzle} r{imp_row}c{imp_col}\nd={outcome.winner_best_impostor_dist:.3f}",
+            ),
+            (
+                outcome.true_piece_file,
+                f"true match (rank {outcome.ranks['fused_winner']})\nd={outcome.winner_true_dist:.3f}",
+            ),
+        )
+        for col, (piece_file, title) in enumerate(cells):
+            ax = axes[row][col]
+            ax.imshow(load_crop(piece_file))
+            ax.set_title(title, fontsize=8)
+            ax.axis("off")
+
+    review_dir = output_dir / "review_reid"
+    review_dir.mkdir(parents=True, exist_ok=True)
+    out_path = review_dir / f"failures_{enroll_bg}_{query_bg}.png"
+    fig.savefig(out_path, dpi=100, bbox_inches="tight")
+    plt.close(fig)
+    return out_path
+
+
+def _print_ablation(title: str, table: Dict[str, Dict[str, float]]) -> None:
+    """Print an ablation top-1/top-5 table.
+
+    Args:
+        title: Table heading.
+        table: `ablation_table` output.
+    """
+    print(f"\n{title}")
+    print(f"{'metric':<22}{'top1':>8}{'top5':>8}")
+    for _metric, display in ABLATION_ROWS:
+        row = table[display]
+        print(f"{display:<22}{row['top1'] * 100:7.1f}%{row['top5'] * 100:7.1f}%")
+
+
+def main() -> None:  # noqa: C901  (evaluation driver, sequential report sections)
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Evaluate cross-background piece re-identification.")
+    parser.add_argument(
+        "--dataset-root", type=Path, default=Path("/Users/claus/Repos/pussel/network/datasets/north_star/v1")
+    )
+    parser.add_argument("--records-dir", type=Path, default=Path(__file__).parent / "outputs" / "piece_records")
+    parser.add_argument("--contours-dir", type=Path, default=Path(__file__).parent / "outputs" / "contours")
+    parser.add_argument("--output-dir", type=Path, default=Path(__file__).parent / "outputs")
+    parser.add_argument("--no-sheets", action="store_true", help="Skip rendering the failure review sheet")
+    args = parser.parse_args()
+
+    fingerprints_dir = args.output_dir / "fingerprints"
+    total_pieces = len({(r.puzzle_id, r.row, r.col) for r in load_metadata(args.dataset_root)})
+
+    gallery_fps: Dict[str, List[PieceFingerprint]] = {}
+    for background in BACKGROUNDS:
+        fp_path = fingerprints_dir / f"{background}.json"
+        if not fp_path.exists():
+            print(f"{fp_path} missing - building it now.")
+            built = build_gallery(args.records_dir, args.contours_dir, args.dataset_root, background)
+            save_fingerprints(built, fp_path)
+        gallery_fps[background] = load_gallery(fp_path, args.records_dir)
+        print(f"{background:12s}: {len(gallery_fps[background]):3d}/{total_pieces} clean pieces enrolled (coverage)")
+
+    galleries = {bg: build_arrays(fps) for bg, fps in gallery_fps.items()}
+
+    cell_keys = [(e, q) for e in BACKGROUNDS for q in BACKGROUNDS if e != q]
+    cells = {(e, q): compute_cell_base(galleries[e], gallery_fps[q], e, q) for e, q in cell_keys}
+    cells_puzzle = {
+        (e, q): compute_cell_base(galleries[e], gallery_fps[q], e, q, restrict_puzzle=True) for e, q in cell_keys
+    }
+
+    variant, method, param, variant_scores, sweep = validation_selection(cells)
+    print(
+        f"\nColor variant chosen on validation "
+        f"(query={VALIDATION_QUERY_BACKGROUND}, color-only top-1): {variant_scores}"
+    )
+    print(f"Winner variant: {variant}")
+    print(f"Fusion sweep on validation cells (top-1): {sweep}")
+    print(f"Frozen winner: method={method}, param={param:g}, color variant={variant}")
+
+    rrf_sp_c = max(RRF_SPATIAL_C_SWEEP, key=lambda c: sweep[f"rrf_sp={c:g}"])
+    rrf3_c = max(RRF_SPATIAL_C_SWEEP, key=lambda c: sweep[f"rrf3={c:g}"])
+    print(
+        f"Frozen ablation-row params: rerank K={RERANK_K:g} (iter 2), rrf_ab c={RRF_AB_C:g} (iter 2), "
+        f"rrf_sp c={rrf_sp_c:g}, rrf3 c={rrf3_c:g}"
+    )
+
+    outcomes_by_cell = finalize_outcomes(cells, galleries, variant, method, param, rrf_sp_c, rrf3_c)
+    outcomes_puzzle_by_cell = finalize_outcomes(cells_puzzle, galleries, variant, method, param, rrf_sp_c, rrf3_c)
+    all_outcomes = [o for outs in outcomes_by_cell.values() for o in outs]
+    all_outcomes_puzzle = [o for outs in outcomes_puzzle_by_cell.values() for o in outs]
+    n_skipped_total = sum(cell.n_skipped for cell in cells.values())
+
+    print(f"\n{len(all_outcomes)} queries across 12 cells ({n_skipped_total} skipped: true identity not in gallery)")
+
+    # (a) Ablation, cross-puzzle hard gallery.
+    table_all = ablation_table(all_outcomes)
+    _print_ablation("=== Ablation (all 12 cells, cross-puzzle gallery) ===", table_all)
+
+    final_9 = [o for o in all_outcomes if o.query_bg != VALIDATION_QUERY_BACKGROUND]
+    table_final9 = ablation_table(final_9)
+    _print_ablation("=== Ablation (9 cells excluding the validation cells) - HEADLINE ===", table_final9)
+
+    winner_display = FUSION_DISPLAY[method]
+    headline_top1 = table_final9[winner_display]["top1"]
+    headline_ranks_9 = [o.ranks["fused_winner"] for o in final_9]
+    headline_top5 = _top_k_ranks(headline_ranks_9, 5)
+
+    # Easier-context line: exclude wood-as-query cells from the headline set
+    # (the production app scans on a gray mat in one session, so wood-query
+    # cells overstate the real difficulty). NOT the headline number.
+    final_6_no_wood = [o for o in final_9 if o.query_bg != "wood"]
+    no_wood_ranks = [o.ranks["fused_winner"] for o in final_6_no_wood]
+    print(
+        f"\nEasier-context (leakage-free, EXCLUDING wood-as-query; {len(final_6_no_wood)} queries, 6 cells): "
+        f"winner top-1 {_top_k_ranks(no_wood_ranks, 1) * 100:.1f}%, top-5 {_top_k_ranks(no_wood_ranks, 5) * 100:.1f}% "
+        f"- context only, not the headline"
+    )
+
+    # (b) 12-cell winner matrix.
+    print(f"\n=== 12-cell winner ({winner_display}) top-1 matrix (rows=enroll, cols=query) ===")
+    print("enroll\\query".ljust(14) + "".join(f"{bg:>14}" for bg in BACKGROUNDS))
+    matrix: Dict[str, Dict[str, float]] = {}
+    for enroll_bg in BACKGROUNDS:
+        row_vals = []
+        matrix[enroll_bg] = {}
+        for query_bg in BACKGROUNDS:
+            if enroll_bg == query_bg:
+                row_vals.append("--".rjust(14))
+                continue
+            top1 = _top_k_ranks([o.ranks["fused_winner"] for o in outcomes_by_cell[(enroll_bg, query_bg)]], 1)
+            matrix[enroll_bg][query_bg] = top1
+            row_vals.append(f"{top1 * 100:13.1f}%")
+        print(enroll_bg.ljust(14) + "".join(row_vals))
+
+    # (c) Fixed-orientation vs rotation-invariant shape base for the winner.
+    top1_ri = _top_k_ranks([o.ranks["fused_winner"] for o in all_outcomes], 1)
+    top1_fixed = _top_k_ranks([o.ranks["fused_winner_fixed"] for o in all_outcomes], 1)
+    print(
+        f"\nFixed-orientation vs rotation-invariant shape base (winner top-1, all 12 cells): "
+        f"fixed={top1_fixed * 100:.1f}%  rotation-invariant={top1_ri * 100:.1f}%"
+    )
+
+    # (d) Genuine/impostor stats + failure concentration.
+    gi_stats = genuine_impostor_stats(all_outcomes)
+    print(
+        f"\nGenuine vs impostor (winner fusion distance): median genuine={gi_stats['median_genuine']:.4f}, "
+        f"median best-impostor={gi_stats['median_best_impostor']:.4f}, impostor p5={gi_stats['impostor_p5']:.4f}, "
+        f"overlap={gi_stats['overlap_frac'] * 100:.1f}% of genuine above impostor p5"
+    )
+    failure_stats = failure_concentration(all_outcomes)
+    print(f"\nFailure concentration ({failure_stats['n_failures']}/{failure_stats['n_total']} winner top-1 misses):")
+    print(f"  by query background: {failure_stats['by_query_background']}")
+    print(f"  by puzzle (top 8):   {failure_stats['by_puzzle']}")
+
+    # (e) Worst-cell failure review sheet.
+    worst_enroll, worst_query = min(((e, q) for e in matrix for q in matrix[e]), key=lambda eq: matrix[eq[0]][eq[1]])
+    worst_top1 = matrix[worst_enroll][worst_query]
+    print(f"\nWorst cell (winner top-1): enroll={worst_enroll} query={worst_query} -> {worst_top1 * 100:.1f}%")
+
+    sheet_path: Optional[Path] = None
+    if not args.no_sheets:
+        bbox_lookup = load_bbox_lookup(args.dataset_root)
+        sheet_path = render_failure_sheet(
+            outcomes_by_cell[(worst_enroll, worst_query)],
+            worst_enroll,
+            worst_query,
+            args.dataset_root,
+            bbox_lookup,
+            args.output_dir,
+        )
+        if sheet_path:
+            print(f"Wrote {sheet_path}")
+
+    # Secondary: within-puzzle gallery.
+    table_puzzle = ablation_table(all_outcomes_puzzle)
+    _print_ablation("=== Secondary: ablation with WITHIN-PUZZLE gallery only (all 12 cells) ===", table_puzzle)
+    winner_puzzle_ranks = [o.ranks["fused_winner"] for o in all_outcomes_puzzle]
+    print(
+        f"Within-puzzle winner ({winner_display}): top-1 {_top_k_ranks(winner_puzzle_ranks, 1) * 100:.1f}%, "
+        f"top-5 {_top_k_ranks(winner_puzzle_ranks, 5) * 100:.1f}%"
+    )
+
+    criterion_met = headline_top1 >= 0.95
+    print(
+        f"\nPlan criterion (winner top-1 >= 95%, headline 9 non-validation cells): "
+        f"top-1 {headline_top1 * 100:.1f}% / top-5 {headline_top5 * 100:.1f}% "
+        f"-> {'MET' if criterion_met else 'NOT MET'}"
+    )
+
+    eval_path = args.output_dir / "reid_eval.json"
+    with open(eval_path, "w", encoding="utf-8") as handle:
+        json.dump(
+            {
+                "coverage": {bg: len(gallery_fps[bg]) for bg in BACKGROUNDS},
+                "total_physical_pieces": total_pieces,
+                "chosen_color_variant": variant,
+                "chosen_fusion": {"method": method, "param": param},
+                "frozen_ablation_params": {
+                    "rerank_k": RERANK_K,
+                    "rrf_ab_c": RRF_AB_C,
+                    "rrf_sp_c": rrf_sp_c,
+                    "rrf3_c": rrf3_c,
+                },
+                "validation_color_variant_scores": variant_scores,
+                "validation_fusion_sweep": sweep,
+                "n_queries": len(all_outcomes),
+                "n_skipped_no_gallery_match": n_skipped_total,
+                "ablation_all_12_cells": table_all,
+                "ablation_final_9_cells": table_final9,
+                "ablation_within_puzzle": table_puzzle,
+                "winner_matrix_12_cell": matrix,
+                "fixed_vs_rotation_invariant_winner_top1": {"fixed": top1_fixed, "rotation_invariant": top1_ri},
+                "genuine_impostor_winner": gi_stats,
+                "failure_concentration": failure_stats,
+                "worst_cell": {
+                    "enroll": worst_enroll,
+                    "query": worst_query,
+                    "top1": worst_top1,
+                    "review_sheet": str(sheet_path) if sheet_path else None,
+                },
+                "headline_top1_final_9_cells": headline_top1,
+                "headline_top5_final_9_cells": headline_top5,
+                "easier_context_no_wood_query": {
+                    "n_cells": 6,
+                    "n_queries": len(final_6_no_wood),
+                    "top1": _top_k_ranks(no_wood_ranks, 1),
+                    "top5": _top_k_ranks(no_wood_ranks, 5),
+                },
+                "plan_criterion_met_final_9_cells": criterion_met,
+            },
+            handle,
+            indent=2,
+        )
+    print(f"\nWrote {eval_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/network/experiments/exp28_piece_geometry/extract_contours.py
+++ b/network/experiments/exp28_piece_geometry/extract_contours.py
@@ -43,7 +43,9 @@ from common import (
     remove_background_rgba,
 )
 
-DEFAULT_DATASET_ROOT = Path("/Users/claus/Repos/pussel/network/datasets/north_star/v1")
+# Repo-relative default (this script lives in network/experiments/exp28_piece_geometry/,
+# so parents[2] is the network/ dir); override with --dataset-root.
+DEFAULT_DATASET_ROOT = Path(__file__).resolve().parents[2] / "datasets" / "north_star" / "v1"
 DEFAULT_MARGIN_FRAC = 0.15
 PROGRESS_INTERVAL = 25
 

--- a/network/experiments/exp28_piece_geometry/extract_contours.py
+++ b/network/experiments/exp28_piece_geometry/extract_contours.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""M1: high-fidelity contour extraction for north_star piece photos.
+
+For every piece photo (optionally filtered by puzzle/background), crops the
+photo to the piece bbox with a margin, then extracts a contour with one or
+both of:
+
+- **rembg**: segmentation alpha -> hardened mask -> contour.
+- **threshold**: grayscale Otsu at both polarities, picking whichever
+  polarity's largest component has a plausible area ratio and the best
+  solidity, -> contour.
+
+Writes one JSON per piece to `outputs/contours/{puzzle_id}/{piece_stem}.json`
+and appends one row per piece x method to `outputs/summary.csv`. Prints
+progress every 25 pieces and a final per-background x per-method clean-rate
+table.
+
+Usage:
+    cd network
+    uv run python experiments/exp28_piece_geometry/extract_contours.py --limit 8
+    uv run python experiments/exp28_piece_geometry/extract_contours.py \
+        --puzzle bambi --background red_carpet --method rembg
+"""
+
+import argparse
+import csv
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import cv2
+import numpy as np
+from common import (
+    PieceRecord,
+    QualityMetrics,
+    alpha_to_mask,
+    contour_quality,
+    crop_with_margin,
+    load_metadata,
+    mask_to_contour,
+    otsu_masks,
+    remove_background_rgba,
+)
+
+DEFAULT_DATASET_ROOT = Path("/Users/claus/Repos/pussel/network/datasets/north_star/v1")
+DEFAULT_MARGIN_FRAC = 0.15
+PROGRESS_INTERVAL = 25
+
+
+def _extract_rembg(crop_bgr: np.ndarray) -> Tuple[Optional[np.ndarray], Optional[QualityMetrics]]:
+    """Extract a contour from a crop via rembg segmentation.
+
+    Args:
+        crop_bgr: The piece crop in OpenCV BGR order.
+
+    Returns:
+        Tuple of (contour in crop-local coordinates, quality metrics), or
+        (None, None) when no contour could be found.
+    """
+    rgba = remove_background_rgba(crop_bgr)
+    mask = alpha_to_mask(rgba)
+    contour = mask_to_contour(mask)
+    if contour is None:
+        return None, None
+    quality = contour_quality(contour, mask, crop_bgr.shape[:2])
+    return contour, quality
+
+
+def _extract_threshold(crop_bgr: np.ndarray) -> Tuple[Optional[np.ndarray], Optional[QualityMetrics], Optional[str]]:
+    """Extract a contour from a crop via Otsu thresholding, picking the better polarity.
+
+    Args:
+        crop_bgr: The piece crop in OpenCV BGR order.
+
+    Returns:
+        Tuple of (contour in crop-local coordinates, quality metrics,
+        polarity name "normal"/"inverted"), or (None, None, None) when
+        neither polarity yields a contour.
+    """
+    gray = cv2.cvtColor(crop_bgr, cv2.COLOR_BGR2GRAY)
+    normal_mask, inverted_mask = otsu_masks(gray)
+
+    candidates: List[Tuple[str, np.ndarray, np.ndarray, QualityMetrics]] = []
+    for name, mask in (("normal", normal_mask), ("inverted", inverted_mask)):
+        contour = mask_to_contour(mask)
+        if contour is None:
+            continue
+        quality = contour_quality(contour, mask, crop_bgr.shape[:2])
+        candidates.append((name, mask, contour, quality))
+
+    if not candidates:
+        return None, None, None
+
+    plausible = [c for c in candidates if 0.05 <= c[3].area_ratio <= 0.9]
+    pool = plausible if plausible else candidates
+    best = max(pool, key=lambda c: c[3].solidity)
+    return best[2], best[3], best[0]
+
+
+def _piece_metadata_dict(record: PieceRecord, bbox: Tuple[int, int, int, int], margin_frac: float) -> Dict[str, Any]:
+    """Build the JSON-serializable piece metadata block.
+
+    Args:
+        record: The piece's metadata row.
+        bbox: The piece bounding box used for cropping.
+        margin_frac: The margin fraction used for cropping.
+
+    Returns:
+        A dict suitable for `json.dump`.
+    """
+    return {
+        "puzzle_id": record.puzzle_id,
+        "piece_file": record.piece_file,
+        "rows": record.rows,
+        "cols": record.cols,
+        "row": record.row,
+        "col": record.col,
+        "rotation": record.rotation,
+        "background": record.background,
+        "bbox": list(bbox),
+        "margin_frac": margin_frac,
+        "flagged": record.flagged,
+        "bbox_suspect": record.bbox_suspect,
+    }
+
+
+def process_piece(
+    dataset_root: Path, record: PieceRecord, methods: List[str], margin_frac: float = DEFAULT_MARGIN_FRAC
+) -> Dict[str, Any]:
+    """Extract contours for one piece photo with the requested methods.
+
+    Args:
+        dataset_root: The north_star dataset root.
+        record: The piece's metadata row.
+        methods: Which methods to run: any of "rembg", "threshold".
+        margin_frac: Crop margin fraction, as a fraction of bbox size.
+
+    Returns:
+        A JSON-serializable dict with the piece metadata and per-method results.
+    """
+    image_path = dataset_root / record.piece_file
+    image = cv2.imread(str(image_path))
+    if image is None:
+        raise FileNotFoundError(f"Could not read image: {image_path}")
+
+    crop, offset = crop_with_margin(image, record.bbox, margin_frac=margin_frac)
+    offset_x, offset_y = offset
+
+    result: Dict[str, Any] = {
+        "piece": _piece_metadata_dict(record, record.bbox, margin_frac),
+        "methods": {},
+    }
+
+    if "rembg" in methods:
+        contour, quality = _extract_rembg(crop)
+        if contour is not None and quality is not None:
+            original_coords = contour + np.array([offset_x, offset_y])
+            result["methods"]["rembg"] = {
+                "contour": original_coords.tolist(),
+                "quality": quality.to_dict(),
+            }
+        else:
+            result["methods"]["rembg"] = {"contour": None, "quality": None}
+
+    if "threshold" in methods:
+        contour, quality, polarity = _extract_threshold(crop)
+        if contour is not None and quality is not None:
+            original_coords = contour + np.array([offset_x, offset_y])
+            result["methods"]["threshold"] = {
+                "contour": original_coords.tolist(),
+                "quality": quality.to_dict(),
+                "polarity": polarity,
+            }
+        else:
+            result["methods"]["threshold"] = {"contour": None, "quality": None, "polarity": None}
+
+    return result
+
+
+def _filter_records(
+    records: List[PieceRecord], puzzle: Optional[str], background: Optional[str], limit: Optional[int]
+) -> List[PieceRecord]:
+    """Apply CLI filters to the loaded metadata rows.
+
+    Args:
+        records: All loaded piece records.
+        puzzle: Substring filter on puzzle_id, or None.
+        background: Exact-match filter on background, or None.
+        limit: Maximum number of records to keep, or None.
+
+    Returns:
+        The filtered (and possibly truncated) record list.
+    """
+    filtered = records
+    if puzzle:
+        filtered = [r for r in filtered if puzzle in r.puzzle_id]
+    if background:
+        filtered = [r for r in filtered if r.background == background]
+    if limit is not None:
+        filtered = filtered[:limit]
+    return filtered
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Extract high-fidelity contours from north_star piece photos.")
+    parser.add_argument("--dataset-root", type=Path, default=DEFAULT_DATASET_ROOT)
+    parser.add_argument("--output-dir", type=Path, default=Path(__file__).parent / "outputs")
+    parser.add_argument("--puzzle", type=str, default=None, help="Substring filter on puzzle_id")
+    parser.add_argument("--background", type=str, default=None, help="Exact filter on background")
+    parser.add_argument("--limit", type=int, default=None, help="Max number of piece photos to process")
+    parser.add_argument("--method", choices=["rembg", "threshold", "both"], default="both")
+    args = parser.parse_args()
+
+    methods = ["rembg", "threshold"] if args.method == "both" else [args.method]
+
+    records = load_metadata(args.dataset_root)
+    records = _filter_records(records, args.puzzle, args.background, args.limit)
+    print(f"Processing {len(records)} piece photos with methods={methods}")
+
+    contours_dir = args.output_dir / "contours"
+    contours_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = args.output_dir / "summary.csv"
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    fieldnames = [
+        "puzzle",
+        "piece",
+        "background",
+        "method",
+        "is_clean",
+        "n_large_components",
+        "border_touching",
+        "area_ratio",
+        "solidity",
+    ]
+    clean_counts: Dict[Tuple[str, str], int] = defaultdict(int)
+    total_counts: Dict[Tuple[str, str], int] = defaultdict(int)
+
+    with open(summary_path, "w", newline="", encoding="utf-8") as summary_file:
+        writer = csv.DictWriter(summary_file, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for i, record in enumerate(records, start=1):
+            result = process_piece(args.dataset_root, record, methods)
+
+            puzzle_dir = contours_dir / record.puzzle_id
+            puzzle_dir.mkdir(parents=True, exist_ok=True)
+            out_path = puzzle_dir / f"{record.piece_stem}.json"
+            with open(out_path, "w", encoding="utf-8") as handle:
+                json.dump(result, handle)
+
+            for method in methods:
+                method_result = result["methods"].get(method, {})
+                quality = method_result.get("quality")
+                is_clean = bool(quality["is_clean"]) if quality else False
+                writer.writerow(
+                    {
+                        "puzzle": record.puzzle_id,
+                        "piece": record.piece_stem,
+                        "background": record.background,
+                        "method": method,
+                        "is_clean": is_clean,
+                        "n_large_components": quality["n_large_components"] if quality else "",
+                        "border_touching": quality["border_touching"] if quality else "",
+                        "area_ratio": f"{quality['area_ratio']:.4f}" if quality else "",
+                        "solidity": f"{quality['solidity']:.4f}" if quality else "",
+                    }
+                )
+                key = (record.background, method)
+                total_counts[key] += 1
+                if is_clean:
+                    clean_counts[key] += 1
+
+            if i % PROGRESS_INTERVAL == 0:
+                print(f"  ...{i}/{len(records)} pieces processed")
+
+    print(f"\nDone. {len(records)} pieces processed. Summary written to {summary_path}")
+
+    backgrounds = sorted({r.background for r in records})
+    print("\nClean-rate table (is_clean fraction):")
+    header = "background".ljust(14) + "".join(m.ljust(14) for m in methods)
+    print(header)
+    for bg in backgrounds:
+        row = bg.ljust(14)
+        for method in methods:
+            key = (bg, method)
+            total = total_counts[key]
+            clean = clean_counts[key]
+            rate = f"{clean}/{total} ({100.0 * clean / total:.1f}%)" if total else "n/a"
+            row += rate.ljust(14)
+        print(row)
+
+
+if __name__ == "__main__":
+    main()

--- a/network/experiments/exp28_piece_geometry/fingerprint.py
+++ b/network/experiments/exp28_piece_geometry/fingerprint.py
@@ -50,7 +50,9 @@ import cv2
 import numpy as np
 from edge_match import canonicalize_edge
 
-DEFAULT_DATASET_ROOT = Path("/Users/claus/Repos/pussel/network/datasets/north_star/v1")
+# Repo-relative default (this script lives in network/experiments/exp28_piece_geometry/,
+# so parents[2] is the network/ dir); override with --dataset-root.
+DEFAULT_DATASET_ROOT = Path(__file__).resolve().parents[2] / "datasets" / "north_star" / "v1"
 
 BACKGROUNDS = ("red_carpet", "gray_fabric", "cardboard", "wood")
 DIRECTIONS = ("N", "E", "S", "W")

--- a/network/experiments/exp28_piece_geometry/fingerprint.py
+++ b/network/experiments/exp28_piece_geometry/fingerprint.py
@@ -1,0 +1,668 @@
+#!/usr/bin/env python3
+"""M6: piece fingerprint (shape + color) library and CLI to build per-background galleries.
+
+A fingerprint identifies one PHYSICAL piece from one photo (puzzle_id, row,
+col, background) and combines two signals:
+
+1. SHAPE: the piece's 4 canonical edge polylines (M4's chord-normalized
+   frames, reused verbatim from `edge_match.canonicalize_edge` /
+   `edge_match.dist_l2` - NOT the mate-flip transform, since this is
+   same-piece re-identification, not edge-to-edge complementarity matching).
+   Piece-to-piece shape distance is the mean per-edge L2 distance, minimized
+   over the 4 cyclic rotations of the edge order (to be robust to the rare
+   case where the upright-photo auto-orientation differs by 90 degrees
+   between two photos of the same piece), gated by an exact edge-type
+   signature match under the winning rotation (with an ungated fallback when
+   no rotation's signature matches).
+2. COLOR: a chi-square histogram distance over the piece's masked, eroded
+   face pixels in three global variants - L*a*b* joint (lighting-sensitive),
+   a*b* only (lighting-robust hypothesis), and a*b* after gray-world
+   normalization of the masked pixels (illuminant-robust hypothesis: each
+   BGR channel is scaled so the masked mean is neutral before conversion) -
+   plus a SPATIAL descriptor: the piece bbox is divided into a 3x3 grid and
+   each cell gets its own gray-world a*b* histogram, so pieces sharing a
+   palette but differing in color LAYOUT stay separable. Spatial distance =
+   mean per-cell chi-square over cells non-empty on both sides, with the
+   candidate's grid rotated consistently with the shape edge shift k.
+
+`build_gallery` loads all clean (non `corner_disagreement`) M3 piece records
+for one background, loads each piece's photo + M1 full contour to compute
+color histograms, and returns one `PieceFingerprint` per piece. The CLI
+persists color histograms + piece references to
+`outputs/fingerprints/{background}.json`; shape data is cheap to recompute
+from the M3 piece records and is intentionally NOT duplicated into that
+file. `load_gallery` reverses this: it reads a fingerprint JSON for the
+color data and re-derives the canonical edge arrays from the M3 records.
+
+Usage:
+    cd network
+    uv run python experiments/exp28_piece_geometry/fingerprint.py
+    uv run python experiments/exp28_piece_geometry/fingerprint.py --background wood
+"""
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import cv2
+import numpy as np
+from edge_match import canonicalize_edge
+
+DEFAULT_DATASET_ROOT = Path("/Users/claus/Repos/pussel/network/datasets/north_star/v1")
+
+BACKGROUNDS = ("red_carpet", "gray_fabric", "cardboard", "wood")
+DIRECTIONS = ("N", "E", "S", "W")
+
+# Erosion radius (pixels) applied to the M1 full contour mask before
+# sampling color, to strip the background halo/anti-aliased edge.
+ERODE_PX = 5
+
+# L*a*b* joint histogram: 8 bins/channel -> 512-d.
+LAB_BINS = 8
+# a*b*-only histogram (lighting-robustness hypothesis): 16 bins/channel -> 256-d.
+AB_BINS = 16
+# OpenCV's 8-bit BGR2LAB maps all three channels into [0, 255].
+CHANNEL_RANGE = (0, 256)
+
+# Spatial color descriptor: the piece's axis-aligned bbox is divided into a
+# SPATIAL_GRID x SPATIAL_GRID grid (upright photo frame); each cell gets a
+# gray-world a*b* histogram with SPATIAL_AB_BINS bins/channel; cells with
+# fewer than SPATIAL_MIN_PIXELS masked pixels are marked empty.
+SPATIAL_GRID = 3
+SPATIAL_AB_BINS = 8
+SPATIAL_MIN_PIXELS = 50
+
+
+def _spatial_rotation_permutations() -> np.ndarray:
+    """Cell-index permutations of the spatial grid under CCW rotations.
+
+    Row k gives, for each query cell index (row-major 3x3), the CANDIDATE
+    cell index that occupies the same physical location once the candidate
+    piece is rotated CCW by k*90 degrees - matching the shape edge shift k
+    convention (query edge i pairs with candidate edge (i+k) mod 4).
+
+    Returns:
+        (4, SPATIAL_GRID**2) integer permutation array.
+    """
+    idx = np.arange(SPATIAL_GRID**2).reshape(SPATIAL_GRID, SPATIAL_GRID)
+    return np.stack([np.rot90(idx, k).flatten() for k in range(4)], axis=0)
+
+
+SPATIAL_ROT_PERMS = _spatial_rotation_permutations()
+
+
+@dataclass(frozen=True)
+class PieceFingerprint:
+    """One physical piece's fingerprint from one background photo.
+
+    Attributes:
+        puzzle_id: Puzzle identifier.
+        row: Piece grid row.
+        col: Piece grid column.
+        background: Background surface name of the source photo.
+        piece_file: Path to the piece photo, relative to the dataset root.
+        edge_types: Edge type per direction, in N/E/S/W order.
+        edges_canonical: (4, 100, 2) canonical edge polylines, N/E/S/W order,
+            each via `edge_match.canonicalize_edge` (not mate-flipped).
+        color_hist_lab: 512-d L1-normalized joint L*a*b* histogram (8 bins/channel).
+        color_hist_ab: 256-d L1-normalized a*b*-only histogram (16 bins/channel).
+        color_hist_ab_gw: 256-d L1-normalized a*b*-only histogram after
+            gray-world normalization of the masked pixels.
+        spatial_hists: (9, 64) per-grid-cell gray-world a*b* histograms
+            (row-major 3x3 over the piece bbox), each L1-normalized or zero.
+        spatial_nonempty: (9,) boolean flags, True where the cell has at
+            least `SPATIAL_MIN_PIXELS` masked pixels.
+    """
+
+    puzzle_id: str
+    row: int
+    col: int
+    background: str
+    piece_file: str
+    edge_types: Tuple[str, str, str, str]
+    edges_canonical: np.ndarray
+    color_hist_lab: np.ndarray
+    color_hist_ab: np.ndarray
+    color_hist_ab_gw: np.ndarray
+    spatial_hists: np.ndarray
+    spatial_nonempty: np.ndarray
+
+    @property
+    def identity(self) -> Tuple[str, int, int]:
+        """The physical-piece identity key (puzzle_id, row, col), shared across backgrounds."""
+        return (self.puzzle_id, self.row, self.col)
+
+
+def canonical_edges_from_record(record: Dict) -> np.ndarray:
+    """Compute the (4, 100, 2) canonical edge array (N/E/S/W order) from an M3 piece record.
+
+    Args:
+        record: A loaded `outputs/piece_records/{puzzle}/{stem}.json` dict.
+
+    Returns:
+        (4, 100, 2) float array of canonical (chord-normalized, unflipped) edge polylines.
+    """
+    arrays = []
+    for direction in DIRECTIONS:
+        polyline = np.array(record["edges"][direction]["polyline"], dtype=np.float64)
+        arrays.append(canonicalize_edge(polyline))
+    return np.stack(arrays, axis=0)
+
+
+def type_signature_from_record(record: Dict) -> Tuple[str, str, str, str]:
+    """Extract the (N, E, S, W) edge-type signature from an M3 piece record.
+
+    Args:
+        record: A loaded piece-record dict.
+
+    Returns:
+        4-tuple of edge types ("tab"/"blank"/"flat"), N/E/S/W order.
+    """
+    return tuple(record["edges"][direction]["type"] for direction in DIRECTIONS)  # type: ignore[return-value]
+
+
+def load_full_contour(contours_dir: Path, puzzle_id: str, piece_stem: str) -> Optional[np.ndarray]:
+    """Load a piece's clean rembg contour from the M1 outputs, if it exists.
+
+    Args:
+        contours_dir: The `outputs/contours` directory.
+        puzzle_id: The piece's puzzle id.
+        piece_stem: The piece's filename stem.
+
+    Returns:
+        Nx2 contour array in original image coordinates, or None when the
+        contour JSON is missing, has no rembg contour, or is not clean.
+    """
+    contour_path = contours_dir / puzzle_id / f"{piece_stem}.json"
+    if not contour_path.exists():
+        return None
+    with open(contour_path, encoding="utf-8") as handle:
+        data = json.load(handle)
+    rembg = data["methods"].get("rembg")
+    if not rembg or not rembg.get("contour") or not rembg["quality"]["is_clean"]:
+        return None
+    return np.array(rembg["contour"], dtype=np.float64)
+
+
+def build_piece_mask(image_shape: Tuple[int, ...], contour: np.ndarray, erode_px: int = ERODE_PX) -> np.ndarray:
+    """Rasterize a full-image-coordinate contour into an eroded binary mask.
+
+    Args:
+        image_shape: The source photo's (H, W[, C]) shape.
+        contour: Nx2 contour points in the photo's own pixel coordinates.
+        erode_px: Erosion radius in pixels, to strip the background halo.
+
+    Returns:
+        Binary mask (H, W) with values in {0, 255}.
+    """
+    mask = np.zeros(image_shape[:2], dtype=np.uint8)
+    cv2.fillPoly(mask, [contour.astype(np.int32)], 255)
+    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (2 * erode_px + 1, 2 * erode_px + 1))
+    return cv2.erode(mask, kernel, iterations=1)
+
+
+def _ab_histogram(lab_pixels: np.ndarray) -> np.ndarray:
+    """L1-normalized a*b*-only histogram (16x16) of L*a*b* pixels.
+
+    Args:
+        lab_pixels: (N, 3) L*a*b* pixel values in OpenCV 8-bit ranges.
+
+    Returns:
+        256-d L1-normalized histogram.
+    """
+    hist_ab, _, _ = np.histogram2d(lab_pixels[:, 1], lab_pixels[:, 2], bins=AB_BINS, range=(CHANNEL_RANGE,) * 2)
+    hist_ab = hist_ab.flatten()
+    return hist_ab / max(hist_ab.sum(), 1e-10)
+
+
+def _gray_world_lab_pixels(bgr_pixels: np.ndarray) -> np.ndarray:
+    """Gray-world-normalize BGR pixels and convert them to L*a*b*.
+
+    Scales each BGR channel so the pixel-set mean is neutral (all channel
+    means equal to their overall mean), clips to [0, 255], and converts the
+    result to OpenCV 8-bit L*a*b*.
+
+    Args:
+        bgr_pixels: (N, 3) float BGR pixel values.
+
+    Returns:
+        (N, 3) L*a*b* pixel values after gray-world normalization.
+    """
+    channel_means = bgr_pixels.mean(axis=0)
+    gray = float(channel_means.mean())
+    scaled = bgr_pixels * (gray / np.maximum(channel_means, 1e-9))
+    scaled_u8 = np.clip(scaled, 0, 255).astype(np.uint8).reshape(-1, 1, 3)
+    return cv2.cvtColor(scaled_u8, cv2.COLOR_BGR2LAB).reshape(-1, 3).astype(np.float64)
+
+
+def compute_color_histograms(image_bgr: np.ndarray, mask: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Compute the three L1-normalized color histograms over masked pixels.
+
+    Variants: (a) joint L*a*b* 8x8x8, (b) a*b*-only 16x16, (c) a*b*-only
+    16x16 after gray-world normalization of the masked pixels
+    (illuminant-robustness hypothesis).
+
+    Args:
+        image_bgr: The full photo in OpenCV BGR channel order.
+        mask: Binary mask (H, W), values in {0, 255}; nonzero pixels are sampled.
+
+    Returns:
+        Tuple of (512-d L*a*b* histogram, 256-d a*b* histogram, 256-d
+        gray-world a*b* histogram), each L1-normalized.
+    """
+    lab = cv2.cvtColor(image_bgr, cv2.COLOR_BGR2LAB)
+    ys, xs = np.where(mask > 0)
+    if len(ys) == 0:
+        zeros_ab = np.zeros(AB_BINS**2, dtype=np.float64)
+        return np.zeros(LAB_BINS**3, dtype=np.float64), zeros_ab, zeros_ab.copy()
+
+    pixels = lab[ys, xs].astype(np.float64)
+
+    hist_lab, _ = np.histogramdd(pixels, bins=(LAB_BINS, LAB_BINS, LAB_BINS), range=(CHANNEL_RANGE,) * 3)
+    hist_lab = hist_lab.flatten()
+    hist_lab = hist_lab / max(hist_lab.sum(), 1e-10)
+
+    hist_ab = _ab_histogram(pixels)
+
+    bgr_pixels = image_bgr[ys, xs].astype(np.float64)
+    hist_ab_gw = _ab_histogram(_gray_world_lab_pixels(bgr_pixels))
+
+    return hist_lab, hist_ab, hist_ab_gw
+
+
+def compute_spatial_color(
+    image_bgr: np.ndarray, mask: np.ndarray, contour: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Compute the 3x3 spatial gray-world a*b* color descriptor over masked pixels.
+
+    The piece's axis-aligned bbox (from the full contour, upright photo
+    frame) is divided into a `SPATIAL_GRID` x `SPATIAL_GRID` grid. All
+    masked pixels are gray-world normalized TOGETHER (one piece-level
+    illuminant correction, same transform as the global ab_gw histogram),
+    then binned per grid cell into an a*b* histogram with
+    `SPATIAL_AB_BINS` bins/channel. Cells with fewer than
+    `SPATIAL_MIN_PIXELS` masked pixels are marked empty.
+
+    Args:
+        image_bgr: The full photo in OpenCV BGR channel order.
+        mask: Binary mask (H, W), values in {0, 255}; nonzero pixels are sampled.
+        contour: Nx2 full contour in the photo's own pixel coordinates
+            (defines the bbox the grid spans).
+
+    Returns:
+        Tuple of (per-cell histograms (9, SPATIAL_AB_BINS**2), row-major
+        cell order, each L1-normalized or all-zero when empty; (9,) boolean
+        non-empty flags).
+    """
+    n_cells = SPATIAL_GRID**2
+    hists = np.zeros((n_cells, SPATIAL_AB_BINS**2), dtype=np.float64)
+    nonempty = np.zeros(n_cells, dtype=bool)
+
+    ys, xs = np.where(mask > 0)
+    if len(ys) == 0:
+        return hists, nonempty
+
+    lab_pixels = _gray_world_lab_pixels(image_bgr[ys, xs].astype(np.float64))
+
+    x1, y1 = contour[:, 0].min(), contour[:, 1].min()
+    x2, y2 = contour[:, 0].max(), contour[:, 1].max()
+    cell_cols = np.clip(((xs - x1) * SPATIAL_GRID / max(x2 - x1, 1e-9)).astype(np.int64), 0, SPATIAL_GRID - 1)
+    cell_rows = np.clip(((ys - y1) * SPATIAL_GRID / max(y2 - y1, 1e-9)).astype(np.int64), 0, SPATIAL_GRID - 1)
+    cell_idx = cell_rows * SPATIAL_GRID + cell_cols
+
+    for cell in range(n_cells):
+        in_cell = cell_idx == cell
+        if int(in_cell.sum()) < SPATIAL_MIN_PIXELS:
+            continue
+        cell_pixels = lab_pixels[in_cell]
+        hist, _, _ = np.histogram2d(
+            cell_pixels[:, 1], cell_pixels[:, 2], bins=SPATIAL_AB_BINS, range=(CHANNEL_RANGE,) * 2
+        )
+        hist = hist.flatten()
+        hists[cell] = hist / max(hist.sum(), 1e-10)
+        nonempty[cell] = True
+
+    return hists, nonempty
+
+
+def spatial_color_distance_matrix(
+    query_hists: np.ndarray,
+    query_nonempty: np.ndarray,
+    gallery_hists: np.ndarray,
+    gallery_nonempty: np.ndarray,
+    k_per_candidate: np.ndarray,
+) -> np.ndarray:
+    """Spatial color distance from one query piece to a gallery, rotation-consistent.
+
+    Each candidate's 3x3 grid is rotated by its shape-chosen edge shift k
+    (via `SPATIAL_ROT_PERMS`), then the distance is the mean per-cell
+    chi-square over cells non-empty on BOTH sides. Candidates sharing no
+    non-empty cell with the query get the maximum chi-square distance (1.0).
+
+    Args:
+        query_hists: (9, D) query cell histograms.
+        query_nonempty: (9,) query non-empty flags.
+        gallery_hists: (N, 9, D) gallery cell histograms.
+        gallery_nonempty: (N, 9) gallery non-empty flags.
+        k_per_candidate: (N,) edge shift k chosen by the shape distance for
+            each candidate (all zeros for the fixed-orientation protocol).
+
+    Returns:
+        (N,) spatial color distances.
+    """
+    n = gallery_hists.shape[0]
+    out = np.full(n, 1.0, dtype=np.float64)
+    for k in np.unique(k_per_candidate):
+        group = np.where(k_per_candidate == k)[0]
+        perm = SPATIAL_ROT_PERMS[int(k) % 4]
+        cand_hists = gallery_hists[group][:, perm, :]  # (G, 9, D)
+        cand_nonempty = gallery_nonempty[group][:, perm]  # (G, 9)
+        q = query_hists[None, :, :]
+        per_cell = 0.5 * np.sum((q - cand_hists) ** 2 / (q + cand_hists + 1e-10), axis=2)  # (G, 9)
+        valid = query_nonempty[None, :] & cand_nonempty  # (G, 9)
+        n_valid = valid.sum(axis=1)
+        sums = np.where(valid, per_cell, 0.0).sum(axis=1)
+        has_valid = n_valid > 0
+        out[group[has_valid]] = sums[has_valid] / n_valid[has_valid]
+    return out
+
+
+def chi_square_distance(p: np.ndarray, q: np.ndarray) -> float:
+    """Chi-square distance between two L1-normalized histograms.
+
+    Args:
+        p: First histogram.
+        q: Second histogram, same shape as `p`.
+
+    Returns:
+        0.5 * sum((p - q)^2 / (p + q + eps)).
+    """
+    return float(0.5 * np.sum((p - q) ** 2 / (p + q + 1e-10)))
+
+
+def chi_square_distance_matrix(query_hist: np.ndarray, gallery_hists: np.ndarray) -> np.ndarray:
+    """Vectorized chi-square distance from one query histogram to a gallery of histograms.
+
+    Args:
+        query_hist: (D,) histogram.
+        gallery_hists: (N, D) stacked histograms.
+
+    Returns:
+        (N,) chi-square distances.
+    """
+    p = query_hist[None, :]
+    q = gallery_hists
+    return 0.5 * np.sum((p - q) ** 2 / (p + q + 1e-10), axis=1)
+
+
+def shape_pair_distance(
+    query_edges: np.ndarray,
+    query_types: Tuple[str, str, str, str],
+    candidate_edges: np.ndarray,
+    candidate_types: Tuple[str, str, str, str],
+    rotation_invariant: bool = True,
+) -> float:
+    """Scalar same-piece shape distance between two pieces' canonical edge sets.
+
+    For each candidate cyclic shift k of the edge order (k=0 only when
+    `rotation_invariant` is False), compares query edge i (same traversal,
+    no mate-flip) to candidate edge (i+k) mod 4 via `edge_match`-style mean
+    pointwise L2, and requires the shifted type signature to match the
+    query's exactly to be an eligible k. Returns the minimum eligible
+    per-edge-mean distance, falling back to the minimum over ALL k when no
+    shift's type signature matches.
+
+    Args:
+        query_edges: (4, 100, 2) canonical edges, N/E/S/W order.
+        query_types: (N, E, S, W) edge types for the query.
+        candidate_edges: (4, 100, 2) canonical edges, N/E/S/W order.
+        candidate_types: (N, E, S, W) edge types for the candidate.
+        rotation_invariant: When False, only k=0 is considered.
+
+    Returns:
+        The scalar shape distance.
+    """
+    ks = range(4) if rotation_invariant else (0,)
+    l2_by_k = []
+    gate_by_k = []
+    for k in ks:
+        shift = [(i + k) % 4 for i in range(4)]
+        shifted_types = tuple(candidate_types[j] for j in shift)
+        gate_by_k.append(shifted_types == query_types)
+        per_edge = [
+            float(np.mean(np.linalg.norm(query_edges[i] - candidate_edges[shift[i]], axis=1))) for i in range(4)
+        ]
+        l2_by_k.append(float(np.mean(per_edge)))
+    if any(gate_by_k):
+        return min(dist for dist, ok in zip(l2_by_k, gate_by_k) if ok)
+    return min(l2_by_k)
+
+
+def shape_distance_matrix(
+    query_edges: np.ndarray,
+    query_types: Tuple[str, str, str, str],
+    gallery_edges: np.ndarray,
+    gallery_types: np.ndarray,
+    rotation_invariant: bool = True,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Vectorized same-piece shape distance from one query piece to a gallery of pieces.
+
+    Same semantics as `shape_pair_distance`, computed for the whole gallery
+    at once via numpy broadcasting. Also returns the winning cyclic shift k
+    per candidate, so downstream rotation-sensitive descriptors (the spatial
+    color grid) can stay consistent with the shape alignment.
+
+    Args:
+        query_edges: (4, 100, 2) canonical edges, N/E/S/W order.
+        query_types: (N, E, S, W) edge types for the query.
+        gallery_edges: (N, 4, 100, 2) canonical edges for N gallery pieces.
+        gallery_types: (N, 4) string array of gallery edge types, N/E/S/W order.
+        rotation_invariant: When False, only k=0 is considered.
+
+    Returns:
+        Tuple of ((N,) shape distances, (N,) winning shift k per candidate).
+    """
+    ks = range(4) if rotation_invariant else (0,)
+    n = gallery_edges.shape[0]
+    query_types_arr = np.array(query_types)
+    l2_stack = np.empty((len(ks), n), dtype=np.float64)
+    gate_stack = np.empty((len(ks), n), dtype=bool)
+    for row, k in enumerate(ks):
+        shift = [(i + k) % 4 for i in range(4)]
+        shifted_edges = gallery_edges[:, shift, :, :]  # (N, 4, 100, 2)
+        diffs = query_edges[None, :, :, :] - shifted_edges
+        per_point = np.linalg.norm(diffs, axis=3)  # (N, 4, 100)
+        per_edge_mean = per_point.mean(axis=2)  # (N, 4)
+        l2_stack[row] = per_edge_mean.mean(axis=1)  # (N,)
+        shifted_types = gallery_types[:, shift]  # (N, 4)
+        gate_stack[row] = np.all(shifted_types == query_types_arr[None, :], axis=1)
+
+    any_gate = gate_stack.any(axis=0)
+    masked = np.where(gate_stack, l2_stack, np.inf)
+    ks_arr = np.array(list(ks))
+    best_k = np.where(any_gate, ks_arr[np.argmin(masked, axis=0)], ks_arr[np.argmin(l2_stack, axis=0)])
+    best_gated = masked.min(axis=0)
+    best_all = l2_stack.min(axis=0)
+    return np.where(any_gate, best_gated, best_all), best_k
+
+
+def build_gallery(records_dir: Path, contours_dir: Path, dataset_root: Path, background: str) -> List[PieceFingerprint]:
+    """Build fingerprints for every clean, non-disagreement piece record of one background.
+
+    "Clean record" = an M3 piece-record JSON exists for this piece x
+    background AND `corner_disagreement` is False (M4 found this gate worth
+    ~8 top-1 points on shape alone; M6 applies the same filter to both the
+    shape and color signal).
+
+    Args:
+        records_dir: The `outputs/piece_records` directory.
+        contours_dir: The `outputs/contours` directory (M1 full contours,
+            used to rasterize the color-sampling mask).
+        dataset_root: The north_star v1 dataset root (for photo pixels).
+        background: Background name to filter to.
+
+    Returns:
+        One `PieceFingerprint` per eligible piece, in file order.
+    """
+    fingerprints: List[PieceFingerprint] = []
+    for path in sorted(records_dir.glob("*/*.json")):
+        with open(path, encoding="utf-8") as handle:
+            record = json.load(handle)
+        if record["background"] != background or record["corner_disagreement"]:
+            continue
+
+        piece_stem = Path(record["piece_file"]).stem
+        contour = load_full_contour(contours_dir, record["puzzle_id"], piece_stem)
+        if contour is None:
+            continue
+
+        image_path = dataset_root / record["piece_file"]
+        image = cv2.imread(str(image_path))
+        if image is None:
+            continue
+
+        mask = build_piece_mask(image.shape, contour)
+        hist_lab, hist_ab, hist_ab_gw = compute_color_histograms(image, mask)
+        spatial_hists, spatial_nonempty = compute_spatial_color(image, mask, contour)
+
+        fingerprints.append(
+            PieceFingerprint(
+                puzzle_id=record["puzzle_id"],
+                row=record["row"],
+                col=record["col"],
+                background=background,
+                piece_file=record["piece_file"],
+                edge_types=type_signature_from_record(record),
+                edges_canonical=canonical_edges_from_record(record),
+                color_hist_lab=hist_lab,
+                color_hist_ab=hist_ab,
+                color_hist_ab_gw=hist_ab_gw,
+                spatial_hists=spatial_hists,
+                spatial_nonempty=spatial_nonempty,
+            )
+        )
+    return fingerprints
+
+
+def save_fingerprints(fingerprints: List[PieceFingerprint], path: Path) -> None:
+    """Persist a gallery's color histograms + piece references (not shape data) to JSON.
+
+    Args:
+        fingerprints: The gallery to persist.
+        path: Output JSON path.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "background": fingerprints[0].background if fingerprints else None,
+        "n_pieces": len(fingerprints),
+        "pieces": [
+            {
+                "puzzle_id": fp.puzzle_id,
+                "row": fp.row,
+                "col": fp.col,
+                "piece_file": fp.piece_file,
+                "edge_types": list(fp.edge_types),
+                "color_hist_lab": fp.color_hist_lab.tolist(),
+                "color_hist_ab": fp.color_hist_ab.tolist(),
+                "color_hist_ab_gw": fp.color_hist_ab_gw.tolist(),
+                "spatial_hists": fp.spatial_hists.tolist(),
+                "spatial_nonempty": fp.spatial_nonempty.tolist(),
+            }
+            for fp in fingerprints
+        ],
+    }
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(data, handle)
+
+
+def load_gallery(fingerprint_path: Path, records_dir: Path) -> List[PieceFingerprint]:
+    """Reload a persisted gallery, re-deriving shape data from the M3 piece records.
+
+    Args:
+        fingerprint_path: Path to an `outputs/fingerprints/{background}.json` file.
+        records_dir: The `outputs/piece_records` directory.
+
+    Returns:
+        One `PieceFingerprint` per persisted piece.
+    """
+    with open(fingerprint_path, encoding="utf-8") as handle:
+        data = json.load(handle)
+    background = data["background"]
+
+    fingerprints: List[PieceFingerprint] = []
+    for piece in data["pieces"]:
+        piece_stem = Path(piece["piece_file"]).stem
+        record_path = records_dir / piece["puzzle_id"] / f"{piece_stem}.json"
+        with open(record_path, encoding="utf-8") as handle:
+            record = json.load(handle)
+        fingerprints.append(
+            PieceFingerprint(
+                puzzle_id=piece["puzzle_id"],
+                row=piece["row"],
+                col=piece["col"],
+                background=background,
+                piece_file=piece["piece_file"],
+                edge_types=tuple(piece["edge_types"]),  # type: ignore[arg-type]
+                edges_canonical=canonical_edges_from_record(record),
+                color_hist_lab=np.array(piece["color_hist_lab"], dtype=np.float64),
+                color_hist_ab=np.array(piece["color_hist_ab"], dtype=np.float64),
+                color_hist_ab_gw=np.array(piece["color_hist_ab_gw"], dtype=np.float64),
+                spatial_hists=np.array(piece["spatial_hists"], dtype=np.float64),
+                spatial_nonempty=np.array(piece["spatial_nonempty"], dtype=bool),
+            )
+        )
+    return fingerprints
+
+
+def main() -> None:
+    """CLI entry point: build and persist fingerprints for one or all backgrounds."""
+    parser = argparse.ArgumentParser(description="Build piece fingerprints (shape + color) per background.")
+    parser.add_argument("--dataset-root", type=Path, default=DEFAULT_DATASET_ROOT)
+    parser.add_argument("--records-dir", type=Path, default=Path(__file__).parent / "outputs" / "piece_records")
+    parser.add_argument("--contours-dir", type=Path, default=Path(__file__).parent / "outputs" / "contours")
+    parser.add_argument("--output-dir", type=Path, default=Path(__file__).parent / "outputs")
+    parser.add_argument("--background", type=str, default=None, choices=BACKGROUNDS)
+    args = parser.parse_args()
+
+    backgrounds = [args.background] if args.background else list(BACKGROUNDS)
+    fingerprints_dir = args.output_dir / "fingerprints"
+
+    n_total_pieces = len({(r.puzzle_id, r.row, r.col) for r in _distinct_pieces(args.records_dir)})
+    for background in backgrounds:
+        fingerprints = build_gallery(args.records_dir, args.contours_dir, args.dataset_root, background)
+        out_path = fingerprints_dir / f"{background}.json"
+        save_fingerprints(fingerprints, out_path)
+        print(f"{background:12s}: {len(fingerprints):3d}/{n_total_pieces} clean pieces fingerprinted -> {out_path}")
+
+
+def _distinct_pieces(records_dir: Path) -> List["_Identity"]:
+    """Enumerate distinct (puzzle_id, row, col) physical pieces across all piece records.
+
+    Args:
+        records_dir: The `outputs/piece_records` directory.
+
+    Returns:
+        List of lightweight identity holders (one per distinct physical piece).
+    """
+    seen: Dict[Tuple[str, int, int], "_Identity"] = {}
+    for path in sorted(records_dir.glob("*/*.json")):
+        with open(path, encoding="utf-8") as handle:
+            record = json.load(handle)
+        key = (record["puzzle_id"], record["row"], record["col"])
+        seen.setdefault(key, _Identity(*key))
+    return list(seen.values())
+
+
+@dataclass(frozen=True)
+class _Identity:
+    """Lightweight (puzzle_id, row, col) identity holder for counting distinct physical pieces."""
+
+    puzzle_id: str
+    row: int
+    col: int
+
+
+if __name__ == "__main__":
+    main()

--- a/network/experiments/exp28_piece_geometry/label_corners.py
+++ b/network/experiments/exp28_piece_geometry/label_corners.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""M2 hand-labeling tool: click the 4 true corners of real piece photos.
+
+Interactive matplotlib tool. Shows each piece crop (with its rembg contour
+overlaid when available) and waits for 4 mouse clicks marking the corners.
+Autosaves to `--labels-file` after every piece, so progress is never lost.
+
+Keys:
+    u - undo the last click
+    r - redo this piece (clear all 4 clicks and start over)
+    s - skip this piece without labeling it
+    q - quit and save
+
+Usage:
+    cd network
+    uv run python experiments/exp28_piece_geometry/label_corners.py --limit 20
+    uv run python experiments/exp28_piece_geometry/label_corners.py --puzzle bambi --background red_carpet
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import cv2
+import matplotlib.pyplot as plt
+import numpy as np
+from common import PieceRecord, crop_with_margin, load_metadata
+
+DEFAULT_DATASET_ROOT = Path("/Users/claus/Repos/pussel/network/datasets/north_star/v1")
+DEFAULT_LABELS_FILE = Path(__file__).parent / "outputs" / "corner_labels.json"
+DEFAULT_MARGIN_FRAC = 0.15
+
+
+def _load_labels(labels_file: Path) -> Dict[str, Any]:
+    """Load existing labels, if any.
+
+    Args:
+        labels_file: Path to the labels JSON file.
+
+    Returns:
+        The labels dict, keyed by piece_file. Empty dict if the file is absent.
+    """
+    if labels_file.exists():
+        with open(labels_file, encoding="utf-8") as handle:
+            return json.load(handle)
+    return {}
+
+
+def _save_labels(labels_file: Path, labels: Dict[str, Any]) -> None:
+    """Persist labels to disk.
+
+    Args:
+        labels_file: Path to the labels JSON file.
+        labels: The labels dict to save.
+    """
+    labels_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(labels_file, "w", encoding="utf-8") as handle:
+        json.dump(labels, handle, indent=2)
+
+
+def _load_contour(contours_dir: Optional[Path], record: PieceRecord) -> Optional[np.ndarray]:
+    """Load a piece's saved rembg contour, if available.
+
+    Args:
+        contours_dir: The `outputs/contours` directory, or None to skip.
+        record: The piece's metadata row.
+
+    Returns:
+        Nx2 contour array in original image coordinates, or None.
+    """
+    if contours_dir is None:
+        return None
+    path = contours_dir / record.puzzle_id / f"{record.piece_stem}.json"
+    if not path.exists():
+        return None
+    with open(path, encoding="utf-8") as handle:
+        data = json.load(handle)
+    contour = data["methods"].get("rembg", {}).get("contour")
+    return np.array(contour) if contour else None
+
+
+class LabelSession:
+    """Drives one matplotlib figure through a sequence of pieces to label."""
+
+    def __init__(
+        self,
+        dataset_root: Path,
+        contours_dir: Optional[Path],
+        records: List[PieceRecord],
+        labels: Dict[str, Any],
+        labels_file: Path,
+    ) -> None:
+        """Set up the labeling session.
+
+        Args:
+            dataset_root: The north_star dataset root.
+            contours_dir: Optional `outputs/contours` directory for contour overlays.
+            records: Pieces to label, in order.
+            labels: The in-memory labels dict (mutated and autosaved as we go).
+            labels_file: Where to autosave `labels`.
+        """
+        self.dataset_root = dataset_root
+        self.contours_dir = contours_dir
+        self.records = records
+        self.labels = labels
+        self.labels_file = labels_file
+        self.index = 0
+        self.clicks: List[List[float]] = []
+        self.quit_requested = False
+
+        self.fig, self.ax = plt.subplots(figsize=(7, 7))
+        self.fig.canvas.mpl_connect("button_press_event", self._on_click)
+        self.fig.canvas.mpl_connect("key_press_event", self._on_key)
+
+    def run(self) -> None:
+        """Run the labeling loop until all pieces are done or the user quits."""
+        while self.index < len(self.records) and not self.quit_requested:
+            self._render_current()
+            plt.waitforbuttonpress()
+            while self.fig.canvas.manager is not None and not self.quit_requested and len(self.clicks) < 4:
+                if not plt.fignum_exists(self.fig.number):
+                    self.quit_requested = True
+                    break
+                plt.waitforbuttonpress()
+        plt.close(self.fig)
+
+    def _render_current(self) -> None:
+        """Draw the current piece crop, contour overlay, and any clicks so far."""
+        record = self.records[self.index]
+        image = cv2.imread(str(self.dataset_root / record.piece_file))
+        crop, offset = crop_with_margin(image, record.bbox, margin_frac=DEFAULT_MARGIN_FRAC)
+        self._offset = offset
+        crop_rgb = cv2.cvtColor(crop, cv2.COLOR_BGR2RGB)
+
+        self.ax.clear()
+        self.ax.imshow(crop_rgb)
+        self.ax.set_title(
+            f"[{self.index + 1}/{len(self.records)}] {record.puzzle_id} r{record.row}c{record.col} "
+            f"{record.background} -- click 4 corners (u=undo r=redo s=skip q=quit)"
+        )
+
+        contour = _load_contour(self.contours_dir, record)
+        if contour is not None:
+            local = contour - np.array(offset)
+            self.ax.plot(local[:, 0], local[:, 1], color="cyan", linewidth=1, alpha=0.7)
+
+        for x, y in self.clicks:
+            self.ax.plot(x, y, "o", color="lime", markersize=8)
+
+        self.fig.canvas.draw_idle()
+
+    def _on_click(self, event: Any) -> None:
+        """Record a corner click.
+
+        Args:
+            event: Matplotlib mouse event.
+        """
+        if event.inaxes != self.ax or event.xdata is None or event.ydata is None:
+            return
+        self.clicks.append([event.xdata, event.ydata])
+        self._render_current()
+        if len(self.clicks) == 4:
+            self._commit_piece()
+
+    def _on_key(self, event: Any) -> None:
+        """Handle keyboard shortcuts (undo/redo/skip/quit).
+
+        Args:
+            event: Matplotlib key event.
+        """
+        if event.key == "u" and self.clicks:
+            self.clicks.pop()
+            self._render_current()
+        elif event.key == "r":
+            self.clicks = []
+            self._render_current()
+        elif event.key == "s":
+            self.clicks = []
+            self.index += 1
+            if self.index < len(self.records):
+                self._render_current()
+            else:
+                self.quit_requested = True
+        elif event.key == "q":
+            self.quit_requested = True
+
+    def _commit_piece(self) -> None:
+        """Convert the 4 clicks to original-image coordinates, save, and advance."""
+        record = self.records[self.index]
+        offset_x, offset_y = self._offset
+        original_coords = [[x + offset_x, y + offset_y] for x, y in self.clicks]
+        self.labels[record.piece_file] = {"corners": original_coords, "background": record.background}
+        _save_labels(self.labels_file, self.labels)
+        print(f"Saved {record.piece_file} ({self.index + 1}/{len(self.records)})")
+
+        self.clicks = []
+        self.index += 1
+        if self.index < len(self.records):
+            self._render_current()
+        else:
+            self.quit_requested = True
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Hand-label the 4 true corners of north_star piece photos.")
+    parser.add_argument("--dataset-root", type=Path, default=DEFAULT_DATASET_ROOT)
+    parser.add_argument("--contours-dir", type=Path, default=Path(__file__).parent / "outputs" / "contours")
+    parser.add_argument("--labels-file", type=Path, default=DEFAULT_LABELS_FILE)
+    parser.add_argument("--puzzle", type=str, default=None, help="Substring filter on puzzle_id")
+    parser.add_argument("--background", type=str, default=None, help="Exact filter on background")
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--only-unlabeled", action=argparse.BooleanOptionalAction, default=True)
+    args = parser.parse_args()
+
+    records = load_metadata(args.dataset_root)
+    if args.puzzle:
+        records = [r for r in records if args.puzzle in r.puzzle_id]
+    if args.background:
+        records = [r for r in records if r.background == args.background]
+
+    labels = _load_labels(args.labels_file)
+    if args.only_unlabeled:
+        records = [r for r in records if r.piece_file not in labels]
+
+    if args.limit is not None:
+        records = records[: args.limit]
+
+    if not records:
+        print("Nothing to label (no pieces matched the filters, or all are already labeled).")
+        return
+
+    contours_dir = args.contours_dir if args.contours_dir.exists() else None
+    session = LabelSession(args.dataset_root, contours_dir, records, labels, args.labels_file)
+    session.run()
+    print(f"\nLabeled {len(session.labels)} pieces total. Saved to {args.labels_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/network/experiments/exp28_piece_geometry/label_corners.py
+++ b/network/experiments/exp28_piece_geometry/label_corners.py
@@ -27,7 +27,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 from common import PieceRecord, crop_with_margin, load_metadata
 
-DEFAULT_DATASET_ROOT = Path("/Users/claus/Repos/pussel/network/datasets/north_star/v1")
+# Repo-relative default (this script lives in network/experiments/exp28_piece_geometry/,
+# so parents[2] is the network/ dir); override with --dataset-root.
+DEFAULT_DATASET_ROOT = Path(__file__).resolve().parents[2] / "datasets" / "north_star" / "v1"
 DEFAULT_LABELS_FILE = Path(__file__).parent / "outputs" / "corner_labels.json"
 DEFAULT_MARGIN_FRAC = 0.15
 

--- a/network/experiments/exp28_piece_geometry/synth_benchmark.py
+++ b/network/experiments/exp28_piece_geometry/synth_benchmark.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""M2 quantitative: corner-detector bake-off on synthetic pieces with known ground truth.
+
+Generates `--n` random pieces via `puzzle_shapes.PieceConfig.random()`,
+rasterizes each to a filled mask (~500px piece size), applies a random
+rotation (expanding the canvas so nothing clips), Gaussian blur, light noise,
+and binarization to mimic a segmented real-photo mask, then runs all three
+`corner_detect` detectors and scores them against the known corner positions
+(the base square's corners, carried through the same rotation).
+
+Metric per piece per method: max over the 4 corners of (distance from
+predicted to its optimally-assigned true corner) / piece diagonal size, as a
+percentage. A method "succeeds" on a piece when that value is <= 3%.
+
+Usage:
+    cd network
+    uv run python experiments/exp28_piece_geometry/synth_benchmark.py --n 10
+    uv run python experiments/exp28_piece_geometry/synth_benchmark.py --n 200 --seed 42
+"""
+
+import argparse
+import csv
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import cv2
+import numpy as np
+from common import mask_to_contour
+from corner_detect import (
+    CornerResult,
+    InsufficientCornersError,
+    detect_corners_curvature,
+    detect_corners_polydp,
+    detect_corners_shitomasi,
+)
+from puzzle_shapes import PieceConfig, generate_piece_path
+from scipy.optimize import linear_sum_assignment
+
+PIECE_SIZE_PX = 500.0
+CANVAS_PAD_FRAC = 0.15  # extra canvas padding, as a fraction of piece size, for tab bulges
+BLUR_SIGMA = 1.0
+NOISE_STD = 6.0
+SUCCESS_THRESHOLD_PCT = 3.0
+
+METHODS = ("curvature", "polydp", "shitomasi")
+
+
+@dataclass(frozen=True)
+class SyntheticPiece:
+    """A rasterized synthetic piece with known ground-truth corners.
+
+    Attributes:
+        mask: Binary mask (H, W) with values in {0, 255}, post rotation/blur/noise.
+        gt_corners: 4x2 array of ground-truth corner positions in mask pixel
+            coordinates, in the same order as the base square
+            (0,0)-(size,0)-(size,size)-(0,size) after rotation.
+    """
+
+    mask: np.ndarray
+    gt_corners: np.ndarray
+
+
+def rasterize_piece(config: PieceConfig, piece_size_px: float = PIECE_SIZE_PX) -> Tuple[np.ndarray, np.ndarray]:
+    """Rasterize a piece config's path to a filled mask, with matching ground-truth corners.
+
+    The ground-truth corners are the 4 corners of the piece's base square
+    (before corner rounding); `corner_radius` rounds them slightly in the
+    rendered path, so the true corners are a small underestimate of the
+    rendered mask's extremal points.
+
+    Args:
+        config: The piece configuration to rasterize.
+        piece_size_px: Pixel size of the base square's side.
+
+    Returns:
+        Tuple of (mask (H, W) uint8 in {0, 255}, ground-truth corners (4x2)),
+        both in the same unrotated pixel coordinate frame.
+    """
+    x, y = generate_piece_path(config)
+    path = np.column_stack([x, y])
+    gt_local = np.array(
+        [[0.0, 0.0], [config.size, 0.0], [config.size, config.size], [0.0, config.size]],
+    )
+
+    scale = piece_size_px / config.size
+    pad = CANVAS_PAD_FRAC * config.size
+
+    min_xy = path.min(axis=0)
+    max_y = path[:, 1].max()
+
+    def to_pixels(pts: np.ndarray) -> np.ndarray:
+        px = (pts[:, 0] - min_xy[0] + pad) * scale
+        py = (max_y - pts[:, 1] + pad) * scale  # flip y: path is math-convention (y up)
+        return np.column_stack([px, py])
+
+    path_px = to_pixels(path)
+    gt_px = to_pixels(gt_local)
+
+    extent = path.max(axis=0) - min_xy
+    canvas_w = int(np.ceil((extent[0] + 2 * pad) * scale))
+    canvas_h = int(np.ceil((extent[1] + 2 * pad) * scale))
+
+    mask = np.zeros((canvas_h, canvas_w), dtype=np.uint8)
+    cv2.fillPoly(mask, [path_px.astype(np.int32)], (255,))
+    return mask, gt_px
+
+
+def apply_random_rotation(mask: np.ndarray, gt_corners: np.ndarray, angle_deg: float) -> Tuple[np.ndarray, np.ndarray]:
+    """Rotate a mask and its ground-truth corners by the same transform, expanding the canvas.
+
+    Args:
+        mask: Binary mask (H, W).
+        gt_corners: 4x2 ground-truth corners in `mask`'s pixel coordinates.
+        angle_deg: Rotation angle in degrees.
+
+    Returns:
+        Tuple of (rotated mask on an expanded canvas, transformed corners).
+    """
+    h, w = mask.shape
+    center = (w / 2.0, h / 2.0)
+    matrix = cv2.getRotationMatrix2D(center, angle_deg, 1.0)
+
+    cos = abs(matrix[0, 0])
+    sin = abs(matrix[0, 1])
+    new_w = int(h * sin + w * cos)
+    new_h = int(h * cos + w * sin)
+    matrix[0, 2] += new_w / 2.0 - center[0]
+    matrix[1, 2] += new_h / 2.0 - center[1]
+
+    rotated_mask = cv2.warpAffine(mask, matrix, (new_w, new_h), flags=cv2.INTER_LINEAR, borderValue=0)
+
+    ones = np.ones((gt_corners.shape[0], 1))
+    homogeneous = np.hstack([gt_corners, ones])
+    rotated_corners = (matrix @ homogeneous.T).T
+    return rotated_mask, rotated_corners
+
+
+def degrade_mask(mask: np.ndarray, rng: np.random.Generator) -> np.ndarray:
+    """Blur, add light noise to, and re-binarize a mask to mimic a segmented real photo.
+
+    Args:
+        mask: Binary mask (H, W) with values in {0, 255}.
+        rng: Numpy random generator for reproducible noise.
+
+    Returns:
+        Re-binarized mask (H, W) with values in {0, 255}.
+    """
+    blurred = cv2.GaussianBlur(mask, ksize=(0, 0), sigmaX=BLUR_SIGMA)
+    noise = rng.normal(0.0, NOISE_STD, size=blurred.shape)
+    noisy = np.clip(blurred.astype(np.float64) + noise, 0, 255)
+    return np.where(noisy > 127, np.uint8(255), np.uint8(0))
+
+
+def generate_synthetic_piece(rng: np.random.Generator) -> Optional[SyntheticPiece]:
+    """Generate one synthetic piece: rasterize, rotate, degrade.
+
+    Args:
+        rng: Numpy random generator for rotation angle and noise.
+
+    Returns:
+        The `SyntheticPiece`, or None if rasterization failed (degenerate config).
+    """
+    config = PieceConfig.random()
+    mask, gt_corners = rasterize_piece(config)
+    if mask.sum() == 0:
+        return None
+
+    angle = float(rng.uniform(0.0, 360.0))
+    rotated_mask, rotated_corners = apply_random_rotation(mask, gt_corners, angle)
+    final_mask = degrade_mask(rotated_mask, rng)
+    if final_mask.sum() == 0:
+        return None
+
+    return SyntheticPiece(mask=final_mask, gt_corners=rotated_corners)
+
+
+def _piece_diagonal(gt_corners: np.ndarray) -> float:
+    """Diagonal size of the ground-truth square (distance between opposite corners).
+
+    Args:
+        gt_corners: 4x2 ground-truth corners, ordered around the square.
+
+    Returns:
+        Euclidean distance between corners 0 and 2.
+    """
+    return float(np.linalg.norm(gt_corners[0] - gt_corners[2]))
+
+
+def score_corners(predicted: np.ndarray, gt_corners: np.ndarray) -> float:
+    """Score predicted corners against ground truth via optimal assignment.
+
+    Args:
+        predicted: 4x2 predicted corner points.
+        gt_corners: 4x2 ground-truth corner points.
+
+    Returns:
+        Max matched-corner distance, as a percentage of the piece diagonal.
+    """
+    dist_matrix = np.linalg.norm(predicted[:, None, :] - gt_corners[None, :, :], axis=2)
+    row_ind, col_ind = linear_sum_assignment(dist_matrix)
+    max_dist = float(dist_matrix[row_ind, col_ind].max())
+    diagonal = _piece_diagonal(gt_corners)
+    return 100.0 * max_dist / diagonal if diagonal > 0 else float("inf")
+
+
+def run_detector(method: str, contour: np.ndarray, mask_shape: Tuple[int, int]) -> Optional[CornerResult]:
+    """Run one named detector, returning None if it fails to find enough corners.
+
+    Args:
+        method: One of "curvature", "polydp", "shitomasi".
+        contour: Nx2 contour points.
+        mask_shape: (height, width) of the source mask, needed by "shitomasi".
+
+    Returns:
+        The `CornerResult`, or None on `InsufficientCornersError`.
+    """
+    try:
+        if method == "curvature":
+            return detect_corners_curvature(contour)
+        if method == "polydp":
+            return detect_corners_polydp(contour)
+        if method == "shitomasi":
+            return detect_corners_shitomasi(contour, mask_shape)
+    except InsufficientCornersError:
+        return None
+    raise ValueError(f"Unknown method: {method}")
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Synthetic corner-detector benchmark against known ground truth.")
+    parser.add_argument("--n", type=int, default=200)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output-dir", type=Path, default=Path(__file__).parent / "outputs")
+    args = parser.parse_args()
+
+    random.seed(args.seed)
+    rng = np.random.default_rng(args.seed)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = args.output_dir / "synth_benchmark.csv"
+
+    per_method_errors: Dict[str, List[float]] = {m: [] for m in METHODS}
+    per_method_success: Dict[str, int] = dict.fromkeys(METHODS, 0)
+    per_method_detected: Dict[str, int] = dict.fromkeys(METHODS, 0)
+    n_generated = 0
+
+    with open(csv_path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["piece_index", "method", "detected", "max_error_pct", "success"])
+        writer.writeheader()
+
+        for i in range(args.n):
+            piece = generate_synthetic_piece(rng)
+            if piece is None:
+                print(f"  [warn] piece {i}: rasterization/degradation produced an empty mask, skipping")
+                continue
+            n_generated += 1
+
+            contour = mask_to_contour(piece.mask)
+            if contour is None:
+                print(f"  [warn] piece {i}: no contour found in degraded mask, skipping")
+                continue
+
+            for method in METHODS:
+                result = run_detector(method, contour, piece.mask.shape)
+                if result is None:
+                    writer.writerow(
+                        {"piece_index": i, "method": method, "detected": False, "max_error_pct": "", "success": False}
+                    )
+                    continue
+                per_method_detected[method] += 1
+                error_pct = score_corners(result.corners, piece.gt_corners)
+                success = error_pct <= SUCCESS_THRESHOLD_PCT
+                per_method_errors[method].append(error_pct)
+                if success:
+                    per_method_success[method] += 1
+                writer.writerow(
+                    {
+                        "piece_index": i,
+                        "method": method,
+                        "detected": True,
+                        "max_error_pct": f"{error_pct:.3f}",
+                        "success": success,
+                    }
+                )
+
+    print(f"\nGenerated {n_generated}/{args.n} synthetic pieces. Results written to {csv_path}\n")
+    print(f"{'method':<12}{'coverage':<14}{'median err%':<14}{'mean err%':<14}{'<=3% err':<12}")
+    for method in METHODS:
+        errors = per_method_errors[method]
+        detected = per_method_detected[method]
+        coverage = f"{detected}/{n_generated}" if n_generated else "n/a"
+        median_err = f"{float(np.median(errors)):.2f}" if errors else "n/a"
+        mean_err = f"{float(np.mean(errors)):.2f}" if errors else "n/a"
+        success_rate = (
+            f"{per_method_success[method]}/{n_generated} ({100.0 * per_method_success[method] / n_generated:.1f}%)"
+            if n_generated
+            else "n/a"
+        )
+        print(f"{method:<12}{coverage:<14}{median_err:<14}{mean_err:<14}{success_rate:<12}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

The "piece geometry scanning" column end to end (plan + per-milestone results: `docs/piece-geometry-scanning.html`; detailed log: `network/experiments/exp28_piece_geometry/HANDOFF.md`):

- **exp28 research (M1–M7)** — contour extraction (rembg, 95–99% clean on north_star), corner detection (polydp + curvature cross-check, 97–98.5% synth), typed edges (≥98% accuracy on friendly backgrounds), edge complementarity matching (L2 top-1 67.4%), shape+spatial-color piece fingerprint, and the M7 collision study that produced the production scoring: one combined z-score for both ranking (95.2% top-1 cross-background) and accept/new thresholding. Zero full-piece die-cut collisions across 1,695 pairs.
- **Backend (M8)** — the exp28 stack productionized in `backend/app/services/piece_geometry/` (scipy-free), with `POST/GET /api/v1/puzzle/{id}/piece/geometry` (dedupe verdicts matched/new/uncertain, `on_uncertain=enroll` escape hatch) and opt-in quality flags on `/api/v1/piece/preview`.
- **iOS (M9)** — live piece-outline overlay: throttled 480px frame streaming to the preview endpoint, CAShapeLayer outline (yellow detected / green lockable), one unit-tested aspect-fill mapping shared by device and Simulator.
- **iOS (M10)** — hands-free scan-and-lock: a stability tracker (bbox IoU across lockable detections ≥1s) auto-captures, posts to the geometry endpoint, and maps verdicts to UX (locked-green flash + haptics / "Already scanned" / uncertain handling). Enrolled pieces join the puzzle page's piece list (position prediction + persistence) and feed the scan gallery's thumbnails. Stale backend puzzle ids self-heal via re-upload + one retry.

Verified on a physical iPhone 15 against real pieces: zero-tap lock → enroll → piece list; re-scans report "Already scanned" without duplicating. Product decision from the device run: `t_accept` sits at M7's FMR=1% ROC point (−3.98) and gray-zone verdicts auto-enroll, trading ~8% duplicate risk on re-scans for tap-free enrollment.

## Test plan

- 212 backend tests (`make check-backend`, pytest with coverage) — pass
- 114 iOS tests (`xcodebuild test`, `make check-ios`) — pass
- Real-photo E2E on the backend endpoint (north_star pieces, cross-background match/new/uncertain verdicts)
- Simulator E2E of the full scan flow via the debug driver (`pusseldebug://scan` + `previewloop`)
- On-device verification of M9 and M10 by the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)