### PR TITLE
Un-enroll deleted pieces from the geometry store

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -602,6 +602,35 @@ async def list_piece_geometry(
     )
 
 
+@app.delete("/api/v1/puzzle/{puzzle_id}/piece/geometry/{piece_id}", status_code=204)
+async def delete_piece_geometry(
+    puzzle_id: str,
+    piece_id: str,
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> None:
+    """Un-enroll one piece from a puzzle's piece-geometry store.
+
+    Mirrors the client deleting a scanned piece from its piece list: the piece
+    disappears from the scanner's gallery, and a fresh photo of it reads as a
+    new piece again instead of matching the stale enrollment.
+
+    Args:
+        puzzle_id: ID of the puzzle the piece belongs to.
+        piece_id: ID of the enrolled piece to remove.
+        current_user: The authenticated user.
+
+    Raises:
+        HTTPException: If the puzzle does not exist, or it has no piece with
+            this id enrolled.
+    """
+    _ = current_user  # Acknowledge the parameter is intentionally unused for now
+    if puzzle_id not in puzzle_images:
+        raise HTTPException(status_code=404, detail="Puzzle not found")
+
+    if not get_piece_geometry_store().remove(puzzle_id, piece_id):
+        raise HTTPException(status_code=404, detail="Piece not found")
+
+
 @app.post("/api/v1/puzzle/{puzzle_id}/generate-piece", response_model=GeneratePieceResponse)
 async def generate_piece(
     puzzle_id: str,

--- a/backend/app/services/piece_geometry/store.py
+++ b/backend/app/services/piece_geometry/store.py
@@ -85,9 +85,14 @@ class PuzzlePieceStore:
     _next_id: int = 1
     # Cached impostor stats and the gallery size they were computed for.
     # `_gallery_stats` is O(n^2) in the gallery and runs on every locked frame,
-    # but the stats only change when a piece is enrolled — so cache them and let
-    # `_enroll` invalidate. The gallery is append-only (pieces are never removed
-    # or mutated in place), so the size is a sufficient cache key.
+    # but the stats only change when the gallery does — so cache them and let
+    # `_enroll` and `remove` invalidate. Pieces are never mutated in place, so
+    # every change routes through one of those two.
+    #
+    # The size alone is NOT a sufficient cache key now that pieces can be
+    # removed: a remove followed by an enroll returns to the same size with a
+    # different gallery. Both mutators clear `_cached_stats` outright, so the
+    # size only guards the cache against a stale hit, never validates it alone.
     _cached_stats: Optional[GalleryStats] = None
     _cached_stats_n: int = -1
 
@@ -217,6 +222,26 @@ class PuzzlePieceStore:
 
         return MatchResult(MatchVerdict.UNCERTAIN, None, match_piece_id, z_score)
 
+    def remove(self, piece_id: str) -> bool:
+        """Un-enroll one piece, so a later photo of it reads as new again.
+
+        Ids are never recycled (`_next_id` only counts up), so a removed id
+        cannot come back attached to a different physical piece.
+
+        Args:
+            piece_id: The piece to remove.
+
+        Returns:
+            True if the piece was enrolled and is now gone; False if this
+            puzzle never had a piece with that id.
+        """
+        before = len(self._pieces)
+        self._pieces = [piece for piece in self._pieces if piece.piece_id != piece_id]
+        if len(self._pieces) == before:
+            return False
+        self._cached_stats = None
+        return True
+
     def list_pieces(self) -> List[EnrolledPiece]:
         """List all pieces enrolled so far, in enrollment order.
 
@@ -277,6 +302,24 @@ class PieceGeometryStore:
         return self._get_or_create(puzzle_id).add_or_match(
             fingerprint, is_clean, corner_disagreement, enroll_uncertain=enroll_uncertain
         )
+
+    def remove(self, puzzle_id: str, piece_id: str) -> bool:
+        """Un-enroll one piece from one puzzle's store.
+
+        Called when the user deletes a scanned piece from the piece list: the
+        piece must stop appearing in the scanner's gallery, and a fresh photo
+        of it must read as new rather than as an already-scanned duplicate.
+
+        Args:
+            puzzle_id: The puzzle the piece belongs to.
+            piece_id: The piece to remove.
+
+        Returns:
+            True if the piece was enrolled and is now gone; False when the
+            puzzle has no store yet or holds no such piece.
+        """
+        store = self._stores.get(puzzle_id)
+        return store.remove(piece_id) if store else False
 
     def list_pieces(self, puzzle_id: str) -> List[EnrolledPiece]:
         """List all pieces enrolled for one puzzle.

--- a/backend/tests/test_piece_geometry_api.py
+++ b/backend/tests/test_piece_geometry_api.py
@@ -346,6 +346,82 @@ class TestListPieceGeometry:
         assert "polyline" not in piece
 
 
+class TestDeletePieceGeometry:
+    """Tests for DELETE /api/v1/puzzle/{puzzle_id}/piece/geometry/{piece_id}."""
+
+    def _enroll_piece(self, puzzle_id: str) -> str:
+        """Enroll one piece via the upload endpoint and return its piece_id."""
+        with patch("app.main.get_piece_geometry_service", return_value=mocked_geometry_service()):
+            response = client.post(
+                f"/api/v1/puzzle/{puzzle_id}/piece/geometry",
+                files=geometry_files(),
+                headers=get_auth_header(),
+            )
+        assert response.status_code == 200
+        return str(response.json()["piece_id"])
+
+    def test_requires_auth(self) -> None:
+        """The endpoint rejects unauthenticated requests."""
+        puzzle_id = upload_test_puzzle()
+
+        response = client.delete(f"/api/v1/puzzle/{puzzle_id}/piece/geometry/p001")
+
+        assert response.status_code in (401, 403)
+
+    def test_unknown_puzzle_returns_404(self) -> None:
+        """Deleting against a nonexistent puzzle_id returns 404."""
+        response = client.delete(
+            "/api/v1/puzzle/does-not-exist/piece/geometry/p001",
+            headers=get_auth_header(),
+        )
+
+        assert response.status_code == 404
+
+    def test_unknown_piece_returns_404(self) -> None:
+        """Deleting a piece_id this puzzle never enrolled returns 404."""
+        puzzle_id = upload_test_puzzle()
+
+        response = client.delete(
+            f"/api/v1/puzzle/{puzzle_id}/piece/geometry/p404",
+            headers=get_auth_header(),
+        )
+
+        assert response.status_code == 404
+
+    def test_deleted_piece_disappears_from_the_list(self) -> None:
+        """A deleted piece is gone from the list endpoint the scanner's gallery pre-fills from."""
+        puzzle_id = upload_test_puzzle()
+        piece_id = self._enroll_piece(puzzle_id)
+
+        response = client.delete(
+            f"/api/v1/puzzle/{puzzle_id}/piece/geometry/{piece_id}",
+            headers=get_auth_header(),
+        )
+
+        assert response.status_code == 204
+        listed = client.get(f"/api/v1/puzzle/{puzzle_id}/piece/geometry", headers=get_auth_header())
+        assert listed.json()["pieces"] == []
+
+    def test_rescanning_a_deleted_piece_reads_as_new(self) -> None:
+        """After deletion the piece is un-enrolled, so its photo no longer matches a stale entry."""
+        puzzle_id = upload_test_puzzle()
+        piece_id = self._enroll_piece(puzzle_id)
+        client.delete(f"/api/v1/puzzle/{puzzle_id}/piece/geometry/{piece_id}", headers=get_auth_header())
+
+        with patch("app.main.get_piece_geometry_service", return_value=mocked_geometry_service()):
+            response = client.post(
+                f"/api/v1/puzzle/{puzzle_id}/piece/geometry",
+                files=geometry_files(),
+                headers=get_auth_header(),
+            )
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["status"] == "new"
+        # Ids are never recycled — the re-scan gets a fresh one.
+        assert result["piece_id"] != piece_id
+
+
 class TestPreviewIncludeQuality:
     """Tests for the /api/v1/piece/preview include_quality flag."""
 

--- a/backend/tests/test_piece_geometry_store.py
+++ b/backend/tests/test_piece_geometry_store.py
@@ -163,8 +163,71 @@ class TestGalleryStatsCaching:
         assert third is not first
 
 
+class TestRemove:
+    """Un-enrolling a piece the user deleted from their piece list."""
+
+    def test_removing_a_piece_drops_it_from_the_gallery(self) -> None:
+        """remove() reports success and the piece stops being listed."""
+        store = PuzzlePieceStore()
+        store.add_or_match(_fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS), True, False)
+
+        assert store.remove("p001") is True
+        assert store.list_pieces() == []
+
+    def test_removing_an_unknown_piece_reports_false(self) -> None:
+        """An id this store never enrolled is a no-op, not an error."""
+        store = PuzzlePieceStore()
+
+        assert store.remove("p404") is False
+
+    def test_a_removed_piece_can_be_rescanned_as_new(self) -> None:
+        """With the stale enrollment gone, the same piece's next photo is new — under a fresh id."""
+        store = PuzzlePieceStore()
+        store.add_or_match(_fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS), True, False)
+        store.remove("p001")
+
+        result = store.add_or_match(_fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS), True, False)
+
+        assert result.verdict == MatchVerdict.NEW
+        # Ids are never recycled, so a removed id can't resurface on another piece.
+        assert result.piece_id == "p002"
+
+    def test_removing_invalidates_the_cached_stats(self) -> None:
+        """A remove + enroll returns the gallery to its old size — the cache must not survive it."""
+        from app.services.piece_geometry.scoring import MIN_GALLERY_FOR_STATS
+
+        store = PuzzlePieceStore()
+        fp = _fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+        for _ in range(MIN_GALLERY_FOR_STATS):
+            store._enroll(fp, True, False)
+        first = store._gallery_stats()
+
+        store.remove("p001")
+        # Same gallery size as when `first` was cached, different gallery — a
+        # size-keyed cache would wrongly hand back `first` here.
+        store._enroll(_fingerprint(PIECE_B_EDGE_TYPES, PIECE_B_COLORS), True, False)
+
+        assert store._gallery_stats() is not first
+
+
 class TestPieceGeometryStore:
     """Tests for the puzzle_id-keyed PieceGeometryStore wrapper."""
+
+    def test_remove_only_affects_the_named_puzzle(self) -> None:
+        """Removing a piece id from one puzzle leaves the same id in another puzzle alone."""
+        store = PieceGeometryStore()
+        store.add_or_match("puzzle-1", _fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS), True, False)
+        store.add_or_match("puzzle-2", _fingerprint(PIECE_B_EDGE_TYPES, PIECE_B_COLORS), True, False)
+
+        assert store.remove("puzzle-1", "p001") is True
+        assert store.list_pieces("puzzle-1") == []
+        assert [p.piece_id for p in store.list_pieces("puzzle-2")] == ["p001"]
+
+    def test_remove_for_unknown_puzzle_reports_false(self) -> None:
+        """Removing from a puzzle with no store yet is a no-op, not an error."""
+        store = PieceGeometryStore()
+
+        assert store.remove("never-seen", "p001") is False
 
     def test_stores_are_isolated_per_puzzle(self) -> None:
         """Two puzzles' piece stores don't share enrolled pieces or id sequences."""

--- a/ios/Pussel/App/AppFlow.swift
+++ b/ios/Pussel/App/AppFlow.swift
@@ -175,9 +175,25 @@ final class SolveSession {
     processNext(api: api)
   }
 
-  func remove(id: UUID) {
+  /// Deletes a piece from the list, and — for pieces that came from the
+  /// scanner — un-enrolls it from the backend's geometry store too. Without
+  /// that second half the scanner's gallery pre-fill (`loadEnrolled`, which
+  /// reads the server's enrolled list) would keep showing the deleted piece
+  /// on the next visit, as a thumbnail-less tile whose photo no longer
+  /// exists locally, and a re-scan of it would report "already scanned".
+  ///
+  /// The local removal is not contingent on the network call: the un-enroll
+  /// is fire-and-forget, so a failure leaves a stale server entry rather than
+  /// a piece the user couldn't delete. Server errors are ignored for the same
+  /// reason — there is nothing actionable to show for a piece that is already
+  /// gone from the user's list.
+  func remove(id: UUID, api: APIClient) {
+    guard let entry = entries.first(where: { $0.id == id }) else { return }
     entries.removeAll { $0.id == id }
     persist()
+    guard let scanPieceId = entry.scanPieceId else { return }
+    let puzzleId = puzzleId
+    Task { try? await api.deletePieceGeometry(puzzleId: puzzleId, pieceId: scanPieceId) }
   }
 
   /// Serially drains the queue — one in-flight prediction at a time, like

--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -56,7 +56,7 @@ struct PieceQueueView: View {
             entry: entry,
             isDeleteMode: isDeleteMode,
             onRetry: { session.retry(id: entry.id, api: model.api) },
-            onDelete: { withAnimation { session.remove(id: entry.id) } },
+            onDelete: { withAnimation { session.remove(id: entry.id, api: model.api) } },
             onEnterDeleteMode: { withAnimation { isDeleteMode = true } },
             onExitDeleteMode: { withAnimation { isDeleteMode = false } },
             onZoom: { onZoomToPiece(entry.id) }

--- a/ios/Pussel/Networking/APIClient.swift
+++ b/ios/Pussel/Networking/APIClient.swift
@@ -101,6 +101,17 @@ final class APIClient {
     return try decoder.decode(PieceGeometryListResponse.self, from: data)
   }
 
+  /// Un-enrolls a piece from the puzzle's geometry store, so it stops
+  /// appearing in the scanner's gallery and a fresh photo of it reads as new
+  /// again. Called when the user deletes a scanned piece from the piece list.
+  func deletePieceGeometry(puzzleId: String, pieceId: String) async throws {
+    var request = URLRequest(
+      url: baseURL.appending(path: "api/v1/puzzle/\(puzzleId)/piece/geometry/\(pieceId)"))
+    request.httpMethod = "DELETE"
+    // 204, no body to decode.
+    _ = try await send(request, authenticated: true)
+  }
+
   /// Streams one downscaled live-preview frame to the piece-region
   /// detector. Stateless and lightweight — `PiecePreviewStreamer` calls
   /// this in a throttled loop while the piece camera is open.

--- a/ios/PusselTests/PuzzleStoreTests.swift
+++ b/ios/PusselTests/PuzzleStoreTests.swift
@@ -228,8 +228,9 @@ final class PuzzleStoreTests: XCTestCase {
 
     session.remove(id: scanned.id, api: stubAPI())
 
-    // The un-enroll is fire-and-forget, so wait for the detached Task's request
-    // rather than assuming it landed by the time remove() returned.
+    // The un-enroll is fire-and-forget — remove() spawns the request in an
+    // unawaited Task — so wait for it rather than assuming it landed by the
+    // time remove() returned.
     try await waitForRequest(matching: "/api/v1/puzzle/server-123/piece/geometry/p007")
     XCTAssertEqual(StubURLProtocol.receivedRequests.last?.httpMethod, "DELETE")
   }

--- a/ios/PusselTests/PuzzleStoreTests.swift
+++ b/ios/PusselTests/PuzzleStoreTests.swift
@@ -54,6 +54,19 @@ final class PuzzleStoreTests: XCTestCase {
     )
   }
 
+  /// An APIClient wired to `StubURLProtocol` (defined in APIClientTests) so
+  /// `remove(id:api:)`'s geometry un-enroll never touches the network. Tests
+  /// that care about the request assert on `StubURLProtocol.receivedRequests`.
+  private func stubAPI() -> APIClient {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [StubURLProtocol.self]
+    return APIClient(
+      baseURL: URL(string: "http://stub.local")!,
+      session: URLSession(configuration: configuration),
+      authStore: AuthStore()
+    )
+  }
+
   // MARK: Zoom copy (display.jpg)
 
   func testZoomCopyIsPersistedAndReloaded() throws {
@@ -185,7 +198,7 @@ final class PuzzleStoreTests: XCTestCase {
     let fileManager = FileManager.default
     XCTAssertTrue(fileManager.fileExists(atPath: uploadFile(session.id, drop.id).path))
 
-    session.remove(id: drop.id)
+    session.remove(id: drop.id, api: stubAPI())
 
     // The dropped piece's image file is pruned; the kept one remains.
     XCTAssertFalse(fileManager.fileExists(atPath: uploadFile(session.id, drop.id).path))
@@ -193,6 +206,67 @@ final class PuzzleStoreTests: XCTestCase {
 
     let reloaded = try XCTUnwrap(PuzzleStore().loadSession(id: session.id))
     XCTAssertEqual(reloaded.entries.map(\.id), [keep.id])
+  }
+
+  func testRemovingScannedPieceUnenrollsItFromTheGeometryStore() async throws {
+    // Without this DELETE, the scanner's gallery pre-fill (loadEnrolled) reads
+    // the piece back off the server on the next visit and shows it as a
+    // thumbnail-less tile, because its local photo is gone.
+    let store = PuzzleStore()
+    let session = makeSession(store: store)
+    addTeardownBlock { @MainActor in store.delete(session.id) }
+
+    StubURLProtocol.receivedRequests = []
+    StubURLProtocol.handler = { _ in (204, Data()) }
+    defer { StubURLProtocol.handler = nil }
+
+    let scanned = CaptureEntry(
+      id: UUID(), uploadJPEG: Data("scanned".utf8), displayImage: Data("scanned".utf8),
+      status: .queued, result: nil, scanPieceId: "p007")
+    session.entries = [scanned]
+    session.persist()
+
+    session.remove(id: scanned.id, api: stubAPI())
+
+    // The un-enroll is fire-and-forget, so wait for the detached Task's request
+    // rather than assuming it landed by the time remove() returned.
+    try await waitForRequest(matching: "/api/v1/puzzle/server-123/piece/geometry/p007")
+    XCTAssertEqual(StubURLProtocol.receivedRequests.last?.httpMethod, "DELETE")
+  }
+
+  func testRemovingUnscannedPieceSkipsTheGeometryDelete() async throws {
+    // A hand-captured piece was never enrolled, so there is nothing to
+    // un-enroll — and no piece id that a DELETE could safely name.
+    let store = PuzzleStore()
+    let session = makeSession(store: store)
+    addTeardownBlock { @MainActor in store.delete(session.id) }
+
+    StubURLProtocol.receivedRequests = []
+    StubURLProtocol.handler = { _ in (204, Data()) }
+    defer { StubURLProtocol.handler = nil }
+
+    let entry = CaptureEntry(
+      id: UUID(), uploadJPEG: Data("manual".utf8), displayImage: Data("manual".utf8),
+      status: .queued, result: nil, scanPieceId: nil)
+    session.entries = [entry]
+    session.persist()
+
+    session.remove(id: entry.id, api: stubAPI())
+
+    // Give any (incorrectly) spawned request a chance to land before asserting
+    // that none did.
+    try await Task.sleep(nanoseconds: 100_000_000)
+    XCTAssertTrue(session.entries.isEmpty)
+    XCTAssertTrue(StubURLProtocol.receivedRequests.isEmpty)
+  }
+
+  /// Polls until a request for `path` shows up, or fails the test after ~2s.
+  private func waitForRequest(matching path: String) async throws {
+    for _ in 0..<40 {
+      if StubURLProtocol.receivedRequests.contains(where: { $0.url?.path == path }) { return }
+      try await Task.sleep(nanoseconds: 50_000_000)
+    }
+    XCTFail("No request for \(path) within the timeout")
   }
 
   func testDeleteRemovesPuzzle() throws {


### PR DESCRIPTION
## Problem

Deleting an already-scanned piece from the main screen left it behind in the continuous scanner: reopening the scanner showed the piece again as a tile with no thumbnail.

Deletion was purely local — `SolveSession.remove` dropped the `CaptureEntry`, but the backend's piece-geometry store was append-only, so nothing un-enrolled the piece. On the next scanner visit `loadEnrolled` read it straight back off the server, and `thumbnailForPiece` found no local photo to pair with it.

The same stale enrollment had a quieter second effect: re-scanning a deleted piece would match the orphaned fingerprint and report "already scanned", so the user could never add it back.

## Change

**Backend**
- `PuzzlePieceStore.remove(piece_id)` and `PieceGeometryStore.remove(puzzle_id, piece_id)`.
- `DELETE /api/v1/puzzle/{puzzle_id}/piece/geometry/{piece_id}` — 204, or 404 for an unknown puzzle or piece.
- The `_gallery_stats` cache was keyed on gallery *size*, which was sound only while the gallery was append-only — a remove followed by an enroll returns to the same size with a different gallery. `remove` now clears the cache outright; a test covers the case that a size-only key would get wrong.
- Piece ids are never recycled (`_next_id` only counts up), so a removed id can't resurface attached to a different physical piece.

**iOS**
- `APIClient.deletePieceGeometry`, called from `remove(id:api:)` when the entry carries a `scanPieceId`.
- The un-enroll is fire-and-forget and the local removal doesn't wait on it: a network failure leaves a stale server entry rather than a piece the user can't delete.
- Shutter/library captures have no `scanPieceId` and skip the call; `reupload` already nils those ids out, so a delete after a backend restart won't name a piece the new store never minted.

## Testing

- Backend: full suite 224 passed, including new coverage for the endpoint (auth, unknown puzzle, unknown piece, gone-from-list, re-scan-reads-as-new) and the store (remove, cache invalidation, per-puzzle isolation).
- iOS: full suite passes, with new tests that the DELETE fires with the right path/method for a scanned piece and is skipped for an unscanned one.
- `make check-backend` clean.

Not verified end-to-end against a live backend in the simulator — the two halves are unit-tested on either side of the wire contract, but the full scan → delete → reopen loop hasn't been driven in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)