### PR TITLE
Show piece thumbnails whole, and on one shared scale

### DIFF
--- a/ios/Pussel/App/AppFlow.swift
+++ b/ios/Pussel/App/AppFlow.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import UIKit
 
 /// The linear real-mode wizard, mirroring the web app's RealModePhase
 /// (frontend/src/app/real/page.tsx) minus the corner-adjust step.
@@ -100,6 +101,23 @@ final class SolveSession {
     /// so `pusseldebug://scan` can demo the scan-and-lock flow there.
     var debugScanOpen = false
   #endif
+
+  /// Pixel aspect (width / height) of `trimmedJPEG`, the image the backend
+  /// predicted against and so the canvas its normalized coordinates refer to.
+  /// `PieceQueueView` needs it to read a `PieceSpan`'s two axes on one scale
+  /// (see `PieceThumbnailGeometry`).
+  ///
+  /// Decoded once and kept, rather than per read: the queue grid asks on
+  /// every layout pass, and this decodes the whole puzzle JPEG. Falls back to
+  /// square on undecodable bytes, which only skews the thumbnails' aspect —
+  /// `trimmedJPEG` decoding is otherwise load-bearing enough that the session
+  /// has bigger problems by then.
+  @ObservationIgnored lazy var puzzleAspect: CGFloat = {
+    guard let size = UIImage(data: trimmedJPEG)?.size, size.width > 0, size.height > 0 else {
+      return 1
+    }
+    return size.width / size.height
+  }()
 
   @ObservationIgnored private let store: PuzzleStore?
 

--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -25,15 +25,18 @@ struct PieceQueueView: View {
   ]
 
   /// Divisor that puts every thumbnail on one scale, so the tiles report
-  /// which piece is bigger instead of how close the camera was. Recomputed
-  /// per layout — it's arithmetic over the entries, and it has to follow the
-  /// grid as pieces are measured, added and deleted.
+  /// which piece is bigger instead of how close the camera was. Scans every
+  /// entry, so read it ONCE per layout and hand the result down — reading it
+  /// per tile walks the whole grid for each tile in it.
   private var thumbnailMaxExtent: CGFloat? {
     PieceThumbnailGeometry.maxExtent(
       spans: session.entries.map { $0.result?.pieceSpan }, puzzleAspect: session.puzzleAspect)
   }
 
   var body: some View {
+    // Bound here rather than read inside the ForEach below, which would scan
+    // every entry once per tile — see `thumbnailMaxExtent`.
+    let maxExtent = thumbnailMaxExtent
     VStack(alignment: .leading, spacing: 8) {
       HStack {
         Text("Pieces (\(session.entries.count))")
@@ -63,7 +66,7 @@ struct PieceQueueView: View {
         ForEach(session.entries.reversed()) { entry in
           QueueTile(
             entry: entry,
-            maxExtent: thumbnailMaxExtent,
+            maxExtent: maxExtent,
             puzzleAspect: session.puzzleAspect,
             isDeleteMode: isDeleteMode,
             onRetry: { session.retry(id: entry.id, api: model.api) },
@@ -255,8 +258,12 @@ private struct QueueTile: View {
       // neighbours. The thumbnail sits inside that square rather than filling
       // it: filling would crop the tabs off any non-square piece, and the tabs
       // are what the piece is recognised by. A quarter turn from
-      // `uprightRotation` swaps the drawn image's bounds, which stay within
-      // the square either way.
+      // `uprightRotation` swaps the drawn image's bounds, which rest within
+      // the square either way — though a near-square piece at the grid's
+      // largest scale sweeps a wider box mid-turn and can graze the clip for
+      // part of the quarter-second it animates. Sizing every piece down to
+      // clear its own diagonal would cost the whole grid real size to buy a
+      // transient on one tile, so the animation keeps its reveal.
       Color.clear
         .aspectRatio(1, contentMode: .fit)
         .overlay {

--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -24,6 +24,15 @@ struct PieceQueueView: View {
     GridItem(.adaptive(minimum: 84), spacing: 12, alignment: .top)
   ]
 
+  /// Divisor that puts every thumbnail on one scale, so the tiles report
+  /// which piece is bigger instead of how close the camera was. Recomputed
+  /// per layout — it's arithmetic over the entries, and it has to follow the
+  /// grid as pieces are measured, added and deleted.
+  private var thumbnailMaxExtent: CGFloat? {
+    PieceThumbnailGeometry.maxExtent(
+      spans: session.entries.map { $0.result?.pieceSpan }, puzzleAspect: session.puzzleAspect)
+  }
+
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
       HStack {
@@ -54,6 +63,8 @@ struct PieceQueueView: View {
         ForEach(session.entries.reversed()) { entry in
           QueueTile(
             entry: entry,
+            maxExtent: thumbnailMaxExtent,
+            puzzleAspect: session.puzzleAspect,
             isDeleteMode: isDeleteMode,
             onRetry: { session.retry(id: entry.id, api: model.api) },
             onDelete: { withAnimation { session.remove(id: entry.id) } },
@@ -195,6 +206,9 @@ private struct AddPieceTile: View {
 
 private struct QueueTile: View {
   let entry: CaptureEntry
+  /// Shared across the grid — see `PieceQueueView.thumbnailMaxExtent`.
+  let maxExtent: CGFloat?
+  let puzzleAspect: CGFloat
   let isDeleteMode: Bool
   let onRetry: () -> Void
   let onDelete: () -> Void
@@ -236,18 +250,37 @@ private struct QueueTile: View {
 
   var body: some View {
     VStack(spacing: 6) {
-      // A clear square sets the tile's size from the column it lands in; the
-      // thumbnail then fills it and is clipped back to the square, so a piece
-      // photo of any aspect ratio still tiles evenly with its neighbours.
+      // A clear square sets the tile's size from the column it lands in, so a
+      // piece photo of any aspect ratio still tiles evenly with its
+      // neighbours. The thumbnail sits inside that square rather than filling
+      // it: filling would crop the tabs off any non-square piece, and the tabs
+      // are what the piece is recognised by. A quarter turn from
+      // `uprightRotation` swaps the drawn image's bounds, which stay within
+      // the square either way.
       Color.clear
         .aspectRatio(1, contentMode: .fit)
         .overlay {
-          if let image = UIImage(data: entry.displayImage) {
-            Image(uiImage: image)
-              .resizable()
-              .scaledToFill()
-              .rotationEffect(.degrees(uprightRotation))
-              .animation(.easeInOut(duration: 0.25), value: uprightRotation)
+          GeometryReader { geo in
+            if let image = UIImage(data: entry.displayImage) {
+              let side = min(geo.size.width, geo.size.height)
+              // The measured frame, so the piece is drawn to the same scale as
+              // its neighbours. An unmeasured piece has nothing to place on
+              // that scale, so it falls back to the tile — which reads as
+              // "big", but inventing a size for it would read as a
+              // measurement.
+              let frame =
+                PieceThumbnailGeometry.size(
+                  span: entry.result?.pieceSpan, maxExtent: maxExtent,
+                  puzzleAspect: puzzleAspect, tileSide: side
+                ) ?? CGSize(width: side, height: side)
+              Image(uiImage: image)
+                .resizable()
+                .scaledToFit()
+                .frame(width: frame.width, height: frame.height)
+                .rotationEffect(.degrees(uprightRotation))
+                .animation(.easeInOut(duration: 0.25), value: uprightRotation)
+                .position(x: geo.size.width / 2, y: geo.size.height / 2)
+            }
           }
         }
         .overlay {

--- a/ios/Pussel/Features/Solve/PieceThumbnailGeometry.swift
+++ b/ios/Pussel/Features/Solve/PieceThumbnailGeometry.swift
@@ -1,0 +1,63 @@
+import CoreGraphics
+
+/// Pure sizing math for the piece queue's thumbnails (`PieceQueueView`'s
+/// `QueueTile`), factored out so it's unit-testable without SwiftUI.
+///
+/// The queue draws every piece at one shared scale, so two tiles side by side
+/// show which piece is actually bigger. Sizing each thumbnail to its own tile
+/// instead would say nothing about the piece: it would only report how close
+/// the camera happened to be when that piece was shot.
+///
+/// The measurement it scales by is `PieceSpan`, which is normalized to the
+/// puzzle's width and height *separately*. Those are different lengths on a
+/// non-square puzzle, so a span's two components aren't comparable as they
+/// stand — `0.1` wide and `0.1` tall is not a square piece. Everything here
+/// works in **puzzle-width units**: x is already in them, and y converts by
+/// the puzzle's aspect. That makes extents comparable both between the axes
+/// and between pieces, since every piece in a session shares one puzzle.
+enum PieceThumbnailGeometry {
+  /// A piece's measured frame in puzzle-width units — the full image frame
+  /// including the backend's transparent margin, in the image's own
+  /// (pre-rotation) axes, matching what `PieceSpan` describes.
+  static func extent(span: PieceSpan, puzzleAspect: CGFloat) -> CGSize {
+    guard puzzleAspect > 0 else { return .zero }
+    return CGSize(width: span.width, height: CGFloat(span.height) / puzzleAspect)
+  }
+
+  /// The largest single dimension any measured piece reaches, in puzzle-width
+  /// units — the divisor that maps measurements onto tiles. Returns nil when
+  /// no piece was measured, leaving the caller to fall back to per-tile
+  /// sizing.
+  ///
+  /// The *largest* is what sets the scale because tiles are square and clip:
+  /// pinning the biggest piece's longest axis to the tile side is exactly the
+  /// point where every piece still fits whole, at any quarter turn, with the
+  /// grid no smaller than it has to be.
+  static func maxExtent(spans: [PieceSpan?], puzzleAspect: CGFloat) -> CGFloat? {
+    let extents = spans.compactMap { span -> CGFloat? in
+      guard let span else { return nil }
+      let size = extent(span: span, puzzleAspect: puzzleAspect)
+      let longest = max(size.width, size.height)
+      return longest > 0 ? longest : nil
+    }
+    return extents.max()
+  }
+
+  /// The frame to draw a thumbnail in, in points, *before* `.rotationEffect`
+  /// is applied — nil for an unmeasured piece, or when there's nothing to
+  /// scale against.
+  ///
+  /// Not swapped for a quarter turn, unlike `PieceMarkerGeometry.size`: that
+  /// one lands its frame on a grid of non-square cells, whereas this one is
+  /// centred in a square tile, where a rotated frame occupies the same
+  /// bounds either way.
+  static func size(
+    span: PieceSpan?, maxExtent: CGFloat?, puzzleAspect: CGFloat, tileSide: CGFloat
+  ) -> CGSize? {
+    guard let span, let maxExtent, maxExtent > 0, tileSide > 0 else { return nil }
+    let size = extent(span: span, puzzleAspect: puzzleAspect)
+    guard size.width > 0, size.height > 0 else { return nil }
+    let scale = tileSide / maxExtent
+    return CGSize(width: size.width * scale, height: size.height * scale)
+  }
+}

--- a/ios/Pussel/Features/Solve/PieceThumbnailGeometry.swift
+++ b/ios/Pussel/Features/Solve/PieceThumbnailGeometry.swift
@@ -21,7 +21,7 @@ enum PieceThumbnailGeometry {
   /// (pre-rotation) axes, matching what `PieceSpan` describes.
   static func extent(span: PieceSpan, puzzleAspect: CGFloat) -> CGSize {
     guard puzzleAspect > 0 else { return .zero }
-    return CGSize(width: span.width, height: CGFloat(span.height) / puzzleAspect)
+    return CGSize(width: CGFloat(span.width), height: CGFloat(span.height) / puzzleAspect)
   }
 
   /// The largest single dimension any measured piece reaches, in puzzle-width

--- a/ios/PusselTests/PieceThumbnailGeometryTests.swift
+++ b/ios/PusselTests/PieceThumbnailGeometryTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+
+@testable import Pussel
+
+final class PieceThumbnailGeometryTests: XCTestCase {
+  /// A 2:1 landscape puzzle — deliberately non-square, since that's what
+  /// makes a span's two axes mean different lengths.
+  private let aspect: CGFloat = 2
+  private let tileSide: CGFloat = 100
+
+  // MARK: extent
+
+  func testExtentConvertsHeightByAspectAndLeavesWidthAlone() {
+    let size = PieceThumbnailGeometry.extent(
+      span: PieceSpan(width: 0.2, height: 0.2), puzzleAspect: aspect)
+    // Equal span components are NOT a square piece: on a 2:1 puzzle, 0.2 of
+    // the height is half as long as 0.2 of the width.
+    XCTAssertEqual(size.width, 0.2, accuracy: 1e-9)
+    XCTAssertEqual(size.height, 0.1, accuracy: 1e-9)
+  }
+
+  func testSquarePuzzleLeavesBothAxesAlone() {
+    let size = PieceThumbnailGeometry.extent(
+      span: PieceSpan(width: 0.2, height: 0.3), puzzleAspect: 1)
+    XCTAssertEqual(size.width, 0.2, accuracy: 1e-9)
+    XCTAssertEqual(size.height, 0.3, accuracy: 1e-9)
+  }
+
+  func testNonPositiveAspectIsRejected() {
+    XCTAssertEqual(
+      PieceThumbnailGeometry.extent(span: PieceSpan(width: 0.2, height: 0.2), puzzleAspect: 0),
+      .zero)
+  }
+
+  // MARK: maxExtent
+
+  func testMaxExtentTakesLongestAxisAcrossMeasuredPieces() {
+    let spans: [PieceSpan?] = [
+      PieceSpan(width: 0.2, height: 0.2),  // extent 0.2 x 0.1 -> 0.2
+      PieceSpan(width: 0.1, height: 0.6),  // extent 0.1 x 0.3 -> 0.3
+    ]
+    XCTAssertEqual(
+      PieceThumbnailGeometry.maxExtent(spans: spans, puzzleAspect: aspect) ?? 0, 0.3,
+      accuracy: 1e-9)
+  }
+
+  func testMaxExtentSkipsUnmeasuredPieces() {
+    let spans: [PieceSpan?] = [nil, PieceSpan(width: 0.25, height: 0.2), nil]
+    XCTAssertEqual(
+      PieceThumbnailGeometry.maxExtent(spans: spans, puzzleAspect: aspect) ?? 0, 0.25,
+      accuracy: 1e-9)
+  }
+
+  func testMaxExtentIsNilWhenNothingIsMeasured() {
+    XCTAssertNil(PieceThumbnailGeometry.maxExtent(spans: [nil, nil], puzzleAspect: aspect))
+    XCTAssertNil(PieceThumbnailGeometry.maxExtent(spans: [], puzzleAspect: aspect))
+  }
+
+  func testMaxExtentIgnoresDegenerateSpans() {
+    let spans: [PieceSpan?] = [PieceSpan(width: 0, height: 0), PieceSpan(width: 0.25, height: 0.2)]
+    XCTAssertEqual(
+      PieceThumbnailGeometry.maxExtent(spans: spans, puzzleAspect: aspect) ?? 0, 0.25,
+      accuracy: 1e-9)
+  }
+
+  // MARK: size
+
+  func testBiggestPieceFillsTheTileAndSmallerOnesScaleWithIt() {
+    let big = PieceSpan(width: 0.1, height: 0.6)  // extent 0.1 x 0.3
+    let small = PieceSpan(width: 0.05, height: 0.3)  // extent 0.05 x 0.15 — half of big
+    let maxExtent = PieceThumbnailGeometry.maxExtent(spans: [big, small], puzzleAspect: aspect)
+
+    let bigSize = PieceThumbnailGeometry.size(
+      span: big, maxExtent: maxExtent, puzzleAspect: aspect, tileSide: tileSide)
+    let smallSize = PieceThumbnailGeometry.size(
+      span: small, maxExtent: maxExtent, puzzleAspect: aspect, tileSide: tileSide)
+
+    // The piece that set the scale reaches the tile edge on its longest axis,
+    // and nothing overflows the square.
+    XCTAssertEqual(bigSize?.height ?? 0, tileSide, accuracy: 1e-6)
+    XCTAssertEqual(bigSize?.width ?? 0, tileSide / 3, accuracy: 1e-6)
+    // Half the piece draws at half the size — the whole point of the shared scale.
+    XCTAssertEqual(smallSize?.width ?? 0, (bigSize?.width ?? 0) / 2, accuracy: 1e-6)
+    XCTAssertEqual(smallSize?.height ?? 0, (bigSize?.height ?? 0) / 2, accuracy: 1e-6)
+  }
+
+  func testNothingOverflowsTheSquareTile() {
+    let spans = [
+      PieceSpan(width: 0.3, height: 0.1), PieceSpan(width: 0.05, height: 0.5),
+      PieceSpan(width: 0.2, height: 0.4),
+    ]
+    let maxExtent = PieceThumbnailGeometry.maxExtent(spans: spans, puzzleAspect: aspect)
+    for span in spans {
+      let size = PieceThumbnailGeometry.size(
+        span: span, maxExtent: maxExtent, puzzleAspect: aspect, tileSide: tileSide)
+      // A quarter turn swaps the frame inside the square, so BOTH axes have
+      // to clear the tile side, not just the one that happens to be longer.
+      XCTAssertLessThanOrEqual(size?.width ?? .infinity, tileSide + 1e-6)
+      XCTAssertLessThanOrEqual(size?.height ?? .infinity, tileSide + 1e-6)
+    }
+  }
+
+  func testUnmeasuredPieceHasNoSize() {
+    XCTAssertNil(
+      PieceThumbnailGeometry.size(
+        span: nil, maxExtent: 0.3, puzzleAspect: aspect, tileSide: tileSide))
+  }
+
+  func testNoScaleToMeasureAgainstHasNoSize() {
+    let span = PieceSpan(width: 0.1, height: 0.6)
+    XCTAssertNil(
+      PieceThumbnailGeometry.size(
+        span: span, maxExtent: nil, puzzleAspect: aspect, tileSide: tileSide))
+    XCTAssertNil(
+      PieceThumbnailGeometry.size(
+        span: span, maxExtent: 0, puzzleAspect: aspect, tileSide: tileSide))
+  }
+
+  func testZeroTileHasNoSize() {
+    XCTAssertNil(
+      PieceThumbnailGeometry.size(
+        span: PieceSpan(width: 0.1, height: 0.6), maxExtent: 0.3, puzzleAspect: aspect,
+        tileSide: 0))
+  }
+}


### PR DESCRIPTION
## What

Two fixes to the piece queue grid on the solve screen.

**Tabs were being cropped off.** The grid scaled each piece photo with `.scaledToFill()` to cover its square tile, then clipped the overhang — which for any non-square piece photo is exactly the tabs, the part a piece is recognised by. It now fits the photo inside the tile instead.

**Every thumbnail was sized to its own tile**, which said nothing about the piece — only how close the camera happened to be when it was shot. Measured pieces are now drawn at one shared scale, so two tiles side by side show which piece is actually bigger.

## How

The shared scale comes from `PieceSpan`, the backend's measurement of the piece image frame as a fraction of the puzzle — the same measurement `PuzzleOverlayView`'s markers are already sized from.

`PieceSpan` normalizes to the puzzle's width and height *separately*, so its two components are different lengths on a non-square puzzle (`0.1` wide and `0.1` tall is not a square piece). The new `PieceThumbnailGeometry` converts both axes to **puzzle-width units** to make them comparable, then pins the largest piece's longest axis to the tile side — the point where every piece still fits whole at any quarter turn, with the grid no smaller than it has to be.

That conversion needs the puzzle's pixel aspect, so `SolveSession` now caches it off `trimmedJPEG` rather than decoding the whole puzzle JPEG on every layout pass.

## Known rough edges

- **Pieces with no `pieceSpan`** (the CNN path, or a matcher failure) have nothing to place on the shared scale, so they fall back to filling the tile. They read as the biggest pieces in the grid despite that meaning nothing — but inventing a size for them would read as a measurement.
- **The shared scale exposes noise in `pieceSpan`.** On a real 11-piece capture the thumbnails vary by ~3×, when the pieces are physically near-identical. The overview markers vary by about the same amount from the same measurement, so this is pre-existing backend noise that per-tile sizing was hiding, not a regression here. Possibly worth investigating separately.

## Testing

- Built and verified on a physical device: pieces render whole, tabs intact, at a common scale.
- `PieceThumbnailGeometry` is covered by `PieceThumbnailGeometryTests` — **these have not been run yet**, as they need a Simulator that was in use. CI will be the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)