### PR TITLE
Turn scanner gallery thumbnails upright from the prediction

### DIFF
--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -223,15 +223,11 @@ private struct QueueTile: View {
   /// gutter absorbs without the badge landing on the neighbouring tile.
   private static let badgeCornerOffset = badgeHitSize / 2 - badgeCircleInset
 
-  /// The model reports how far the piece is turned from its place in the
-  /// puzzle, so undoing it shows the piece as it will sit there — the same
-  /// counter-clockwise correction PuzzleOverlayView applies to its markers.
-  /// Normalized to (-180, 180] so the tile animates the short way round
-  /// rather than spinning three quarter turns to reach the same place.
+  /// Shows the piece as it will sit in the puzzle. Zero until the prediction
+  /// lands — the capture is drawn as photographed until there is something
+  /// better to say. See `PieceResponse.uprightRotationDegrees`.
   private var uprightRotation: Double {
-    guard let piece = entry.result else { return 0 }
-    let degrees = (360 - piece.rotation % 360) % 360
-    return Double(degrees > 180 ? degrees - 360 : degrees)
+    entry.result?.uprightRotationDegrees ?? 0
   }
 
   var body: some View {

--- a/ios/Pussel/Features/Solve/PieceScanView.swift
+++ b/ios/Pussel/Features/Solve/PieceScanView.swift
@@ -256,6 +256,7 @@ struct PieceScanView: View {
             ForEach(pieces) { piece in
               GalleryItemView(
                 piece: piece,
+                uprightRotation: uprightRotation(for: piece),
                 isHighlighted: isAlreadyScanned && piece.pieceId == matchedId
               )
             }
@@ -269,6 +270,20 @@ struct PieceScanView: View {
   }
 
   // MARK: - Helpers
+
+  /// How far to turn a gallery thumbnail so it shows the piece the way the
+  /// puzzle page's grid and overlay do.
+  ///
+  /// Read from the session rather than stored on `ScannedPiece`, because the
+  /// gallery item exists before its orientation is known: the geometry lock
+  /// enrols the piece, and only the position prediction that follows says
+  /// which way round it goes. Reading `entries` here inside `body` is what
+  /// subscribes the strip to that later update, so the thumbnail turns itself
+  /// upright when the prediction lands. Zero until then, and for pieces from
+  /// an earlier scanner visit that never got one.
+  private func uprightRotation(for piece: ScannedPiece) -> Double {
+    session.entry(forScanPieceId: piece.pieceId)?.result?.uprightRotationDegrees ?? 0
+  }
 
   /// Joins edge glyphs with the middle-dot separator used throughout the UI.
   private func edgeGlyphs(_ types: [GeometryEdgeType]) -> String {
@@ -291,6 +306,8 @@ struct PieceScanView: View {
 /// placeholder, with the edge-type glyphs underneath.
 private struct GalleryItemView: View {
   let piece: ScannedPiece
+  /// Degrees to turn the thumbnail so it matches the puzzle page's grid.
+  let uprightRotation: Double
   let isHighlighted: Bool
 
   private static let size: CGFloat = 56
@@ -308,6 +325,11 @@ private struct GalleryItemView: View {
             .resizable()
             .scaledToFill()
             .frame(width: Self.size, height: Self.size)
+            // Rotate inside the clip, not with it: `.rotationEffect` leaves
+            // the layout size alone, so the rounded square stays square and
+            // the turned photo is trimmed back to it.
+            .rotationEffect(.degrees(uprightRotation))
+            .animation(.easeInOut(duration: 0.25), value: uprightRotation)
             .clipShape(RoundedRectangle(cornerRadius: Self.cornerRadius))
         } else {
           Image(systemName: "puzzlepiece")

--- a/ios/Pussel/Models/PieceModels.swift
+++ b/ios/Pussel/Models/PieceModels.swift
@@ -25,6 +25,21 @@ struct PieceResponse: Codable, Equatable {
   let pieceSpan: PieceSpan?
 }
 
+extension PieceResponse {
+  /// How far to turn the captured image so the piece appears as it will sit
+  /// in the puzzle. The model reports how far the piece is turned *away from*
+  /// its place, so showing it upright means undoing that — the same
+  /// counter-clockwise correction `PuzzleOverlayView` applies to its markers.
+  ///
+  /// Normalized to (-180, 180] so a view animating this value turns the short
+  /// way round rather than spinning three quarter turns to reach the same
+  /// place.
+  var uprightRotationDegrees: Double {
+    let degrees = (360 - rotation % 360) % 360
+    return Double(degrees > 180 ? degrees - 360 : degrees)
+  }
+}
+
 /// Bounding box normalized to [0,1] image coordinates, mirroring the
 /// backend's `BoundingBox` model.
 struct NormalizedBoundingBox: Codable, Equatable {

--- a/ios/PusselTests/PieceRotationTests.swift
+++ b/ios/PusselTests/PieceRotationTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+@testable import Pussel
+
+/// `PieceResponse.uprightRotationDegrees` — the correction that turns a piece
+/// photo to sit the way the puzzle does. Shared by the piece grid
+/// (`PieceQueueView`) and the scanner's gallery strip (`PieceScanView`), so
+/// the two can't disagree about which way a piece faces.
+final class PieceRotationTests: XCTestCase {
+
+  private func response(rotation: Int) -> PieceResponse {
+    PieceResponse(
+      position: NormalizedPoint(x: 0.5, y: 0.5),
+      positionConfidence: 0.9,
+      rotation: rotation,
+      rotationConfidence: 0.9,
+      cleanedImage: nil,
+      pieceSpan: nil
+    )
+  }
+
+  /// The correction undoes the reported rotation, so the two cancel out.
+  func testUndoesTheReportedRotation() {
+    XCTAssertEqual(response(rotation: 0).uprightRotationDegrees, 0)
+    XCTAssertEqual(response(rotation: 90).uprightRotationDegrees, -90)
+    XCTAssertEqual(response(rotation: 270).uprightRotationDegrees, 90)
+  }
+
+  /// A half turn stays positive: 180 and -180 land in the same place, and the
+  /// (-180, 180] normalization keeps the upper bound.
+  func testHalfTurnKeepsThePositiveForm() {
+    XCTAssertEqual(response(rotation: 180).uprightRotationDegrees, 180)
+  }
+
+  /// Every correction is the short way round, so an animating view never
+  /// spins three quarter turns to reach a place one turn away.
+  func testTakesTheShortWayRound() {
+    for rotation in [0, 90, 180, 270] {
+      let degrees = response(rotation: rotation).uprightRotationDegrees
+      XCTAssertGreaterThan(degrees, -180)
+      XCTAssertLessThanOrEqual(degrees, 180)
+    }
+  }
+
+  /// Rotations that arrive already wrapped past a full turn are equivalent to
+  /// their in-range form rather than producing a second, larger correction.
+  func testFullTurnsAreEquivalentToTheirInRangeForm() {
+    XCTAssertEqual(response(rotation: 360).uprightRotationDegrees, 0)
+    XCTAssertEqual(response(rotation: 450).uprightRotationDegrees, -90)
+  }
+}


### PR DESCRIPTION
## What

The continuous scanner's gallery strip drew each scanned piece exactly as photographed, while the puzzle page's grid turns its tiles to sit the way the piece will in the puzzle. Same piece, two different orientations — the strip ignored what the backend told us.

This makes the strip reflect our best knowledge of each piece's orientation.

## How

The rotation **can't** be stored on `ScannedPiece` at lock time, because it doesn't exist yet: the geometry lock enrols the piece and puts it in the strip, and only the position prediction that follows says which way round it goes. So the strip looks the angle up from `SolveSession` by `scanPieceId` during `body`, which subscribes it to that later update — the thumbnail sits as-photographed for a moment, then animates upright when the prediction lands.

The correction `QueueTile` was computing inline moved to `PieceResponse.uprightRotationDegrees`, so the grid and the scanner can't drift apart on which way a piece faces. It's covered by tests now that it's shared.

In `GalleryItemView` the `.rotationEffect` goes *inside* the clip: it leaves the layout size alone, so the rounded square stays square and the turned photo is trimmed back to it.

## Verification

All 134 iOS tests pass, including 4 new ones for the rotation rule.

Driven end-to-end in the Simulator against a real backend, using three real Frozen pieces physically turned 90°/180°/270° before being fed to the scanner. The backend predicted exactly those angles at confidence 1.00, and all three thumbnails came out with the capture session's arrow marker pointing up — matching the grid tiles on the puzzle page.

## Noted in passing (not addressed here)

The app's overview frame detection over-crops an already-tight overview photo, cutting off the puzzle's border. That collapses matcher confidence to ~0.13 and makes the predicted rotation essentially a coin flip. It bit this verification (the app returned `rotation=0` where curl on the same image returned `rotation=90, conf=1.00`) and would degrade real users' predictions the same way. Worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)