### PR TITLE
Scope puzzles to their owner and close backend API auth gaps

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,3 +10,12 @@ JWT_EXPIRE_MINUTES=60
 # Google OAuth (for token verification)
 # Get from Google Cloud Console: https://console.cloud.google.com/apis/credentials
 GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
+
+# Email allowlist for login. Empty (default, i.e. unset) means ANY Google
+# account with a verified email may sign in — convenient for local dev, but
+# there is no user table so this is the only gate on who gets an account.
+# Set this to restrict access. Like other list settings (e.g.
+# BACKEND_CORS_ORIGINS), pydantic-settings parses this as a JSON array from
+# the env var. Matching is case-insensitive and tolerates surrounding
+# whitespace around each entry.
+# ALLOWED_EMAILS=["you@example.com", "teammate@example.com"]

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -7,6 +7,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from app.auth.service import AuthService, get_auth_service
 from app.models.user_model import User
+from app.services.puzzle_store import PuzzleRecord, get_puzzle_store
 
 # HTTP Bearer token scheme
 security = HTTPBearer(auto_error=False)
@@ -63,3 +64,28 @@ async def get_optional_user(
         return None
 
     return auth_service.get_user_from_token(credentials.credentials)
+
+
+async def get_owned_puzzle(
+    puzzle_id: str,
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> PuzzleRecord:
+    """Look up a puzzle and verify the current user owns it.
+
+    Args:
+        puzzle_id: The puzzle's id, taken from the request path.
+        current_user: The authenticated user.
+
+    Returns:
+        The requested puzzle's record.
+
+    Raises:
+        HTTPException: 404 when the puzzle doesn't exist, or exists but is
+            owned by someone else. A 403 would confirm the id exists (just
+            not for this caller), leaking information about other users'
+            puzzles — so both cases are indistinguishable 404s.
+    """
+    puzzle = get_puzzle_store().get(puzzle_id)
+    if puzzle is None or puzzle.owner_id != current_user.id:
+        raise HTTPException(status_code=404, detail="Puzzle not found")
+    return puzzle

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,11 +1,14 @@
 """Configuration module for the puzzle solver application."""
 
+import logging
 import os
 from functools import lru_cache
 from typing import Literal
 
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
 
 
 class Settings(BaseSettings):
@@ -20,7 +23,7 @@ class Settings(BaseSettings):
     MAX_UPLOAD_SIZE: int = 10 * 1024 * 1024  # 10MB
 
     # CORS settings
-    BACKEND_CORS_ORIGINS: list[str] = ["*"]
+    BACKEND_CORS_ORIGINS: list[str] = ["http://localhost:3000"]
 
     # Azure settings
     USE_AZURE_STORAGE: bool = False
@@ -31,6 +34,14 @@ class Settings(BaseSettings):
     JWT_ALGORITHM: str = "HS256"
     JWT_EXPIRE_MINUTES: int = 60
     GOOGLE_CLIENT_ID: str = ""
+
+    # Email allowlist for login: any successfully-verified Google account whose
+    # email appears here (case-insensitively, whitespace-trimmed) may sign in.
+    # An EMPTY list means "allow any Google account" — this preserves today's
+    # behavior and is convenient for local dev, but means anyone with a Gmail
+    # account gets a full account since there's no user table to otherwise
+    # gate access. Set this in deployed environments to restrict access.
+    ALLOWED_EMAILS: list[str] = []
 
     # Background removal settings
     ENABLE_BACKGROUND_REMOVAL: bool = True
@@ -60,6 +71,44 @@ class Settings(BaseSettings):
     PIECE_GEOMETRY_T_ACCEPT: float = -3.98
     PIECE_GEOMETRY_T_NEW: float = -0.80
 
+    # Rate limiting (in-memory, per-process — see app/rate_limit.py for the
+    # per-process caveat). Both are requests-per-minute per caller identity.
+    # Set either to 0 to disable that limit entirely, e.g. for tests and
+    # local dev where hammering an endpoint on purpose shouldn't 429.
+    #
+    # Per-IP, guards POST /api/v1/auth/google (unauthenticated, does a
+    # network call to Google's cert endpoint per request): generous enough
+    # for real logins/retries, low enough to blunt brute force and free DoS
+    # amplification.
+    RATE_LIMIT_AUTH_PER_MINUTE: int = Field(default=10, ge=0)
+    # Per-user, guards POST /api/v1/piece/preview, which the client polls in
+    # a loop while the piece camera is open. Measured client cadences: the
+    # web frontend polls at a 400ms floor between requests (~150/min in
+    # steady state; see DETECT_INTERVAL_MS in
+    # frontend/src/components/camera/live-piece-capture.tsx), and the iOS
+    # app targets ~4Hz / a 250ms minimum interval, serialized on one
+    # in-flight request at a time (~240/min; see
+    # PiecePreviewThrottle.minInterval in
+    # ios/Pussel/Features/Solve/PiecePreviewThrottle.swift). 300/min sits
+    # comfortably above the faster (iOS) cadence so normal live-preview use
+    # never gets 429'd, while still bounding a runaway or malicious client.
+    RATE_LIMIT_PREVIEW_PER_MINUTE: int = Field(default=300, ge=0)
+
+    # Whether to trust the inbound X-Forwarded-For header for per-IP rate
+    # limiting (see app/rate_limit.py::_client_ip). Defaults to False:
+    # nothing in this deployment (no Uvicorn --proxy-headers, no
+    # ProxyHeadersMiddleware, no infra-level stripping) removes or rewrites
+    # an inbound X-Forwarded-For, so a direct caller can set it to an
+    # arbitrary/random value on every request and land in a fresh rate-limit
+    # bucket each time -- trusting it by default would make the auth
+    # brute-force limiter trivially bypassable by exactly the attacker it
+    # exists to stop. Only flip this to True when the app is actually
+    # deployed behind a reverse proxy that overwrites/appends to
+    # X-Forwarded-For itself (e.g. Azure App Service's front end), so the
+    # header's rightmost entry is guaranteed proxy-authored rather than
+    # attacker-authored.
+    TRUST_PROXY_HEADERS: bool = False
+
     # Environment setting (used for validation)
     ENVIRONMENT: str = "development"  # development, test, or production
 
@@ -84,6 +133,25 @@ class Settings(BaseSettings):
             )
         return self
 
+    def is_email_allowed(self, email: str) -> bool:
+        """Check whether an email may authenticate, per ALLOWED_EMAILS.
+
+        Comparison is case-insensitive and tolerant of surrounding whitespace
+        on the configured values, since Google emails are case-insensitive in
+        practice and a comma-separated env var may include stray spaces.
+
+        Args:
+            email: The candidate email address, as returned by Google.
+
+        Returns:
+            True if ALLOWED_EMAILS is empty (allow any account) or the email
+            matches an entry in ALLOWED_EMAILS, False otherwise.
+        """
+        if not self.ALLOWED_EMAILS:
+            return True
+        normalized_allowed = {allowed.strip().lower() for allowed in self.ALLOWED_EMAILS}
+        return email.strip().lower() in normalized_allowed
+
 
 @lru_cache()
 def get_settings() -> Settings:
@@ -93,6 +161,12 @@ def get_settings() -> Settings:
 
 # Create instance
 settings = get_settings()
+
+if not settings.ALLOWED_EMAILS:
+    logger.warning(
+        "ALLOWED_EMAILS is empty: any Google account with a verified email can sign in. "
+        "Set ALLOWED_EMAILS to restrict access to this application."
+    )
 
 # Ensure upload directory exists
 os.makedirs(settings.UPLOAD_DIR, exist_ok=True)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -660,7 +660,7 @@ async def list_piece_geometry(
 async def delete_piece_geometry(
     puzzle_id: str,
     piece_id: str,
-    current_user: Annotated[User, Depends(get_current_user)],
+    puzzle: Annotated[PuzzleRecord, Depends(get_owned_puzzle)],
 ) -> None:
     """Un-enroll one piece from a puzzle's piece-geometry store.
 
@@ -671,16 +671,13 @@ async def delete_piece_geometry(
     Args:
         puzzle_id: ID of the puzzle the piece belongs to.
         piece_id: ID of the enrolled piece to remove.
-        current_user: The authenticated user.
+        puzzle: The caller's owned puzzle record; the dependency also 404s
+            when the puzzle doesn't exist or belongs to someone else.
 
     Raises:
         HTTPException: If the puzzle does not exist, or it has no piece with
             this id enrolled.
     """
-    _ = current_user  # Acknowledge the parameter is intentionally unused for now
-    if puzzle_id not in puzzle_images:
-        raise HTTPException(status_code=404, detail="Puzzle not found")
-
     if not get_piece_geometry_store().remove(puzzle_id, piece_id):
         raise HTTPException(status_code=404, detail="Piece not found")
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ import base64
 import io
 import os
 import uuid
-from typing import Annotated, Dict, List, Literal, Optional, Tuple
+from typing import Annotated, List, Literal, Optional
 
 import numpy as np
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, UploadFile
@@ -12,7 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from PIL import Image, ImageOps, UnidentifiedImageError
 from pydantic import ValidationError
 
-from app.auth.dependencies import get_current_user
+from app.auth.dependencies import get_current_user, get_owned_puzzle
 from app.auth.service import AuthService, get_auth_service
 from app.config import settings
 from app.models.piece_geometry_model import (
@@ -34,10 +34,13 @@ from app.models.puzzle_model import (
     GeneratePieceResponse,
     PiecePreviewResponse,
     PieceResponse,
+    PuzzleListResponse,
     PuzzleResponse,
+    PuzzleSummary,
     QuadCorners,
 )
 from app.models.user_model import GoogleAuthRequest, TokenResponse, User
+from app.rate_limit import FixedWindowRateLimiter, rate_limit_by_ip, rate_limit_by_user
 from app.services.classical_matcher import get_classical_matcher
 from app.services.image_processor import get_image_processor
 from app.services.piece_detector import get_piece_detector
@@ -50,6 +53,7 @@ from app.services.piece_geometry.store import get_piece_geometry_store
 from app.services.piece_shape import PieceShapeGenerator, calculate_grid_dimensions
 from app.services.puzzle_cutter import get_puzzle_cutter
 from app.services.puzzle_detector import get_puzzle_detector
+from app.services.puzzle_store import PuzzleRecord, get_puzzle_store
 
 # Initialize FastAPI app
 app = FastAPI(title=settings.PROJECT_NAME)
@@ -63,17 +67,16 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Store puzzle images in memory for demo
-puzzle_images: Dict[str, str] = {}
-# Grid (rows, cols) estimated from an optional client-supplied piece count at
-# upload time; used to size the classical matcher's NCC template. Only present
-# for puzzles uploaded with piece_count.
-puzzle_grids: Dict[str, Tuple[int, int]] = {}
-
 # piece_count must produce a sane grid: a puzzle can't reasonably have fewer
 # than 4 pieces, and this backend isn't tuned for four-digit piece counts.
 MIN_PIECE_COUNT = 4
 MAX_PIECE_COUNT = 2000
+
+# Rate limiters (see app/rate_limit.py). One instance per protected route so
+# their counters don't collide; limits are read live from settings on each
+# request (see app/config.py: RATE_LIMIT_AUTH_PER_MINUTE / _PREVIEW_PER_MINUTE).
+auth_rate_limiter = FixedWindowRateLimiter()
+piece_preview_rate_limiter = FixedWindowRateLimiter()
 
 
 @app.get("/health")
@@ -87,7 +90,11 @@ def health_check() -> dict[str, str]:
 # =============================================================================
 
 
-@app.post("/api/v1/auth/google", response_model=TokenResponse)
+@app.post(
+    "/api/v1/auth/google",
+    response_model=TokenResponse,
+    dependencies=[Depends(rate_limit_by_ip(auth_rate_limiter, lambda: settings.RATE_LIMIT_AUTH_PER_MINUTE))],
+)
 async def google_auth(
     request: GoogleAuthRequest,
     auth_service: Annotated[AuthService, Depends(get_auth_service)],
@@ -95,6 +102,10 @@ async def google_auth(
     """Authenticate with Google OAuth.
 
     Exchanges a Google ID token for an application JWT token.
+
+    Unauthenticated and rate-limited per-IP (see `app.rate_limit`): this
+    endpoint does a network call to Google's cert endpoint per request, so
+    without a limit it's both brute-forceable and a free DoS amplifier.
 
     Args:
         request: The Google authentication request containing the ID token.
@@ -104,13 +115,21 @@ async def google_auth(
         TokenResponse containing the access token and user information.
 
     Raises:
-        HTTPException: If the Google token is invalid.
+        HTTPException: If the Google token is invalid, the account's email
+            isn't on the configured allowlist (see `Settings.ALLOWED_EMAILS`),
+            or the caller's IP has exceeded `RATE_LIMIT_AUTH_PER_MINUTE` (429).
     """
     user_info = auth_service.verify_google_token(request.id_token)
     if user_info is None:
         raise HTTPException(
             status_code=401,
             detail="Invalid Google token",
+        )
+
+    if not settings.is_email_allowed(user_info["email"]):
+        raise HTTPException(
+            status_code=403,
+            detail="This account is not authorized to use this application",
         )
 
     user = User(
@@ -178,8 +197,6 @@ async def upload_puzzle(
             range, or (when piece_count is given) the file isn't a decodable
             image.
     """
-    # Note: current_user can be used to associate puzzles with users in the future
-    _ = current_user  # Acknowledge the parameter is intentionally unused for now
     if file is None:
         raise HTTPException(status_code=400, detail="No file provided")
 
@@ -210,16 +227,51 @@ async def upload_puzzle(
     with open(file_path, "wb") as f:
         f.write(contents)
 
-    puzzle_images[puzzle_id] = file_path
-    if rows is not None and cols is not None:
-        puzzle_grids[puzzle_id] = (rows, cols)
+    get_puzzle_store().add(
+        PuzzleRecord(
+            puzzle_id=puzzle_id,
+            owner_id=current_user.id,
+            file_path=file_path,
+            grid=(rows, cols) if rows is not None and cols is not None else None,
+        )
+    )
 
     return PuzzleResponse(puzzle_id=puzzle_id, piece_count=piece_count, rows=rows, cols=cols)
 
 
-@app.post("/api/v1/puzzle/detect-frame", response_model=DetectFrameResponse)
-async def detect_frame(
+@app.get("/api/v1/puzzles", response_model=PuzzleListResponse)
+async def list_puzzles(
     current_user: Annotated[User, Depends(get_current_user)],
+) -> PuzzleListResponse:
+    """List the caller's own puzzles.
+
+    Args:
+        current_user: The authenticated user.
+
+    Returns:
+        PuzzleListResponse with one summary (puzzle_id, plus rows/cols when
+        known) per puzzle owned by the caller, in upload order. Never
+        includes other users' puzzles.
+    """
+    records = get_puzzle_store().list_for_owner(current_user.id)
+    return PuzzleListResponse(
+        puzzles=[
+            PuzzleSummary(
+                puzzle_id=record.puzzle_id,
+                rows=record.grid[0] if record.grid is not None else None,
+                cols=record.grid[1] if record.grid is not None else None,
+            )
+            for record in records
+        ]
+    )
+
+
+@app.post(
+    "/api/v1/puzzle/detect-frame",
+    response_model=DetectFrameResponse,
+    dependencies=[Depends(get_current_user)],
+)
+async def detect_frame(
     file: Optional[UploadFile] = None,
     corners: Annotated[Optional[str], Form(description="Manually adjusted corners as JSON QuadCorners")] = None,
 ) -> DetectFrameResponse:
@@ -230,8 +282,10 @@ async def detect_frame(
     When ``corners`` is provided (manual adjustment), detection is skipped and
     the supplied corners are used for the warp with confidence 1.0.
 
+    Requires authentication (see the route's ``dependencies``), but doesn't
+    need the caller's identity — it doesn't persist or look up anything.
+
     Args:
-        current_user: The authenticated user.
         file: The raw photo of the puzzle.
         corners: Optional JSON-encoded QuadCorners overriding auto-detection.
 
@@ -243,7 +297,6 @@ async def detect_frame(
         HTTPException: If no/invalid file is provided, the file is too large,
             or the corners payload is malformed.
     """
-    _ = current_user  # Acknowledge the parameter is intentionally unused for now
     if file is None:
         raise HTTPException(status_code=400, detail="No file provided")
 
@@ -286,9 +339,14 @@ async def detect_frame(
     )
 
 
-@app.post("/api/v1/piece/preview", response_model=PiecePreviewResponse)
+@app.post(
+    "/api/v1/piece/preview",
+    response_model=PiecePreviewResponse,
+    dependencies=[
+        Depends(rate_limit_by_user(piece_preview_rate_limiter, lambda: settings.RATE_LIMIT_PREVIEW_PER_MINUTE))
+    ],
+)
 async def preview_piece(
-    current_user: Annotated[User, Depends(get_current_user)],
     file: Optional[UploadFile] = None,
     include_quality: Annotated[
         bool,
@@ -307,8 +365,14 @@ async def preview_piece(
     while the piece camera is open and overlays the returned outline on the
     preview, so the user can see what will be captured.
 
+    Requires authentication and is rate-limited per-user (see the route's
+    ``dependencies``, which composes `get_current_user` with a rate-limit
+    check — see `app.rate_limit.rate_limit_by_user`): the client polls this
+    in a loop, and an authenticated (or buggy) client could otherwise
+    saturate the server's per-frame CV work. Doesn't need the caller's
+    identity beyond that, though — it doesn't persist or look up anything.
+
     Args:
-        current_user: The authenticated user.
         file: A downscaled camera frame.
         include_quality: When true, populates the best-effort `lockable` and
             `corner_disagreement` piece-geometry flags computed from the
@@ -322,9 +386,9 @@ async def preview_piece(
         expressing how piece-like the region is, or found=False.
 
     Raises:
-        HTTPException: If no/invalid file is provided.
+        HTTPException: If no/invalid file is provided, or the caller has
+            exceeded `RATE_LIMIT_PREVIEW_PER_MINUTE` (429).
     """
-    _ = current_user  # Acknowledge the parameter is intentionally unused for now
     if file is None:
         raise HTTPException(status_code=400, detail="No file provided")
 
@@ -366,7 +430,7 @@ async def preview_piece(
 @app.post("/api/v1/puzzle/{puzzle_id}/piece", response_model=PieceResponse)
 async def process_piece(
     puzzle_id: str,
-    current_user: Annotated[User, Depends(get_current_user)],
+    puzzle: Annotated[PuzzleRecord, Depends(get_owned_puzzle)],
     file: Optional[UploadFile] = None,
     remove_bg: Annotated[bool, Query(description="Remove background from piece image using rembg")] = True,
 ) -> PieceResponse:
@@ -374,7 +438,8 @@ async def process_piece(
 
     Args:
         puzzle_id: ID of the puzzle to match against.
-        current_user: The authenticated user.
+        puzzle: The caller's owned puzzle record; the dependency also 404s
+            when the puzzle doesn't exist or belongs to someone else.
         file: The puzzle piece image file.
         remove_bg: Whether to remove background from piece image (default: True).
 
@@ -384,21 +449,16 @@ async def process_piece(
     Raises:
         HTTPException: If puzzle not found or file type is invalid.
     """
-    _ = current_user  # Acknowledge the parameter is intentionally unused for now
     if file is None:
         raise HTTPException(status_code=400, detail="No file provided")
-
-    if puzzle_id not in puzzle_images:
-        raise HTTPException(status_code=404, detail="Puzzle not found")
 
     if settings.MATCHER == "cnn":
         return await get_image_processor().process_piece(file, puzzle_id, remove_background=remove_bg)
 
     # Pass along the grid estimated at upload time (if any) so the NCC fallback's
     # nominal template size uses the puzzle's real grid instead of the defaults.
-    grid_hint = puzzle_grids.get(puzzle_id)
     return await get_classical_matcher().process_piece(
-        file, puzzle_id, remove_background=remove_bg, grid_hint=grid_hint
+        file, puzzle_id, remove_background=remove_bg, grid_hint=puzzle.grid
     )
 
 
@@ -479,7 +539,7 @@ def _geometry_record_response(
 @app.post("/api/v1/puzzle/{puzzle_id}/piece/geometry", response_model=PieceGeometryUploadResponse)
 async def upload_piece_geometry(
     puzzle_id: str,
-    current_user: Annotated[User, Depends(get_current_user)],
+    puzzle: Annotated[PuzzleRecord, Depends(get_owned_puzzle)],
     file: Optional[UploadFile] = None,
     include_contour: Annotated[
         bool, Query(description="Include the full contour polyline in the response (large)")
@@ -506,7 +566,8 @@ async def upload_piece_geometry(
 
     Args:
         puzzle_id: ID of the puzzle this piece photo belongs to.
-        current_user: The authenticated user.
+        puzzle: The caller's owned puzzle record; the dependency also 404s
+            when the puzzle doesn't exist or belongs to someone else.
         file: The puzzle piece photo.
         include_contour: Whether to include the full (large) contour polyline.
         on_uncertain: Gray-zone resolution: "report" (default) keeps the
@@ -521,12 +582,8 @@ async def upload_piece_geometry(
         HTTPException: If no/invalid file is provided, the file is too
             large, or the puzzle does not exist.
     """
-    _ = current_user  # Acknowledge the parameter is intentionally unused for now
     if file is None:
         raise HTTPException(status_code=400, detail="No file provided")
-
-    if puzzle_id not in puzzle_images:
-        raise HTTPException(status_code=404, detail="Puzzle not found")
 
     if file.size and file.size > settings.MAX_UPLOAD_SIZE:
         raise HTTPException(status_code=413, detail="File too large")
@@ -568,13 +625,14 @@ async def upload_piece_geometry(
 @app.get("/api/v1/puzzle/{puzzle_id}/piece/geometry", response_model=PieceGeometryListResponse)
 async def list_piece_geometry(
     puzzle_id: str,
-    current_user: Annotated[User, Depends(get_current_user)],
+    puzzle: Annotated[PuzzleRecord, Depends(get_owned_puzzle)],
 ) -> PieceGeometryListResponse:
     """List the pieces enrolled in a puzzle's piece-geometry store.
 
     Args:
         puzzle_id: ID of the puzzle to list.
-        current_user: The authenticated user.
+        puzzle: The caller's owned puzzle record; the dependency also 404s
+            when the puzzle doesn't exist or belongs to someone else.
 
     Returns:
         PieceGeometryListResponse with one summary (id, edge types, quality
@@ -583,10 +641,6 @@ async def list_piece_geometry(
     Raises:
         HTTPException: If the puzzle does not exist.
     """
-    _ = current_user  # Acknowledge the parameter is intentionally unused for now
-    if puzzle_id not in puzzle_images:
-        raise HTTPException(status_code=404, detail="Puzzle not found")
-
     enrolled = get_piece_geometry_store().list_pieces(puzzle_id)
     return PieceGeometryListResponse(
         puzzle_id=puzzle_id,
@@ -606,7 +660,7 @@ async def list_piece_geometry(
 async def generate_piece(
     puzzle_id: str,
     request: GeneratePieceRequest,
-    current_user: Annotated[User, Depends(get_current_user)],
+    puzzle: Annotated[PuzzleRecord, Depends(get_owned_puzzle)],
 ) -> GeneratePieceResponse:
     """Generate a realistic jigsaw-shaped piece at the specified position.
 
@@ -618,7 +672,8 @@ async def generate_piece(
         puzzle_id: ID of the puzzle to extract piece from.
         request: Contains center_x, center_y (normalized 0-1 coordinates)
             and optional piece_size_ratio.
-        current_user: The authenticated user.
+        puzzle: The caller's owned puzzle record; the dependency also 404s
+            when the puzzle doesn't exist or belongs to someone else.
 
     Returns:
         GeneratePieceResponse with piece_image (base64 PNG) and piece_config.
@@ -626,13 +681,7 @@ async def generate_piece(
     Raises:
         HTTPException: If puzzle not found.
     """
-    _ = current_user  # Acknowledge the parameter is intentionally unused for now
-    if puzzle_id not in puzzle_images:
-        raise HTTPException(status_code=404, detail="Puzzle not found")
-
-    # Load puzzle image
-    puzzle_path = puzzle_images[puzzle_id]
-    puzzle_img = Image.open(puzzle_path).convert("RGBA")
+    puzzle_img = Image.open(puzzle.file_path).convert("RGBA")
 
     # Generate piece with random jigsaw shape
     generator = PieceShapeGenerator(piece_size_ratio=request.piece_size_ratio)
@@ -657,6 +706,7 @@ async def generate_piece(
 async def cut_puzzle(
     puzzle_id: str,
     request: CutPuzzleRequest,
+    puzzle: Annotated[PuzzleRecord, Depends(get_owned_puzzle)],
 ) -> CutPuzzleResponse:
     """Cut a puzzle into jigsaw-shaped pieces for manual solving.
 
@@ -664,9 +714,14 @@ async def cut_puzzle(
     pieces with realistic Bezier curve edges. Each piece is returned as a PNG
     with transparent background, along with its correct position for game play.
 
+    Requires authentication and ownership of the puzzle (previously this
+    endpoint had no auth dependency at all).
+
     Args:
         puzzle_id: ID of the puzzle to cut.
         request: Contains rows, cols, and optional seed for reproducibility.
+        puzzle: The caller's owned puzzle record; the dependency also 404s
+            when the puzzle doesn't exist or belongs to someone else.
 
     Returns:
         CutPuzzleResponse with list of pieces, grid dimensions, and puzzle size.
@@ -674,12 +729,7 @@ async def cut_puzzle(
     Raises:
         HTTPException: If puzzle not found.
     """
-    if puzzle_id not in puzzle_images:
-        raise HTTPException(status_code=404, detail="Puzzle not found")
-
-    # Load puzzle image
-    puzzle_path = puzzle_images[puzzle_id]
-    puzzle_img = Image.open(puzzle_path)
+    puzzle_img = Image.open(puzzle.file_path)
 
     # Cut into pieces
     cutter = get_puzzle_cutter()

--- a/backend/app/models/puzzle_model.py
+++ b/backend/app/models/puzzle_model.py
@@ -49,6 +49,20 @@ class PuzzleResponse(BaseModel):
     cols: Optional[int] = Field(default=None, description="Estimated grid cols, present when piece_count was given")
 
 
+class PuzzleSummary(BaseModel):
+    """Summary of one puzzle owned by the caller, as returned by the puzzle-listing endpoint."""
+
+    puzzle_id: str
+    rows: Optional[int] = Field(default=None, description="Estimated grid rows, present when known")
+    cols: Optional[int] = Field(default=None, description="Estimated grid cols, present when known")
+
+
+class PuzzleListResponse(BaseModel):
+    """Response model for listing the caller's own puzzles."""
+
+    puzzles: List[PuzzleSummary] = Field(..., description="The caller's puzzles, in upload order")
+
+
 # Models for puzzle frame detection (real mode)
 
 

--- a/backend/app/models/user_model.py
+++ b/backend/app/models/user_model.py
@@ -1,6 +1,6 @@
 """User and authentication models."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from pydantic import BaseModel, EmailStr, Field
@@ -13,7 +13,9 @@ class User(BaseModel):
     email: EmailStr = Field(..., description="User's email address")
     name: str = Field(..., description="User's display name")
     picture: Optional[str] = Field(None, description="URL to user's profile picture")
-    created_at: datetime = Field(default_factory=datetime.utcnow, description="Account creation timestamp")
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc), description="Account creation timestamp"
+    )
 
 
 class TokenPayload(BaseModel):

--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -1,0 +1,243 @@
+"""Minimal in-memory rate limiting for FastAPI routes.
+
+This is a small fixed-window limiter over a process-local dict — no Redis,
+no external dependency. That means it is **per-process**: if this app is
+ever run with multiple uvicorn workers (or multiple instances behind a load
+balancer), each process enforces its own independent limit rather than
+sharing a single global count, so the *effective* limit for a caller scales
+with the number of processes. That's an accepted tradeoff for this in-memory
+demo app (storage elsewhere in the app is already per-process/in-memory) —
+it still meaningfully blocks single-process abuse and brute force without
+adding an external moving part.
+
+Per-IP keying (`_client_ip` below) trusts `X-Forwarded-For` only when
+`settings.TRUST_PROXY_HEADERS` is explicitly enabled, and even then only its
+rightmost entry. See `_client_ip`'s docstring for why: an untrusted
+`X-Forwarded-For` lets a caller manufacture a fresh rate-limit bucket on
+every request, silently defeating IP-based limiting.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Annotated, Callable
+
+from fastapi import Depends, HTTPException, Request
+
+from app.auth.dependencies import get_current_user
+from app.config import settings
+from app.models.user_model import User
+
+# Hard cap on distinct keys tracked at once. Without this, an attacker who
+# varies their identity per request (e.g. a spoofed X-Forwarded-For value)
+# could grow the tracking dict without bound, trading a rate-limit hole for
+# a memory-leak hole. When the cap is hit, the least-recently-touched key is
+# evicted to make room for the new one.
+DEFAULT_MAX_TRACKED_KEYS = 10_000
+
+
+@dataclass
+class _Window:
+    """Fixed-window counter state for a single key."""
+
+    count: int
+    window_start: float
+
+
+class FixedWindowRateLimiter:
+    """A minimal fixed-window rate limiter keyed by an arbitrary string.
+
+    Each key gets its own rolling window: the first hit for a key opens a
+    `window_seconds`-wide window, subsequent hits within that window
+    increment its counter, and the window resets once it expires. The limit
+    itself is passed in on each `check()` call (rather than fixed at
+    construction) so callers can read it from live config (e.g.
+    `app.config.settings`) and tests can adjust it at runtime.
+    """
+
+    def __init__(
+        self,
+        window_seconds: float = 60.0,
+        clock: Callable[[], float] = time.monotonic,
+        max_tracked_keys: int = DEFAULT_MAX_TRACKED_KEYS,
+    ) -> None:
+        """Initialize the limiter.
+
+        Args:
+            window_seconds: Width of each key's rolling window, in seconds.
+            clock: Monotonic time source. Defaults to `time.monotonic` so
+                wall-clock changes (NTP adjustments, DST, manual clock
+                changes) can't confuse the window. Injectable for tests via
+                `set_clock`.
+            max_tracked_keys: Memory bound — the most distinct keys tracked
+                at once before the oldest-touched is evicted.
+        """
+        self._window_seconds = window_seconds
+        self._clock = clock
+        self._max_tracked_keys = max_tracked_keys
+        self._buckets: "OrderedDict[str, _Window]" = OrderedDict()
+
+    def set_clock(self, clock: Callable[[], float]) -> None:
+        """Swap the time source.
+
+        Intended for tests that need to fast-forward past a window without `time.sleep()`.
+
+        Args:
+            clock: The replacement zero-argument time source.
+        """
+        self._clock = clock
+
+    def reset(self) -> None:
+        """Clear all tracked state. Intended for test isolation between tests."""
+        self._buckets.clear()
+
+    @property
+    def tracked_key_count(self) -> int:
+        """Number of distinct keys currently tracked (for tests/inspection)."""
+        return len(self._buckets)
+
+    def check(self, key: str, limit_per_minute: int) -> None:
+        """Record one hit for `key`, raising 429 if it exceeds `limit_per_minute`.
+
+        Args:
+            key: Identity string for the caller (e.g. an IP address or user id).
+            limit_per_minute: Max hits allowed per `window_seconds`. A value
+                of 0 (or negative) disables limiting entirely — useful for
+                tests and local dev.
+
+        Raises:
+            HTTPException: 429 with a `Retry-After` header (seconds) when the
+                caller has exceeded the limit for the current window.
+        """
+        if limit_per_minute <= 0:
+            return
+
+        now = self._clock()
+
+        window = self._buckets.get(key)
+        if window is None or now - window.window_start >= self._window_seconds:
+            window = _Window(count=0, window_start=now)
+
+        window.count += 1
+        self._buckets[key] = window
+        self._buckets.move_to_end(key)
+
+        # Bound memory: evict the least-recently-touched key(s) once we're
+        # over the cap, rather than letting the dict grow forever.
+        while len(self._buckets) > self._max_tracked_keys:
+            self._buckets.popitem(last=False)
+
+        if window.count > limit_per_minute:
+            remaining = self._window_seconds - (now - window.window_start)
+            retry_after = max(1, math.ceil(remaining))
+            raise HTTPException(
+                status_code=429,
+                detail="Too many requests. Please slow down and try again shortly.",
+                headers={"Retry-After": str(retry_after)},
+            )
+
+
+def _client_ip(request: Request) -> str:
+    """Best-effort caller IP for unauthenticated rate limiting.
+
+    Keying is gated by `settings.TRUST_PROXY_HEADERS` (default False):
+
+    - False (default): uses `request.client.host` only. `X-Forwarded-For` is
+      ignored entirely. Nothing in this deployment strips or rewrites an
+      inbound `X-Forwarded-For` header, so trusting it here would let a
+      direct caller send a fresh, arbitrary value on every request and land
+      in a brand-new rate-limit bucket each time -- defeating the very
+      brute-force protection this limiter exists to provide. The tradeoff:
+      if the app *is* actually behind a real reverse proxy while this flag
+      is off, every request arrives with the same `request.client.host` (the
+      proxy's IP), so all callers share one bucket. That's a deliberate
+      fail-CLOSED choice (over-limiting real distinct users) rather than
+      fail-OPEN (no effective limiting at all) -- the correct default when
+      we don't know whether a trusted proxy is in front of us.
+    - True: only set this when the app is actually deployed behind a
+      reverse proxy that overwrites/appends to `X-Forwarded-For` itself
+      (e.g. Azure App Service). In that case, use the RIGHTMOST entry of
+      `X-Forwarded-For`, not the leftmost. The rightmost entry is the one
+      appended by the nearest trusted proxy hop and therefore cannot be
+      forged by the external client; every entry to its left (including the
+      traditional "original client" leftmost entry) is attacker-controlled
+      free text the client can set to anything, including a fresh random
+      value per request. Do not "fix" this back to the leftmost entry --
+      that reintroduces the spoofing bypass. Falls back to
+      `request.client.host` when the header is absent or empty.
+
+    Falls back to a constant key if `request.client` is None, which
+    Starlette allows (e.g. some test clients/transports).
+
+    NOTE: even the rightmost `X-Forwarded-For` entry is only as trustworthy
+    as the proxy in front of us; this is abuse-mitigation, not a security
+    boundary, and must never be used for authentication/authorization.
+
+    Args:
+        request: The incoming request.
+
+    Returns:
+        A best-effort identity string for the caller.
+    """
+    if settings.TRUST_PROXY_HEADERS:
+        forwarded = request.headers.get("x-forwarded-for")
+        if forwarded:
+            entries = [entry.strip() for entry in forwarded.split(",")]
+            non_empty = [entry for entry in entries if entry]
+            if non_empty:
+                return non_empty[-1]
+    if request.client is not None:
+        return request.client.host
+    return "unknown-client"
+
+
+def rate_limit_by_ip(limiter: FixedWindowRateLimiter, limit_per_minute: Callable[[], int]) -> Callable[[Request], None]:
+    """Build a per-IP rate-limiting FastAPI dependency.
+
+    Intended for unauthenticated routes, where the caller's IP is the only
+    identity available.
+
+    Args:
+        limiter: The `FixedWindowRateLimiter` instance tracking this route's state.
+        limit_per_minute: Called on each request to read the current limit
+            (e.g. `lambda: settings.RATE_LIMIT_AUTH_PER_MINUTE`) rather than
+            baking one in at import time, so config changes and test
+            monkeypatches take effect immediately.
+
+    Returns:
+        A dependency callable suitable for a route's `dependencies=[...]`.
+    """
+
+    def _dependency(request: Request) -> None:
+        limiter.check(_client_ip(request), limit_per_minute())
+
+    return _dependency
+
+
+def rate_limit_by_user(limiter: FixedWindowRateLimiter, limit_per_minute: Callable[[], int]) -> Callable[..., User]:
+    """Build a per-user rate-limiting FastAPI dependency, composed on top of auth.
+
+    Keys the limiter by `User.id` rather than IP: it survives NAT (many
+    users behind one IP don't share a bucket) and can't be spoofed the way a
+    header can. Depends on `get_current_user`, so applying this dependency
+    to a route both enforces authentication and adds rate limiting in one
+    line — no separate `Depends(get_current_user)` needed alongside it.
+
+    Args:
+        limiter: The `FixedWindowRateLimiter` instance tracking this route's state.
+        limit_per_minute: Called on each request to read the current limit,
+            same rationale as `rate_limit_by_ip`.
+
+    Returns:
+        A dependency callable suitable for a route's `dependencies=[...]`
+        (or as a regular parameter dependency, since it also returns the user).
+    """
+
+    def _dependency(current_user: Annotated[User, Depends(get_current_user)]) -> User:
+        limiter.check(current_user.id, limit_per_minute())
+        return current_user
+
+    return _dependency

--- a/backend/app/services/piece_geometry/store.py
+++ b/backend/app/services/piece_geometry/store.py
@@ -291,6 +291,17 @@ class PieceGeometryStore:
         store = self._stores.get(puzzle_id)
         return store.list_pieces() if store else []
 
+    def drop(self, puzzle_id: str) -> None:
+        """Remove a puzzle's piece-geometry store entirely.
+
+        Called when a puzzle is evicted from `PuzzleStore` so its enrolled
+        pieces don't linger in memory. A no-op if the puzzle has no store.
+
+        Args:
+            puzzle_id: The puzzle's id.
+        """
+        self._stores.pop(puzzle_id, None)
+
 
 _piece_geometry_store: Optional[PieceGeometryStore] = None
 

--- a/backend/app/services/puzzle_store.py
+++ b/backend/app/services/puzzle_store.py
@@ -1,0 +1,118 @@
+"""In-memory puzzle store: owner-scoped records with FIFO eviction.
+
+Puzzles are stored purely in memory — a deliberate decision, not a stopgap;
+this backend intentionally has no database. Each `puzzle_id` maps to a
+`PuzzleRecord` recording who owns it, where its image lives on disk, and its
+optional estimated grid. `MAX_PUZZLES` caps memory growth: once the cap is
+exceeded, the oldest puzzle is evicted (FIFO) and its resources (the stored
+file, matcher caches, and piece-geometry entries) are cleaned up so nothing
+leaks.
+"""
+
+from collections import OrderedDict
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import List, Optional, Tuple
+
+# Cap on concurrently-tracked puzzles. The dict would otherwise grow without
+# bound; once this is exceeded, the oldest puzzle (by insertion order) is
+# evicted to make room for the new one.
+MAX_PUZZLES = 100
+
+
+@dataclass(frozen=True)
+class PuzzleRecord:
+    """One uploaded puzzle: who owns it, where its image lives, and its grid.
+
+    Attributes:
+        puzzle_id: The puzzle's id.
+        owner_id: The uploading user's id (Google `sub`).
+        file_path: Path to the puzzle's stored image on disk.
+        grid: Estimated (rows, cols), when a `piece_count` was supplied at
+            upload time; None otherwise.
+    """
+
+    puzzle_id: str
+    owner_id: str
+    file_path: str
+    grid: Optional[Tuple[int, int]]
+
+
+def _evict(record: PuzzleRecord) -> None:
+    """Clean up an evicted puzzle's resources: its file, matcher caches, and geometry store.
+
+    Imports are local to this function (rather than module-level) so that
+    importing `puzzle_store` doesn't eagerly pull in the classical matcher,
+    the CNN image processor, or the piece-geometry store — and to avoid an
+    import cycle, since those modules may in turn end up depending on this
+    one.
+
+    Args:
+        record: The evicted puzzle's record.
+    """
+    import os
+
+    from app.services.classical_matcher import get_classical_matcher
+    from app.services.image_processor import get_image_processor
+    from app.services.piece_geometry.store import get_piece_geometry_store
+
+    try:
+        os.remove(record.file_path)
+    except OSError:
+        pass
+
+    get_classical_matcher().clear_puzzle_cache(record.puzzle_id)
+    get_image_processor().clear_puzzle_cache(record.puzzle_id)
+    get_piece_geometry_store().drop(record.puzzle_id)
+
+
+class PuzzleStore:
+    """In-memory puzzle records keyed by puzzle_id, with FIFO eviction at `MAX_PUZZLES`."""
+
+    def __init__(self) -> None:
+        """Initialize an empty store."""
+        self._records: "OrderedDict[str, PuzzleRecord]" = OrderedDict()
+
+    def add(self, record: PuzzleRecord) -> None:
+        """Add a new puzzle record, evicting the oldest one if now over capacity.
+
+        Args:
+            record: The puzzle record to add.
+        """
+        self._records[record.puzzle_id] = record
+        if len(self._records) > MAX_PUZZLES:
+            _, oldest = self._records.popitem(last=False)
+            _evict(oldest)
+
+    def get(self, puzzle_id: str) -> Optional[PuzzleRecord]:
+        """Look up a puzzle by id.
+
+        Args:
+            puzzle_id: The puzzle's id.
+
+        Returns:
+            The puzzle's record, or None if it doesn't exist (never
+            uploaded, or evicted).
+        """
+        return self._records.get(puzzle_id)
+
+    def list_for_owner(self, owner_id: str) -> List[PuzzleRecord]:
+        """List all puzzles owned by a given user, in upload order.
+
+        Args:
+            owner_id: The owning user's id.
+
+        Returns:
+            The owner's puzzle records, oldest first.
+        """
+        return [record for record in self._records.values() if record.owner_id == owner_id]
+
+
+@lru_cache()
+def get_puzzle_store() -> PuzzleStore:
+    """Get or create the singleton PuzzleStore instance.
+
+    Returns:
+        The shared PuzzleStore instance.
+    """
+    return PuzzleStore()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,25 @@
+"""Shared pytest fixtures for the backend test suite."""
+
+from typing import Generator
+
+import pytest
+
+from app.main import auth_rate_limiter, piece_preview_rate_limiter
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiters() -> Generator[None, None, None]:
+    """Reset the process-global rate limiters before every test.
+
+    `auth_rate_limiter` and `piece_preview_rate_limiter` (app/main.py) hold
+    process-wide state, same as `get_puzzle_store()` and other singletons
+    used across this suite. Without this, one test file's calls to
+    `/api/v1/auth/google` or `/api/v1/piece/preview` would leak counters into
+    the next test (and TestClient requests share a single "IP"/user
+    identity), causing order-dependent 429s.
+    """
+    auth_rate_limiter.reset()
+    piece_preview_rate_limiter.reset()
+    yield
+    auth_rate_limiter.reset()
+    piece_preview_rate_limiter.reset()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -109,6 +109,90 @@ class TestAuthEndpoints:
         assert response.status_code == 401
         assert response.json()["detail"] == "Invalid Google token"
 
+    def test_google_auth_empty_allowlist_allows_any_account(self) -> None:
+        """Test that an empty ALLOWED_EMAILS (the default) preserves today's behavior."""
+        mock_user_info = {
+            "sub": "google-user-123",
+            "email": "anyone@example.com",
+            "name": "Anyone",
+            "picture": None,
+        }
+
+        with (
+            patch("app.auth.service.AuthService.verify_google_token", return_value=mock_user_info),
+            patch.object(settings, "ALLOWED_EMAILS", []),
+        ):
+            response = client.post(
+                "/api/v1/auth/google",
+                json={"id_token": "fake-google-token"},
+            )
+
+        assert response.status_code == 200
+        assert "access_token" in response.json()
+
+    def test_google_auth_allowlist_permits_listed_email(self) -> None:
+        """Test that a non-empty allowlist admits an email that's on it."""
+        mock_user_info = {
+            "sub": "google-user-123",
+            "email": "user@example.com",
+            "name": "Allowed User",
+            "picture": None,
+        }
+
+        with (
+            patch("app.auth.service.AuthService.verify_google_token", return_value=mock_user_info),
+            patch.object(settings, "ALLOWED_EMAILS", ["user@example.com"]),
+        ):
+            response = client.post(
+                "/api/v1/auth/google",
+                json={"id_token": "fake-google-token"},
+            )
+
+        assert response.status_code == 200
+        assert "access_token" in response.json()
+
+    def test_google_auth_allowlist_rejects_unlisted_email(self) -> None:
+        """Test that a non-empty allowlist rejects an email that's not on it."""
+        mock_user_info = {
+            "sub": "google-user-123",
+            "email": "intruder@example.com",
+            "name": "Intruder",
+            "picture": None,
+        }
+
+        with (
+            patch("app.auth.service.AuthService.verify_google_token", return_value=mock_user_info),
+            patch.object(settings, "ALLOWED_EMAILS", ["user@example.com"]),
+        ):
+            response = client.post(
+                "/api/v1/auth/google",
+                json={"id_token": "fake-google-token"},
+            )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "This account is not authorized to use this application"
+
+    def test_google_auth_allowlist_case_insensitive_and_whitespace_tolerant(self) -> None:
+        """Test that allowlist matching ignores case and surrounding whitespace in configured entries."""
+        mock_user_info = {
+            "sub": "google-user-123",
+            "email": "user@example.com",
+            "name": "Allowed User",
+            "picture": None,
+        }
+
+        with (
+            patch("app.auth.service.AuthService.verify_google_token", return_value=mock_user_info),
+            patch.object(settings, "ALLOWED_EMAILS", [" User@Example.com ", "other@example.com"]),
+        ):
+            response = client.post(
+                "/api/v1/auth/google",
+                json={"id_token": "fake-google-token"},
+            )
+
+        assert response.status_code == 200
+        assert "access_token" in response.json()
+
     def test_get_current_user_profile_success(self) -> None:
         """Test getting current user profile with valid token."""
         token = create_test_token()
@@ -300,3 +384,16 @@ class TestAuthService:
         ):
             result = auth_service.verify_google_token("fake-token")
             assert result is None
+
+
+class TestUserModel:
+    """Tests for the User model."""
+
+    def test_created_at_is_timezone_aware(self) -> None:
+        """Test that User.created_at defaults to a timezone-aware datetime (not a naive utcnow())."""
+        from app.models.user_model import User
+
+        user = User(id="test-id", email="test@example.com", name="Test User", picture=None)
+
+        assert user.created_at.tzinfo is not None
+        assert user.created_at.tzinfo.utcoffset(user.created_at) == timedelta(0)

--- a/backend/tests/test_piece_geometry_store.py
+++ b/backend/tests/test_piece_geometry_store.py
@@ -197,3 +197,23 @@ class TestPieceGeometryStore:
         store = PieceGeometryStore()
 
         assert store.list_pieces("never-seen") == []
+
+    def test_drop_removes_the_puzzles_store(self) -> None:
+        """Dropping a puzzle clears its enrolled pieces; a later add starts a fresh id sequence."""
+        store = PieceGeometryStore()
+        fp_a = _fingerprint(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+        store.add_or_match("puzzle-1", fp_a, True, False)
+        assert len(store.list_pieces("puzzle-1")) == 1
+
+        store.drop("puzzle-1")
+
+        assert store.list_pieces("puzzle-1") == []
+        # A fresh enrollment after drop starts over at p001, proving the old store is gone.
+        result = store.add_or_match("puzzle-1", fp_a, True, False)
+        assert result.piece_id == "p001"
+
+    def test_drop_unknown_puzzle_is_a_noop(self) -> None:
+        """Dropping a puzzle with no store yet doesn't raise."""
+        store = PieceGeometryStore()
+
+        store.drop("never-seen")

--- a/backend/tests/test_puzzle_ownership.py
+++ b/backend/tests/test_puzzle_ownership.py
@@ -1,0 +1,328 @@
+"""Tests for puzzle ownership (IDOR fix): every {puzzle_id} endpoint is owner-scoped.
+
+Mirrors the token/auth patterns in tests/test_auth.py and tests/test_main.py,
+and the mocked piece-geometry pipeline in tests/test_piece_geometry_api.py.
+"""
+
+import os
+import shutil
+from datetime import datetime, timedelta, timezone
+from io import BytesIO
+from pathlib import Path
+from typing import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+from piece_geometry_fixtures import PIECE_A_COLORS, PIECE_A_EDGE_TYPES, encode_png, make_piece_rgba
+from PIL import Image, ImageDraw
+
+from app.config import settings
+from app.main import app
+from app.models.puzzle_model import PieceResponse, Position
+from app.services.piece_geometry.service import PieceGeometryService
+from app.services.puzzle_store import MAX_PUZZLES, PuzzleRecord, PuzzleStore, get_puzzle_store
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _ensure_upload_dir() -> Generator[None, None, None]:
+    """Recreate UPLOAD_DIR before each test and reset the puzzle store singleton after.
+
+    Resetting avoids this file's uploads (owners "user-a"/"user-b") lingering
+    in the shared, process-wide `get_puzzle_store()` singleton across tests.
+    """
+    os.makedirs(settings.UPLOAD_DIR, exist_ok=True)
+    yield
+    shutil.rmtree(settings.UPLOAD_DIR, ignore_errors=True)
+    get_puzzle_store.cache_clear()
+
+
+def create_test_token(user_id: str) -> str:
+    """Create a valid test JWT token for the given user (mirrors tests/test_auth.py)."""
+    expire = datetime.now(timezone.utc) + timedelta(hours=1)
+    payload = {
+        "sub": user_id,
+        "email": f"{user_id}@example.com",
+        "name": user_id,
+        "picture": None,
+        "exp": expire,
+    }
+    return jwt.encode(payload, settings.JWT_SECRET, algorithm=settings.JWT_ALGORITHM)
+
+
+def auth_header(user_id: str) -> dict[str, str]:
+    """Create an authorization header for the given user."""
+    return {"Authorization": f"Bearer {create_test_token(user_id)}"}
+
+
+USER_A = "user-a"
+USER_B = "user-b"
+
+
+def make_photo_jpeg() -> bytes:
+    """Create an in-memory JPEG photo with a bright rectangle on a dark background."""
+    image = Image.new("RGB", (800, 600), (20, 20, 20))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((100, 80, 700, 520), fill=(220, 210, 190))
+    buffer = BytesIO()
+    image.save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+def upload_puzzle_as(user_id: str) -> str:
+    """Upload a puzzle as the given user and return its puzzle_id."""
+    response = client.post(
+        "/api/v1/puzzle/upload",
+        files={"file": ("photo.jpg", BytesIO(make_photo_jpeg()), "image/jpeg")},
+        headers=auth_header(user_id),
+    )
+    assert response.status_code == 200
+    return str(response.json()["puzzle_id"])
+
+
+def mocked_geometry_service() -> PieceGeometryService:
+    """A PieceGeometryService whose mocked background remover echoes the uploaded RGBA PNG."""
+    remover = MagicMock()
+    remover.remove_background.side_effect = lambda image_bytes: Image.open(BytesIO(image_bytes)).convert("RGBA")
+    return PieceGeometryService(background_remover=remover)
+
+
+def geometry_files() -> dict[str, tuple[str, BytesIO, str]]:
+    """Build the multipart files dict for a piece-geometry photo upload."""
+    rgba = make_piece_rgba(PIECE_A_EDGE_TYPES, PIECE_A_COLORS)
+    return {"file": ("piece.png", BytesIO(encode_png(rgba)), "image/png")}
+
+
+def piece_files() -> dict[str, tuple[str, BytesIO, str]]:
+    """Build the multipart files dict for a piece-processing upload."""
+    return {"file": ("piece.jpg", BytesIO(b"fake piece content"), "image/jpeg")}
+
+
+class TestProcessPieceOwnership:
+    """Tests for POST /api/v1/puzzle/{puzzle_id}/piece."""
+
+    def test_owner_can_process_piece(self) -> None:
+        """User A can process a piece against their own puzzle."""
+        puzzle_id = upload_puzzle_as(USER_A)
+
+        mock_response = PieceResponse(
+            position=Position(x=0.5, y=0.5), position_confidence=0.5, rotation=0, rotation_confidence=0.5
+        )
+        mock_matcher = MagicMock()
+        mock_matcher.process_piece = AsyncMock(return_value=mock_response)
+
+        with patch("app.main.get_classical_matcher", return_value=mock_matcher):
+            response = client.post(
+                f"/api/v1/puzzle/{puzzle_id}/piece",
+                files=piece_files(),
+                headers=auth_header(USER_A),
+            )
+
+        assert response.status_code == 200
+
+    def test_non_owner_gets_404(self) -> None:
+        """User B gets 404 (not 403) trying to process a piece against user A's puzzle."""
+        puzzle_id = upload_puzzle_as(USER_A)
+
+        response = client.post(
+            f"/api/v1/puzzle/{puzzle_id}/piece",
+            files=piece_files(),
+            headers=auth_header(USER_B),
+        )
+
+        assert response.status_code == 404
+
+
+class TestPieceGeometryOwnership:
+    """Tests for POST/GET /api/v1/puzzle/{puzzle_id}/piece/geometry."""
+
+    def test_owner_can_upload_geometry(self) -> None:
+        """User A can upload piece geometry against their own puzzle."""
+        puzzle_id = upload_puzzle_as(USER_A)
+
+        with patch("app.main.get_piece_geometry_service", return_value=mocked_geometry_service()):
+            response = client.post(
+                f"/api/v1/puzzle/{puzzle_id}/piece/geometry",
+                files=geometry_files(),
+                headers=auth_header(USER_A),
+            )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "new"
+
+    def test_non_owner_gets_404_on_upload(self) -> None:
+        """User B gets 404 uploading geometry against user A's puzzle."""
+        puzzle_id = upload_puzzle_as(USER_A)
+
+        with patch("app.main.get_piece_geometry_service", return_value=mocked_geometry_service()):
+            response = client.post(
+                f"/api/v1/puzzle/{puzzle_id}/piece/geometry",
+                files=geometry_files(),
+                headers=auth_header(USER_B),
+            )
+
+        assert response.status_code == 404
+
+    def test_owner_can_list_geometry(self) -> None:
+        """User A can list piece geometry for their own puzzle."""
+        puzzle_id = upload_puzzle_as(USER_A)
+
+        response = client.get(f"/api/v1/puzzle/{puzzle_id}/piece/geometry", headers=auth_header(USER_A))
+
+        assert response.status_code == 200
+
+    def test_non_owner_gets_404_on_list(self) -> None:
+        """User B gets 404 listing geometry for user A's puzzle."""
+        puzzle_id = upload_puzzle_as(USER_A)
+
+        response = client.get(f"/api/v1/puzzle/{puzzle_id}/piece/geometry", headers=auth_header(USER_B))
+
+        assert response.status_code == 404
+
+
+class TestGeneratePieceOwnership:
+    """Tests for POST /api/v1/puzzle/{puzzle_id}/generate-piece."""
+
+    def test_owner_can_generate_piece(self) -> None:
+        """User A can generate a piece from their own puzzle."""
+        puzzle_id = upload_puzzle_as(USER_A)
+
+        response = client.post(
+            f"/api/v1/puzzle/{puzzle_id}/generate-piece",
+            json={"center_x": 0.5, "center_y": 0.5},
+            headers=auth_header(USER_A),
+        )
+
+        assert response.status_code == 200
+        assert response.json()["piece_image"].startswith("data:image/png;base64,")
+
+    def test_non_owner_gets_404(self) -> None:
+        """User B gets 404 generating a piece from user A's puzzle."""
+        puzzle_id = upload_puzzle_as(USER_A)
+
+        response = client.post(
+            f"/api/v1/puzzle/{puzzle_id}/generate-piece",
+            json={"center_x": 0.5, "center_y": 0.5},
+            headers=auth_header(USER_B),
+        )
+
+        assert response.status_code == 404
+
+
+class TestCutAllOwnership:
+    """Tests for POST /api/v1/puzzle/{puzzle_id}/cut-all — previously unauthenticated."""
+
+    def test_owner_can_cut_puzzle(self) -> None:
+        """User A can cut their own puzzle into pieces."""
+        puzzle_id = upload_puzzle_as(USER_A)
+
+        response = client.post(
+            f"/api/v1/puzzle/{puzzle_id}/cut-all",
+            json={"rows": 2, "cols": 2},
+            headers=auth_header(USER_A),
+        )
+
+        assert response.status_code == 200
+        result = response.json()
+        assert len(result["pieces"]) == 4
+
+    def test_non_owner_gets_404(self) -> None:
+        """User B gets 404 cutting user A's puzzle."""
+        puzzle_id = upload_puzzle_as(USER_A)
+
+        response = client.post(
+            f"/api/v1/puzzle/{puzzle_id}/cut-all",
+            json={"rows": 2, "cols": 2},
+            headers=auth_header(USER_B),
+        )
+
+        assert response.status_code == 404
+
+    def test_no_token_returns_401(self) -> None:
+        """Regression test: cut-all previously had no auth dependency at all."""
+        puzzle_id = upload_puzzle_as(USER_A)
+
+        response = client.post(
+            f"/api/v1/puzzle/{puzzle_id}/cut-all",
+            json={"rows": 2, "cols": 2},
+        )
+
+        assert response.status_code == 401
+
+
+class TestListPuzzles:
+    """Tests for GET /api/v1/puzzles."""
+
+    def test_returns_only_callers_own_puzzles(self) -> None:
+        """The listing includes the caller's puzzles and excludes other users'."""
+        puzzle_a1 = upload_puzzle_as(USER_A)
+        puzzle_a2 = upload_puzzle_as(USER_A)
+        puzzle_b = upload_puzzle_as(USER_B)
+
+        response = client.get("/api/v1/puzzles", headers=auth_header(USER_A))
+
+        assert response.status_code == 200
+        puzzle_ids = {p["puzzle_id"] for p in response.json()["puzzles"]}
+        assert puzzle_ids == {puzzle_a1, puzzle_a2}
+        assert puzzle_b not in puzzle_ids
+
+    def test_requires_auth(self) -> None:
+        """Listing puzzles requires authentication."""
+        response = client.get("/api/v1/puzzles")
+
+        assert response.status_code in (401, 403)
+
+
+class TestPuzzleStoreEviction:
+    """Tests for PuzzleStore's FIFO eviction cap (MAX_PUZZLES)."""
+
+    def test_fifo_eviction_drops_oldest_and_cleans_up(self, tmp_path: Path) -> None:
+        """Adding past MAX_PUZZLES evicts the oldest record and cleans up its resources."""
+        store = PuzzleStore()
+        mock_classical = MagicMock()
+        mock_image_processor = MagicMock()
+        mock_geometry_store = MagicMock()
+
+        with (
+            patch("app.services.classical_matcher.get_classical_matcher", return_value=mock_classical),
+            patch("app.services.image_processor.get_image_processor", return_value=mock_image_processor),
+            patch("app.services.piece_geometry.store.get_piece_geometry_store", return_value=mock_geometry_store),
+        ):
+            for i in range(MAX_PUZZLES + 1):
+                puzzle_id = f"puzzle-{i}"
+                file_path = tmp_path / f"{puzzle_id}.jpg"
+                file_path.write_bytes(b"fake")
+                store.add(PuzzleRecord(puzzle_id=puzzle_id, owner_id=USER_A, file_path=str(file_path), grid=None))
+
+        # The oldest puzzle was evicted; the rest (including the newest) remain.
+        assert store.get("puzzle-0") is None
+        assert store.get("puzzle-1") is not None
+        assert store.get(f"puzzle-{MAX_PUZZLES}") is not None
+        assert len(store.list_for_owner(USER_A)) == MAX_PUZZLES
+
+        # Cleanup happened for the evicted puzzle: file removed, caches cleared.
+        assert not (tmp_path / "puzzle-0.jpg").exists()
+        mock_classical.clear_puzzle_cache.assert_any_call("puzzle-0")
+        mock_image_processor.clear_puzzle_cache.assert_any_call("puzzle-0")
+        mock_geometry_store.drop.assert_any_call("puzzle-0")
+
+    def test_eviction_tolerates_missing_file(self, tmp_path: Path) -> None:
+        """Eviction doesn't blow up when the puzzle's file is already gone."""
+        store = PuzzleStore()
+        missing_path = tmp_path / "already-gone.jpg"
+
+        with (
+            patch("app.services.classical_matcher.get_classical_matcher", return_value=MagicMock()),
+            patch("app.services.image_processor.get_image_processor", return_value=MagicMock()),
+            patch("app.services.piece_geometry.store.get_piece_geometry_store", return_value=MagicMock()),
+        ):
+            store.add(PuzzleRecord(puzzle_id="evictee", owner_id=USER_A, file_path=str(missing_path), grid=None))
+            for i in range(MAX_PUZZLES):
+                store.add(
+                    PuzzleRecord(puzzle_id=f"filler-{i}", owner_id=USER_A, file_path=str(missing_path), grid=None)
+                )
+
+        assert store.get("evictee") is None

--- a/backend/tests/test_puzzle_ownership.py
+++ b/backend/tests/test_puzzle_ownership.py
@@ -183,6 +183,73 @@ class TestPieceGeometryOwnership:
         assert response.status_code == 404
 
 
+class TestDeletePieceGeometryOwnership:
+    """Tests for DELETE /api/v1/puzzle/{puzzle_id}/piece/geometry/{piece_id}."""
+
+    def _enroll_piece(self, puzzle_id: str, user_id: str) -> str:
+        """Enroll one piece against a puzzle and return its piece id.
+
+        Args:
+            puzzle_id: The puzzle to enroll the piece under.
+            user_id: The user performing the enrollment.
+
+        Returns:
+            The enrolled piece's id.
+        """
+        with patch("app.main.get_piece_geometry_service", return_value=mocked_geometry_service()):
+            response = client.post(
+                f"/api/v1/puzzle/{puzzle_id}/piece/geometry",
+                files=geometry_files(),
+                headers=auth_header(user_id),
+            )
+        assert response.status_code == 200
+        piece_id = response.json()["piece_id"]
+        assert isinstance(piece_id, str)
+        return piece_id
+
+    def test_owner_can_delete_piece(self) -> None:
+        """User A can un-enroll a piece from their own puzzle."""
+        puzzle_id = upload_puzzle_as(USER_A)
+        piece_id = self._enroll_piece(puzzle_id, USER_A)
+
+        response = client.delete(
+            f"/api/v1/puzzle/{puzzle_id}/piece/geometry/{piece_id}",
+            headers=auth_header(USER_A),
+        )
+
+        assert response.status_code == 204
+
+    def test_non_owner_gets_404_on_delete(self) -> None:
+        """User B gets 404 deleting a piece from user A's puzzle.
+
+        Guards the destructive case: before ownership was enforced, any
+        authenticated user could un-enroll another user's scanned pieces.
+        """
+        puzzle_id = upload_puzzle_as(USER_A)
+        piece_id = self._enroll_piece(puzzle_id, USER_A)
+
+        response = client.delete(
+            f"/api/v1/puzzle/{puzzle_id}/piece/geometry/{piece_id}",
+            headers=auth_header(USER_B),
+        )
+
+        assert response.status_code == 404
+
+        # The piece must still be enrolled: a rejected delete has to be a no-op,
+        # not a 404 returned after the store was already mutated.
+        listed = client.get(f"/api/v1/puzzle/{puzzle_id}/piece/geometry", headers=auth_header(USER_A))
+        assert [piece["piece_id"] for piece in listed.json()["pieces"]] == [piece_id]
+
+    def test_delete_requires_auth(self) -> None:
+        """An unauthenticated delete is rejected."""
+        puzzle_id = upload_puzzle_as(USER_A)
+        piece_id = self._enroll_piece(puzzle_id, USER_A)
+
+        response = client.delete(f"/api/v1/puzzle/{puzzle_id}/piece/geometry/{piece_id}")
+
+        assert response.status_code == 401
+
+
 class TestGeneratePieceOwnership:
     """Tests for POST /api/v1/puzzle/{puzzle_id}/generate-piece."""
 

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,493 @@
+"""Tests for the in-memory rate limiter and its FastAPI wiring.
+
+Covers app/rate_limit.py itself plus its use on POST /api/v1/auth/google
+(per-IP) and POST /api/v1/piece/preview (per-user).
+
+Mirrors the token/mocking patterns in tests/test_auth.py and the
+photo-upload helpers in tests/test_main.py. The process-global limiter
+instances (app.main.auth_rate_limiter / piece_preview_rate_limiter) are
+reset before/after every test by the autouse fixture in tests/conftest.py.
+"""
+
+import itertools
+from datetime import datetime, timedelta, timezone
+from io import BytesIO
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from PIL import Image, ImageDraw
+
+from app.config import settings
+from app.main import app, auth_rate_limiter, piece_preview_rate_limiter
+from app.rate_limit import FixedWindowRateLimiter, _client_ip
+
+client = TestClient(app)
+
+_counter = itertools.count()
+
+
+def make_photo_jpeg() -> bytes:
+    """Create a tiny in-memory JPEG so upload endpoints have something to decode."""
+    image = Image.new("RGB", (64, 64), (20, 20, 20))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((10, 10, 50, 50), fill=(220, 210, 190))
+    buffer = BytesIO()
+    image.save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+def photo_files() -> dict[str, tuple[str, BytesIO, str]]:
+    """Build a fresh multipart files dict for a photo upload (BytesIO isn't reusable)."""
+    return {"file": ("photo.jpg", BytesIO(make_photo_jpeg()), "image/jpeg")}
+
+
+def create_test_token(user_id: str = "test-user-id") -> str:
+    """Create a valid test JWT for `user_id`, matching tests/test_auth.py's helper."""
+    expire = datetime.now(timezone.utc) + timedelta(hours=1)
+    payload = {
+        "sub": user_id,
+        "email": f"{user_id}@example.com",
+        "name": "Test User",
+        "picture": None,
+        "exp": expire,
+    }
+    return jwt.encode(payload, settings.JWT_SECRET, algorithm=settings.JWT_ALGORITHM)
+
+
+def auth_header(user_id: str = "test-user-id") -> dict[str, str]:
+    """Build an Authorization header for `user_id`."""
+    return {"Authorization": f"Bearer {create_test_token(user_id)}"}
+
+
+@pytest.fixture
+def mock_piece_detector_not_found() -> Generator[None, None, None]:
+    """Make /api/v1/piece/preview fast and deterministic: nothing detected."""
+    detector = MagicMock()
+    detector.detect_region.return_value = None
+    with patch("app.main.get_piece_detector", return_value=detector):
+        yield
+
+
+@pytest.fixture
+def mock_google_auth_success() -> Generator[None, None, None]:
+    """Make /api/v1/auth/google succeed without a real Google network call."""
+    mock_user_info = {
+        "sub": "google-user-123",
+        "email": "user@example.com",
+        "name": "Google User",
+        "picture": None,
+    }
+    with patch("app.auth.service.AuthService.verify_google_token", return_value=mock_user_info):
+        yield
+
+
+def unique_email() -> dict[str, str]:
+    """A fresh JSON body for /api/v1/auth/google (the endpoint doesn't care about the value)."""
+    return {"id_token": f"fake-google-token-{next(_counter)}"}
+
+
+# =============================================================================
+# _client_ip helper unit tests
+# =============================================================================
+
+
+def _fake_request(forwarded_for: str | None, client_host: str | None) -> MagicMock:
+    """Build a minimal Request-like double for _client_ip, without a real ASGI request."""
+    request = MagicMock()
+    request.headers.get.return_value = forwarded_for
+    request.client = MagicMock(host=client_host) if client_host is not None else None
+    return request
+
+
+class TestClientIp:
+    """Unit tests for the caller-IP resolution used by the per-IP limiter."""
+
+    def test_default_ignores_x_forwarded_for_entirely(self) -> None:
+        """TRUST_PROXY_HEADERS=False (default): X-Forwarded-For is ignored, even if present."""
+        with patch.object(settings, "TRUST_PROXY_HEADERS", False):
+            request = _fake_request(forwarded_for="1.2.3.4, 10.0.0.1", client_host="10.0.0.1")
+            assert _client_ip(request) == "10.0.0.1"
+
+    def test_default_spoofed_x_forwarded_for_cannot_create_new_bucket(self) -> None:
+        """The attack this fix closes: a varying X-Forwarded-For must not change the key.
+
+        With TRUST_PROXY_HEADERS off (the default), the resolved key must stay the
+        same across requests that only differ by X-Forwarded-For, since nothing in
+        this deployment strips/rewrites an inbound X-Forwarded-For header.
+        """
+        with patch.object(settings, "TRUST_PROXY_HEADERS", False):
+            first = _fake_request(forwarded_for="1.1.1.1", client_host="10.0.0.1")
+            second = _fake_request(forwarded_for="9.9.9.9", client_host="10.0.0.1")
+            assert _client_ip(first) == _client_ip(second) == "10.0.0.1"
+
+    def test_falls_back_to_request_client_host_when_no_forwarded_header(self) -> None:
+        """Without X-Forwarded-For, falls back to request.client.host."""
+        with patch.object(settings, "TRUST_PROXY_HEADERS", False):
+            request = _fake_request(forwarded_for=None, client_host="192.168.1.1")
+            assert _client_ip(request) == "192.168.1.1"
+
+    def test_falls_back_to_constant_when_client_is_none(self) -> None:
+        """request.client can be None (Starlette allows it); falls back to a constant key."""
+        request = _fake_request(forwarded_for=None, client_host=None)
+        assert _client_ip(request) == "unknown-client"
+
+    def test_trust_proxy_headers_uses_rightmost_entry(self) -> None:
+        """TRUST_PROXY_HEADERS=True: the rightmost entry (nearest trusted proxy hop) wins.
+
+        The leftmost entry is attacker-controlled free text; only the rightmost
+        entry is guaranteed proxy-authored.
+        """
+        with patch.object(settings, "TRUST_PROXY_HEADERS", True):
+            request = _fake_request(forwarded_for="1.2.3.4, 5.6.7.8", client_host="5.6.7.8")
+            assert _client_ip(request) == "5.6.7.8"
+
+    def test_trust_proxy_headers_spoofed_leftmost_cannot_create_new_bucket(self) -> None:
+        """A varying, attacker-controlled leftmost entry must not change the resolved key.
+
+        With TRUST_PROXY_HEADERS=True, only the rightmost entry is used, so the
+        leftmost entry (which the client fully controls) can be anything.
+        """
+        with patch.object(settings, "TRUST_PROXY_HEADERS", True):
+            first = _fake_request(forwarded_for="1.1.1.1, 5.6.7.8", client_host="5.6.7.8")
+            second = _fake_request(forwarded_for="9.9.9.9, 5.6.7.8", client_host="5.6.7.8")
+            assert _client_ip(first) == _client_ip(second) == "5.6.7.8"
+
+    def test_trust_proxy_headers_strips_whitespace_and_skips_empty_entries(self) -> None:
+        """Rightmost entry resolution tolerates stray whitespace and a trailing empty entry."""
+        with patch.object(settings, "TRUST_PROXY_HEADERS", True):
+            request = _fake_request(forwarded_for=" 1.2.3.4 ,  5.6.7.8  , ", client_host="5.6.7.8")
+            assert _client_ip(request) == "5.6.7.8"
+
+    def test_trust_proxy_headers_falls_back_when_header_absent(self) -> None:
+        """TRUST_PROXY_HEADERS=True but no X-Forwarded-For header: falls back to request.client.host."""
+        with patch.object(settings, "TRUST_PROXY_HEADERS", True):
+            request = _fake_request(forwarded_for=None, client_host="192.168.1.1")
+            assert _client_ip(request) == "192.168.1.1"
+
+
+# =============================================================================
+# FixedWindowRateLimiter unit tests
+# =============================================================================
+
+
+class TestFixedWindowRateLimiter:
+    """Direct tests against the limiter, independent of FastAPI wiring."""
+
+    def test_requests_under_limit_do_not_raise(self) -> None:
+        """Every request within the limit passes silently."""
+        limiter = FixedWindowRateLimiter()
+        for _ in range(5):
+            limiter.check("key-a", limit_per_minute=5)  # should not raise
+
+    def test_request_over_limit_raises_429_with_retry_after(self) -> None:
+        """The (limit+1)th request in a window raises 429 with a Retry-After header."""
+        limiter = FixedWindowRateLimiter(window_seconds=60.0)
+        for _ in range(3):
+            limiter.check("key-a", limit_per_minute=3)
+
+        with pytest.raises(HTTPException) as exc_info:
+            limiter.check("key-a", limit_per_minute=3)
+
+        error = exc_info.value
+        assert error.status_code == 429
+        headers = error.headers or {}
+        assert "Retry-After" in headers
+        assert int(headers["Retry-After"]) >= 1
+
+    def test_window_resets_after_expiry_via_injected_clock(self) -> None:
+        """Once the injected clock advances past window_seconds, the counter resets.
+
+        Uses an injectable fake clock instead of time.sleep() so the test is
+        instant and deterministic.
+        """
+        current_time = [1000.0]
+        limiter = FixedWindowRateLimiter(window_seconds=60.0, clock=lambda: current_time[0])
+
+        for _ in range(3):
+            limiter.check("key-a", limit_per_minute=3)
+        with pytest.raises(HTTPException):
+            limiter.check("key-a", limit_per_minute=3)
+
+        # Advance the fake clock past the window.
+        current_time[0] += 60.0
+        limiter.check("key-a", limit_per_minute=3)  # should not raise: fresh window
+
+    def test_set_clock_swaps_time_source(self) -> None:
+        """set_clock lets a test inject a different time source after construction."""
+        limiter = FixedWindowRateLimiter(window_seconds=60.0)
+        current_time = [500.0]
+        limiter.set_clock(lambda: current_time[0])
+
+        for _ in range(2):
+            limiter.check("key-a", limit_per_minute=2)
+        with pytest.raises(HTTPException):
+            limiter.check("key-a", limit_per_minute=2)
+
+        current_time[0] += 61.0
+        limiter.check("key-a", limit_per_minute=2)  # fresh window, should not raise
+
+    def test_limit_zero_disables_limiting(self) -> None:
+        """A limit_per_minute of 0 means unlimited, even for many requests."""
+        limiter = FixedWindowRateLimiter()
+        for _ in range(1000):
+            limiter.check("key-a", limit_per_minute=0)  # should never raise
+        assert limiter.tracked_key_count == 0  # disabled: nothing is even tracked
+
+    def test_different_keys_have_independent_buckets(self) -> None:
+        """Exhausting one key's limit does not affect a different key."""
+        limiter = FixedWindowRateLimiter()
+        for _ in range(3):
+            limiter.check("key-a", limit_per_minute=3)
+        with pytest.raises(HTTPException):
+            limiter.check("key-a", limit_per_minute=3)
+
+        limiter.check("key-b", limit_per_minute=3)  # unaffected, should not raise
+
+    def test_memory_bound_evicts_oldest_key_once_over_cap(self) -> None:
+        """The tracked-key dict never grows past max_tracked_keys."""
+        limiter = FixedWindowRateLimiter(max_tracked_keys=3)
+
+        for i in range(10):
+            limiter.check(f"key-{i}", limit_per_minute=100)
+            assert limiter.tracked_key_count <= 3
+
+        assert limiter.tracked_key_count == 3
+        # The most recently touched key must still be tracked...
+        limiter.check("key-9", limit_per_minute=100)
+        # ...while a long-evicted key starts a fresh window rather than
+        # inheriting stale state (best-effort check: just shouldn't raise
+        # even after many more hits than the original limit would allow
+        # if state had leaked).
+        for _ in range(5):
+            limiter.check("key-0", limit_per_minute=100)
+
+    def test_reset_clears_all_tracked_state(self) -> None:
+        """reset() drops every key, as used by the test-isolation fixture."""
+        limiter = FixedWindowRateLimiter()
+        limiter.check("key-a", limit_per_minute=10)
+        limiter.check("key-b", limit_per_minute=10)
+        assert limiter.tracked_key_count == 2
+
+        limiter.reset()
+        assert limiter.tracked_key_count == 0
+
+
+# =============================================================================
+# Endpoint wiring: POST /api/v1/auth/google (per-IP)
+# =============================================================================
+
+
+class TestAuthGoogleRateLimit:
+    """Integration tests for the per-IP limiter on /api/v1/auth/google."""
+
+    def test_requests_within_limit_succeed(self, mock_google_auth_success: None) -> None:
+        """Requests up to the configured limit all succeed."""
+        with patch.object(settings, "RATE_LIMIT_AUTH_PER_MINUTE", 3):
+            for _ in range(3):
+                response = client.post(
+                    "/api/v1/auth/google",
+                    json=unique_email(),
+                    headers={"X-Forwarded-For": "10.0.0.1"},
+                )
+                assert response.status_code == 200
+
+    def test_request_over_limit_returns_429_with_retry_after(self, mock_google_auth_success: None) -> None:
+        """The request past the limit is rejected with 429 and Retry-After."""
+        with patch.object(settings, "RATE_LIMIT_AUTH_PER_MINUTE", 2):
+            for _ in range(2):
+                response = client.post(
+                    "/api/v1/auth/google",
+                    json=unique_email(),
+                    headers={"X-Forwarded-For": "10.0.0.2"},
+                )
+                assert response.status_code == 200
+
+            response = client.post(
+                "/api/v1/auth/google",
+                json=unique_email(),
+                headers={"X-Forwarded-For": "10.0.0.2"},
+            )
+
+        assert response.status_code == 429
+        assert "retry-after" in response.headers
+        assert int(response.headers["retry-after"]) >= 1
+
+    def test_default_spoofed_x_forwarded_for_does_not_evade_rate_limit(self, mock_google_auth_success: None) -> None:
+        """Regression test for the XFF rate-limit bypass: default config keys on real IP only.
+
+        TestClient requests all share the same underlying `request.client.host`
+        (TestClient's fixed test IP), so with TRUST_PROXY_HEADERS off (the default)
+        a varying, attacker-supplied X-Forwarded-For must NOT grant a fresh bucket
+        per request -- that was the vulnerability: an attacker sending a new random
+        X-Forwarded-For on every request evaded the limiter entirely. This test
+        fails against the old leftmost-X-Forwarded-For-trusting implementation.
+        """
+        with (
+            patch.object(settings, "TRUST_PROXY_HEADERS", False),
+            patch.object(settings, "RATE_LIMIT_AUTH_PER_MINUTE", 1),
+        ):
+            first = client.post(
+                "/api/v1/auth/google",
+                json=unique_email(),
+                headers={"X-Forwarded-For": "10.0.0.10"},
+            )
+            assert first.status_code == 200
+
+            # A different, spoofed X-Forwarded-For must NOT grant a new bucket: same
+            # underlying test client IP, so this must now be rate-limited.
+            second = client.post(
+                "/api/v1/auth/google",
+                json=unique_email(),
+                headers={"X-Forwarded-For": "10.0.0.11"},
+            )
+            assert second.status_code == 429
+
+    def test_trust_proxy_headers_true_uses_rightmost_x_forwarded_for_entry(
+        self, mock_google_auth_success: None
+    ) -> None:
+        """With TRUST_PROXY_HEADERS=True, only the rightmost X-Forwarded-For entry is trusted.
+
+        A spoofed leftmost entry must not create a new bucket; only varying the
+        rightmost entry (the one a trusted proxy would append) does.
+        """
+        with (
+            patch.object(settings, "TRUST_PROXY_HEADERS", True),
+            patch.object(settings, "RATE_LIMIT_AUTH_PER_MINUTE", 1),
+        ):
+            first = client.post(
+                "/api/v1/auth/google",
+                json=unique_email(),
+                headers={"X-Forwarded-For": "1.2.3.4, 10.0.0.20"},
+            )
+            assert first.status_code == 200
+
+            # Spoofed leftmost entry, same rightmost entry: still rate-limited.
+            second = client.post(
+                "/api/v1/auth/google",
+                json=unique_email(),
+                headers={"X-Forwarded-For": "9.9.9.9, 10.0.0.20"},
+            )
+            assert second.status_code == 429
+
+            # Different rightmost entry: independent bucket, should still succeed.
+            third = client.post(
+                "/api/v1/auth/google",
+                json=unique_email(),
+                headers={"X-Forwarded-For": "1.2.3.4, 10.0.0.21"},
+            )
+            assert third.status_code == 200
+
+    def test_limit_of_zero_disables_rate_limiting(self, mock_google_auth_success: None) -> None:
+        """Setting RATE_LIMIT_AUTH_PER_MINUTE to 0 disables the limit."""
+        with patch.object(settings, "RATE_LIMIT_AUTH_PER_MINUTE", 0):
+            for _ in range(25):
+                response = client.post(
+                    "/api/v1/auth/google",
+                    json=unique_email(),
+                    headers={"X-Forwarded-For": "10.0.0.99"},
+                )
+                assert response.status_code == 200
+
+
+# =============================================================================
+# Endpoint wiring: POST /api/v1/piece/preview (per-user)
+# =============================================================================
+
+
+class TestPiecePreviewRateLimit:
+    """Integration tests for the per-user limiter on /api/v1/piece/preview."""
+
+    def test_requests_within_limit_succeed(self, mock_piece_detector_not_found: None) -> None:
+        """Requests up to the configured limit all succeed for one user."""
+        with patch.object(settings, "RATE_LIMIT_PREVIEW_PER_MINUTE", 3):
+            for _ in range(3):
+                response = client.post(
+                    "/api/v1/piece/preview",
+                    files=photo_files(),
+                    headers=auth_header("user-a"),
+                )
+                assert response.status_code == 200
+
+    def test_request_over_limit_returns_429_with_retry_after(self, mock_piece_detector_not_found: None) -> None:
+        """The request past the limit is rejected with 429 and Retry-After."""
+        with patch.object(settings, "RATE_LIMIT_PREVIEW_PER_MINUTE", 2):
+            for _ in range(2):
+                response = client.post(
+                    "/api/v1/piece/preview",
+                    files=photo_files(),
+                    headers=auth_header("user-b"),
+                )
+                assert response.status_code == 200
+
+            response = client.post(
+                "/api/v1/piece/preview",
+                files=photo_files(),
+                headers=auth_header("user-b"),
+            )
+
+        assert response.status_code == 429
+        assert "retry-after" in response.headers
+        assert int(response.headers["retry-after"]) >= 1
+
+    def test_exhausting_one_user_does_not_rate_limit_another(self, mock_piece_detector_not_found: None) -> None:
+        """A shared/global counter here would be a cross-user DoS -- verify keying is per-user."""
+        with patch.object(settings, "RATE_LIMIT_PREVIEW_PER_MINUTE", 1):
+            first = client.post(
+                "/api/v1/piece/preview",
+                files=photo_files(),
+                headers=auth_header("user-exhausted"),
+            )
+            assert first.status_code == 200
+
+            # Same user again: now rate-limited.
+            second = client.post(
+                "/api/v1/piece/preview",
+                files=photo_files(),
+                headers=auth_header("user-exhausted"),
+            )
+            assert second.status_code == 429
+
+            # A different authenticated user must be unaffected.
+            third = client.post(
+                "/api/v1/piece/preview",
+                files=photo_files(),
+                headers=auth_header("user-fresh"),
+            )
+            assert third.status_code == 200
+
+    def test_limit_of_zero_disables_rate_limiting(self, mock_piece_detector_not_found: None) -> None:
+        """Setting RATE_LIMIT_PREVIEW_PER_MINUTE to 0 disables the limit."""
+        with patch.object(settings, "RATE_LIMIT_PREVIEW_PER_MINUTE", 0):
+            for _ in range(25):
+                response = client.post(
+                    "/api/v1/piece/preview",
+                    files=photo_files(),
+                    headers=auth_header("user-unlimited"),
+                )
+                assert response.status_code == 200
+
+    def test_still_requires_authentication(self, mock_piece_detector_not_found: None) -> None:
+        """The rate-limit dependency composes on top of auth; it must not bypass it."""
+        response = client.post("/api/v1/piece/preview", files=photo_files())
+        assert response.status_code in (401, 403)
+
+
+# =============================================================================
+# Sanity: the limiters used by the app are the same instances the test fixture resets
+# =============================================================================
+
+
+def test_app_exposes_module_level_limiter_instances() -> None:
+    """The dependency wiring in app.main uses these exact singletons.
+
+    Guards against a future refactor accidentally constructing a new limiter
+    per-request (which would silently disable rate limiting) or per-app
+    (which the conftest fixture wouldn't be resetting).
+    """
+    assert isinstance(app, FastAPI)
+    assert isinstance(auth_rate_limiter, FixedWindowRateLimiter)
+    assert isinstance(piece_preview_rate_limiter, FixedWindowRateLimiter)


### PR DESCRIPTION
## Why

A security review of the backend API found that it **authenticated every endpoint but authorized none of them**. Each handler resolved the caller and then threw it away:

```python
_ = current_user  # Acknowledge the parameter is intentionally unused for now
```

Puzzles lived in a module-global dict keyed only by `puzzle_id` with no owner recorded, so **any authenticated user who knew a `puzzle_id` could read and modify any other user's puzzle and pieces**. Since any Google account could sign in, that was an IDOR across the whole API — the `uuid4` id was the only thing standing in the way, which made it a capability-URL model by accident rather than by design.

Separately, `POST /puzzle/{id}/cut-all` had **no authentication dependency at all**.

## How

Record an owner at creation and resolve puzzles **exclusively** through a `get_owned_puzzle` dependency, so the check can't be forgotten by the next endpoint someone writes — no handler touches the store directly anymore:

```python
async def get_owned_puzzle(puzzle_id, current_user) -> PuzzleRecord:
    puzzle = get_puzzle_store().get(puzzle_id)
    # 404 rather than 403: a 403 would confirm the id exists.
    if puzzle is None or puzzle.owner_id != current_user.id:
        raise HTTPException(status_code=404, detail="Puzzle not found")
    return puzzle
```

Pieces need no separate mechanism — the piece endpoints and the geometry store are keyed by `puzzle_id`, so they inherit the puzzle's ownership.

## Also in this change

- **`cut-all` is now gated** like the rest. Regression test asserts it 401s without a token.
- **`ALLOWED_EMAILS`** gates who may sign in. Empty (the default) allows any Google account, preserving today's behavior; there is no user table, so this is the only gate on account creation.
- **Rate limiting** on `/auth/google` (per IP) and `/piece/preview` (per user), in-memory and dependency-free.
- **Puzzle store capped** at 100 with FIFO eviction (it previously grew unbounded); eviction clears the file, both matcher caches, and the geometry store entry.
- **New `GET /api/v1/puzzles`**, listing only the caller's own puzzles.
- `BACKEND_CORS_ORIGINS` default tightened from `["*"]` to localhost; deprecated naive `datetime.utcnow()` replaced.

## Two decisions worth reviewer attention

**Preview rate limit is 300/min, not something tighter.** The iOS client polls at ~4Hz (`PiecePreviewThrottle.swift`) and web at 400ms (`live-piece-capture.tsx`); a lower limit would break the live preview UX.

**`X-Forwarded-For` is only trusted when `TRUST_PROXY_HEADERS=true`, and then only its *rightmost* entry.** An adversarial review of this branch caught the first cut trusting the leftmost entry unconditionally — nothing in the stack strips the inbound header, so an attacker could send a random `X-Forwarded-For` per request, land in a fresh bucket every time, and evade the brute-force limiter entirely. The default now ignores the header. The tradeoff, called out in the code: behind a real proxy with the flag off, all callers share one bucket keyed to the proxy IP — deliberate fail-closed (over-limiting) rather than fail-open (no limiting).

## Out of scope (deliberate)

- **Storage stays in-memory.** Ownership dies on restart and is per-worker. A DB is the real answer if these puzzles should outlive a deploy, but that's a separate call.
- **The deployed `JWT_SECRET`/`ENVIRONMENT` hardening is deferred** — there is no production deployment, so it's moot for now. Worth revisiting before one exists, since a forged token defeats an ownership check as easily as a missing one.

## Testing

`262 passed` (up from 228), `make check-backend` clean, pyright 0 errors.

New `test_puzzle_ownership.py` asserts user B gets a **404** on every puzzle-scoped endpoint for user A's puzzle, plus happy paths, the `cut-all` no-token 401 regression, `GET /puzzles` isolation, and store eviction. The XFF regression test was verified to genuinely fail against the old leftmost-entry logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)