### PR TITLE
Detect the puzzle rectangle for frame crops instead of rembg's salient object

### DIFF
--- a/backend/app/services/puzzle_detector.py
+++ b/backend/app/services/puzzle_detector.py
@@ -1,14 +1,11 @@
 """Service for detecting a puzzle picture's boundary in a photo and perspective-correcting it."""
 
-import io
 import math
 from typing import List, Optional, Tuple, cast
 
 import cv2
 import numpy as np
 from PIL import Image
-
-from app.services.background_remover import get_background_remover
 
 Point = Tuple[float, float]
 
@@ -30,6 +27,22 @@ BORDER_FRACTION = 0.05
 # If the border ring's 99th-percentile chroma deviation exceeds this, there is no
 # uniform background around the subject (e.g. an edge-to-edge image) and detection bails out
 MAX_BORDER_CHROMA_SPREAD = 0.06
+
+# Auto-Canny spread: thresholds are set to (1 ± sigma) × the image's median intensity,
+# so the edge detector adapts to each photo's exposure rather than using fixed levels
+EDGE_CANNY_SIGMA = 0.33
+
+# Kernel size for dilating the edge map, closing small gaps in the puzzle's border
+# so its outline forms a single traceable contour
+EDGE_DILATE_KERNEL = 5
+
+# Polygon-approximation tolerances (as a fraction of contour perimeter) tried in order
+# when reducing an edge contour to a quadrilateral
+EDGE_APPROX_EPSILONS = (0.02, 0.04, 0.06)
+
+# Line thickness (working pixels) used when rasterizing a candidate quad's outline to
+# measure how much of it coincides with real detected edges (the edge-support term)
+EDGE_SUPPORT_THICKNESS = 2 * EDGE_DILATE_KERNEL + 1
 
 
 def _order_corners(points: "np.ndarray") -> "np.ndarray":
@@ -75,22 +88,17 @@ class PuzzleFrameDetector:
 
     Detection is layered. The fast path segments the subject from a roughly
     uniform background (sampled from the photo's border) using chroma distance
-    — which ignores shadows — plus a brighter-than-background luminance rule.
-    When the border is not a uniform background (e.g. a webcam shot with a
-    cluttered room behind the puzzle), it falls back to rembg salient-object
-    segmentation. Either way a quadrilateral is fitted to the convex hull of
-    the largest segmented region.
+    — which ignores shadows — plus a brighter-than-background luminance rule,
+    then fits a quadrilateral to the convex hull of the largest region. When
+    the border is not a uniform background (e.g. a handheld photo where the
+    puzzle nearly fills the frame), it falls back to direct edge-based
+    detection of the puzzle's rectangular boundary.
+
+    The puzzle picture is a strong quadrilateral with straight edges, so the
+    fallback looks for that rectangle explicitly rather than asking a
+    salient-object model — a salient-object model segments whatever the
+    artwork depicts (an elephant, a lion) instead of the puzzle's outline.
     """
-
-    def __init__(self, salient_fallback: bool = True) -> None:
-        """Initialize the detector.
-
-        Args:
-            salient_fallback: Whether to fall back to rembg salient-object
-                segmentation when background-based segmentation is not
-                applicable. Disable for fast, dependency-free detection only.
-        """
-        self._salient_fallback = salient_fallback
 
     def detect_corners(self, image: Image.Image) -> Tuple[List[Point], float]:
         """Detect the puzzle picture's quadrilateral in the image.
@@ -119,9 +127,8 @@ class PuzzleFrameDetector:
         mask = self._foreground_mask(work)
         result = self._quad_from_mask(mask, work_w, work_h) if mask is not None else None
 
-        if result is None and self._salient_fallback:
-            mask = self._salient_mask(rgb)
-            result = self._quad_from_mask(mask, work_w, work_h) if mask is not None else None
+        if result is None:
+            result = self._edge_quad(work, work_w, work_h)
 
         if result is None:
             return list(FULL_IMAGE_CORNERS), 0.0
@@ -198,32 +205,100 @@ class PuzzleFrameDetector:
         mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, np.ones((11, 11), dtype=np.uint8))
         return cast("np.ndarray", mask)
 
-    def _salient_mask(self, rgb: "np.ndarray") -> Optional["np.ndarray"]:
-        """Segment the most salient object using rembg (u2net).
+    def _edge_quad(self, work: "np.ndarray", work_w: int, work_h: int) -> Optional[Tuple["np.ndarray", float]]:
+        """Detect the puzzle's rectangular boundary directly from image edges.
 
-        Used when there is no uniform background to segment against, e.g. a
-        webcam shot of a puzzle held up in front of a cluttered room.
+        Used when there is no uniform background to segment against (e.g. a
+        handheld photo where the puzzle nearly fills the frame). The puzzle
+        picture is a large quadrilateral with straight edges, so this traces
+        edge contours and keeps the best-scoring convex four-sided one. Unlike
+        a salient-object model, it answers "where is the rectangle?" rather
+        than "what does the artwork depict?".
 
         Args:
-            rgb: Working-size uint8 RGB image.
+            work: Blurred float RGB working image.
+            work_w: Working image width.
+            work_h: Working image height.
 
         Returns:
-            A uint8 mask (0/255) of the salient object, or None if
-            segmentation fails.
+            A (quad, confidence) tuple where quad has shape (4, 2), or None
+            when no sufficiently large convex quadrilateral is found.
         """
-        try:
-            buffer = io.BytesIO()
-            Image.fromarray(rgb).save(buffer, format="PNG")
-            rgba = get_background_remover().remove_background(buffer.getvalue())
-        except Exception:
-            return None
-        if rgba.mode != "RGBA":
-            return None
-        alpha = np.asarray(rgba.split()[3])
-        mask = (alpha > 128).astype(np.uint8) * 255
-        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, np.ones((25, 25), dtype=np.uint8))
-        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, np.ones((11, 11), dtype=np.uint8))
-        return cast("np.ndarray", mask)
+        gray = cv2.cvtColor(np.clip(work, 0, 255).astype(np.uint8), cv2.COLOR_RGB2GRAY)
+        median = float(np.median(gray))
+        lower = int(max(0, (1.0 - EDGE_CANNY_SIGMA) * median))
+        upper = int(min(255, (1.0 + EDGE_CANNY_SIGMA) * median))
+        edges = cv2.Canny(gray, lower, upper)
+        edges = cv2.dilate(edges, np.ones((EDGE_DILATE_KERNEL, EDGE_DILATE_KERNEL), dtype=np.uint8))
+
+        contours, _ = cv2.findContours(edges, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
+        image_area = work_w * work_h
+        best: Optional[Tuple["np.ndarray", float]] = None
+        for contour in contours:
+            if cv2.contourArea(contour) < MIN_AREA_RATIO * image_area:
+                continue
+            quad = self._quad_from_contour(contour)
+            if quad is None:
+                continue
+            confidence = self._rect_confidence(quad, edges, work_w, work_h)
+            if best is None or confidence > best[1]:
+                best = (quad, confidence)
+        return best
+
+    def _quad_from_contour(self, contour: "np.ndarray") -> Optional["np.ndarray"]:
+        """Reduce an edge contour to a convex quadrilateral, if it is one.
+
+        Tries increasingly coarse polygon approximations; accepts the first
+        that yields exactly four convex points. Requiring a clean four-sided
+        approximation is what rejects the artwork's subject: a puzzle border
+        traces a quadrilateral, an elephant does not.
+
+        Args:
+            contour: A contour from cv2.findContours.
+
+        Returns:
+            Array of shape (4, 2), float32, unordered, or None if the contour
+            does not approximate a convex quadrilateral.
+        """
+        perimeter = cv2.arcLength(contour, closed=True)
+        for epsilon in EDGE_APPROX_EPSILONS:
+            approx = cv2.approxPolyDP(contour, epsilon * perimeter, closed=True)
+            if len(approx) == 4 and cv2.isContourConvex(approx):
+                return approx.reshape(4, 2).astype(np.float32)
+        return None
+
+    def _rect_confidence(self, quad: "np.ndarray", edges: "np.ndarray", work_w: int, work_h: int) -> float:
+        """Score how puzzle-like a candidate quad is, in [0, 1].
+
+        Combines three signals that together mean "this is the puzzle's
+        rectangle" rather than merely "this is a tidy quad": how rectangular
+        the quad is, how much of the photo it covers, and how much of its
+        outline actually lies on detected edges (edge support). Edge support is
+        the key discriminator — a quad that traces a real bordered rectangle
+        sits on strong edges, an arbitrary quad does not.
+
+        Args:
+            quad: The candidate quadrilateral, shape (4, 2).
+            edges: The (dilated) binary edge map the quad was found in.
+            work_w: Working image width.
+            work_h: Working image height.
+
+        Returns:
+            Confidence value clamped to [0, 1].
+        """
+        rect_w, rect_h = cv2.minAreaRect(quad.reshape(-1, 1, 2))[1]
+        rect_area = rect_w * rect_h
+        quad_area = cv2.contourArea(quad.reshape(-1, 1, 2))
+        rectangularity = quad_area / rect_area if rect_area > 0 else 0.0
+        area_ratio = quad_area / (work_w * work_h)
+
+        outline = np.zeros((work_h, work_w), dtype=np.uint8)
+        cv2.polylines(outline, [quad.astype(np.int32)], isClosed=True, color=255, thickness=EDGE_SUPPORT_THICKNESS)
+        outline_pixels = int(np.count_nonzero(outline))
+        edge_support = float(np.count_nonzero(edges & outline)) / outline_pixels if outline_pixels else 0.0
+
+        confidence = rectangularity * edge_support * min(1.0, area_ratio / FULL_CONFIDENCE_AREA_RATIO)
+        return float(np.clip(confidence, 0.0, 1.0))
 
     def _quad_from_mask(self, mask: "np.ndarray", work_w: int, work_h: int) -> Optional[Tuple["np.ndarray", float]]:
         """Fit a quadrilateral to the largest region of a foreground mask.

--- a/backend/tests/test_puzzle_detector.py
+++ b/backend/tests/test_puzzle_detector.py
@@ -2,6 +2,8 @@
 
 from typing import List, Tuple
 
+import cv2
+import numpy as np
 import pytest
 from PIL import Image, ImageDraw
 
@@ -16,8 +18,8 @@ CORNER_TOLERANCE = 0.03
 
 @pytest.fixture
 def detector() -> PuzzleFrameDetector:
-    """Provide a detector instance without the (slow) rembg salient-object fallback."""
-    return PuzzleFrameDetector(salient_fallback=False)
+    """Provide a detector instance."""
+    return PuzzleFrameDetector()
 
 
 def make_rectangle_image() -> Image.Image:
@@ -93,9 +95,6 @@ class TestDetectCorners:
         because the picture's internal edges fragment its outline, and brightness-based
         segmentation included the shadow.
         """
-        import cv2
-        import numpy as np
-
         rng = np.random.default_rng(7)
         width, height = 1600, 1200
         background = np.full((height, width, 3), (92, 64, 48), dtype=np.uint8)
@@ -189,68 +188,79 @@ class TestWarp:
         assert abs(warped.height - image.height) <= 2
 
 
-class TestSalientFallback:
-    """Tests for the rembg salient-object fallback path."""
+class TestEdgeFallback:
+    """Tests for the edge-based rectangle fallback (no uniform background)."""
 
     @staticmethod
-    def make_cluttered_photo() -> Image.Image:
-        """Create a photo whose border is too varied for background segmentation."""
-        import numpy as np
+    def make_edge_to_edge_puzzle(with_subject: bool) -> Tuple[Image.Image, "np.ndarray"]:
+        """Render a tilted, bordered puzzle rectangle that fills the frame.
 
-        rng = np.random.default_rng(3)
-        clutter = rng.integers(0, 255, (600, 800, 3), dtype=np.uint8)
-        image = Image.fromarray(clutter)
-        draw = ImageDraw.Draw(image)
-        draw.rectangle(RECT_BOUNDS, fill=(220, 210, 190))
-        return image
+        The border ring is not a uniform background (the puzzle nearly reaches
+        every edge), so the chroma fast path bails and the edge fallback runs.
+        This reproduces the real handheld-overview failure mode from issue #110.
 
-    def test_salient_fallback_detects_subject(self) -> None:
-        """When the border is cluttered, the rembg mask drives detection."""
-        from unittest.mock import MagicMock, patch
+        Args:
+            with_subject: When true, paint a large blob of a single colour in
+                the middle of the artwork — a stand-in for the salient subject
+                (Dumbo, Simba) that a salient-object model wrongly crops to.
 
-        import numpy as np
+        Returns:
+            The photo and the destination quad (4x2, TL/TR/BR/BL) of the
+            puzzle's outline in pixel coordinates.
+        """
+        rng = np.random.default_rng(11)
+        width, height = 900, 700
+        # Slightly non-uniform, mid-tone surround so the border ring is not "background"
+        photo = np.full((height, width, 3), (110, 118, 130), dtype=np.uint8)
+        photo = np.clip(photo.astype(np.int16) + rng.normal(0, 6, (height, width, 3)), 0, 255).astype(np.uint8)
 
-        # Fake rembg output: alpha covering exactly the drawn rectangle
-        alpha = np.zeros((600, 800), dtype=np.uint8)
-        left, top, right, bottom = RECT_BOUNDS
-        alpha[top:bottom, left:right] = 255
-        rgba = np.dstack([np.zeros((600, 800, 3), dtype=np.uint8), alpha])
-        remover = MagicMock()
-        remover.remove_background.return_value = Image.fromarray(rgba, mode="RGBA")
+        # Busy artwork with a dark border, warped to a tilted quad that nearly fills the frame
+        art = np.full((512, 512, 3), (235, 225, 205), dtype=np.uint8)
+        art[:, :, 0] = np.linspace(60, 230, 512, dtype=np.uint8)[None, :]
+        art[::40] = (60, 90, 160)
+        art[:, ::40] = (170, 70, 60)
+        cv2.rectangle(art, (0, 0), (511, 511), (25, 25, 25), 14)  # the puzzle's own border
+        if with_subject:
+            cv2.circle(art, (256, 256), 150, (240, 40, 40), -1)  # salient "subject"
 
-        detector = PuzzleFrameDetector(salient_fallback=True)
-        with patch("app.services.puzzle_detector.get_background_remover", return_value=remover):
-            corners, confidence = detector.detect_corners(self.make_cluttered_photo())
+        dst_quad = np.array([[70, 90], [840, 55], [860, 640], [55, 660]], dtype=np.float32)
+        src_quad = np.array([[0, 0], [512, 0], [512, 512], [0, 512]], dtype=np.float32)
+        matrix = cv2.getPerspectiveTransform(src_quad, dst_quad)
+        warped = cv2.warpPerspective(art, matrix, (width, height))
+        mask = cv2.warpPerspective(np.full((512, 512), 255, np.uint8), matrix, (width, height))
+        photo = np.where(mask[..., None] > 0, warped, photo)
+        return Image.fromarray(photo), dst_quad
 
-        remover.remove_background.assert_called_once()
+    def test_edge_fallback_traces_puzzle_rectangle(self, detector: PuzzleFrameDetector) -> None:
+        """A bordered puzzle that fills the frame is detected by its rectangle."""
+        photo, dst_quad = self.make_edge_to_edge_puzzle(with_subject=False)
+        width, height = photo.size
+
+        corners, confidence = detector.detect_corners(photo)
+
+        expected = [(float(x) / width, float(y) / height) for x, y in dst_quad.tolist()]
         assert confidence > 0.4
-        assert_corners_close(corners, expected_corners())
+        assert_corners_close(corners, expected, tolerance=0.05)
 
-    def test_salient_fallback_failure_returns_full_frame(self) -> None:
-        """If rembg raises, detection degrades gracefully to the full-frame fallback."""
-        from unittest.mock import MagicMock, patch
+    def test_traces_rectangle_not_the_salient_subject(self, detector: PuzzleFrameDetector) -> None:
+        """The puzzle outline wins over a large salient blob inside the artwork.
 
-        remover = MagicMock()
-        remover.remove_background.side_effect = RuntimeError("model unavailable")
+        Regression for issue #110: a salient-object model cropped overviews to
+        the artwork's subject (an elephant, a lion). The edge detector must
+        trace the puzzle's rectangular border instead, so the returned quad
+        covers the whole puzzle rather than the central blob.
+        """
+        photo, dst_quad = self.make_edge_to_edge_puzzle(with_subject=True)
+        width, height = photo.size
 
-        detector = PuzzleFrameDetector(salient_fallback=True)
-        with patch("app.services.puzzle_detector.get_background_remover", return_value=remover):
-            corners, confidence = detector.detect_corners(self.make_cluttered_photo())
+        corners, confidence = detector.detect_corners(photo)
 
-        assert corners == FULL_IMAGE_CORNERS
-        assert confidence == 0.0
-
-    def test_no_fallback_when_disabled(self) -> None:
-        """With salient_fallback=False a cluttered border goes straight to full frame."""
-        from unittest.mock import patch
-
-        detector = PuzzleFrameDetector(salient_fallback=False)
-        with patch("app.services.puzzle_detector.get_background_remover") as mock_get:
-            corners, confidence = detector.detect_corners(self.make_cluttered_photo())
-
-        mock_get.assert_not_called()
-        assert corners == FULL_IMAGE_CORNERS
-        assert confidence == 0.0
+        expected = [(float(x) / width, float(y) / height) for x, y in dst_quad.tolist()]
+        assert confidence > 0.4
+        assert_corners_close(corners, expected, tolerance=0.05)
+        # The detected region covers the whole puzzle, not the ~0.09-area central blob
+        area = cv2.contourArea(np.array([(x * width, y * height) for x, y in corners], dtype=np.float32))
+        assert area / (width * height) > 0.5
 
 
 def test_get_puzzle_detector_is_singleton() -> None:

--- a/backend/tests/test_puzzle_detector.py
+++ b/backend/tests/test_puzzle_detector.py
@@ -193,11 +193,12 @@ class TestEdgeFallback:
 
     @staticmethod
     def make_edge_to_edge_puzzle(with_subject: bool) -> Tuple[Image.Image, "np.ndarray"]:
-        """Render a tilted, bordered puzzle rectangle that fills the frame.
+        """Render a tilted, bordered puzzle on a non-uniform (gradient) surround.
 
-        The border ring is not a uniform background (the puzzle nearly reaches
-        every edge), so the chroma fast path bails and the edge fallback runs.
-        This reproduces the real handheld-overview failure mode from issue #110.
+        The surround's chroma varies across the frame, so the border ring is
+        not a uniform background: the chroma fast path bails and the edge
+        fallback runs. This reproduces the real handheld-overview failure mode
+        from issue #110, where the chroma path bails on every real photo.
 
         Args:
             with_subject: When true, paint a large blob of a single colour in
@@ -208,11 +209,14 @@ class TestEdgeFallback:
             The photo and the destination quad (4x2, TL/TR/BR/BL) of the
             puzzle's outline in pixel coordinates.
         """
-        rng = np.random.default_rng(11)
         width, height = 900, 700
-        # Slightly non-uniform, mid-tone surround so the border ring is not "background"
-        photo = np.full((height, width, 3), (110, 118, 130), dtype=np.uint8)
-        photo = np.clip(photo.astype(np.int16) + rng.normal(0, 6, (height, width, 3)), 0, 255).astype(np.uint8)
+        # Smooth left-to-right colour gradient: chroma varies across the border
+        # ring (so the chroma path bails) but stays low-frequency (few stray edges).
+        ramp = np.linspace(0.0, 1.0, width, dtype=np.float32)[None, :]
+        photo = np.zeros((height, width, 3), dtype=np.uint8)
+        photo[:, :, 0] = (200 - 150 * ramp).astype(np.uint8)  # red fades out
+        photo[:, :, 1] = 120
+        photo[:, :, 2] = (50 + 150 * ramp).astype(np.uint8)  # blue fades in
 
         # Busy artwork with a dark border, warped to a tilted quad that nearly fills the frame
         art = np.full((512, 512, 3), (235, 225, 205), dtype=np.uint8)
@@ -231,12 +235,30 @@ class TestEdgeFallback:
         photo = np.where(mask[..., None] > 0, warped, photo)
         return Image.fromarray(photo), dst_quad
 
+    def test_chroma_path_bails_on_gradient_surround(self, detector: PuzzleFrameDetector) -> None:
+        """The fixture's non-uniform surround makes the chroma fast path bail.
+
+        This is the precondition for the tests below: they only exercise the
+        edge fallback if the chroma path declines first. Guards against a future
+        threshold tweak silently routing these through the chroma path.
+        """
+        import cv2 as _cv2
+
+        photo, _ = self.make_edge_to_edge_puzzle(with_subject=False)
+        work = _cv2.GaussianBlur(np.asarray(photo), (7, 7), 0).astype(np.float32)
+
+        assert detector._foreground_mask(work) is None
+
     def test_edge_fallback_traces_puzzle_rectangle(self, detector: PuzzleFrameDetector) -> None:
-        """A bordered puzzle that fills the frame is detected by its rectangle."""
+        """A bordered puzzle on a non-uniform surround is detected by its rectangle."""
+        from unittest.mock import patch
+
         photo, dst_quad = self.make_edge_to_edge_puzzle(with_subject=False)
         width, height = photo.size
 
-        corners, confidence = detector.detect_corners(photo)
+        with patch.object(detector, "_edge_quad", wraps=detector._edge_quad) as spy:
+            corners, confidence = detector.detect_corners(photo)
+        spy.assert_called_once()  # detection went through the edge path, not chroma
 
         expected = [(float(x) / width, float(y) / height) for x, y in dst_quad.tolist()]
         assert confidence > 0.4


### PR DESCRIPTION
## Summary

Fixes #110. The overview frame detector (`POST /api/v1/puzzle/detect-frame`) auto-cropped photos to the **artwork's subject** (Dumbo, Simba) instead of the puzzle's rectangle, and reported high confidence (0.72–0.74) while doing it.

The root cause: `PuzzleFrameDetector` has a fast chroma-border path and a rembg/u2net salient-object fallback. On real handheld photos the chroma path bails every time (border isn't a uniform background), so rembg did all the work — and u2net is a *salient object* model, so it segments whatever the artwork depicts, not the puzzle's outline. `_confidence` measured "is this quad tidy", not "is this quad the puzzle", so a cropped subject scored well and slipped past the `< 0.4` warning.

## What changed

- **Replace the rembg salient-object fallback with direct edge-based rectangle detection** (`_edge_quad`): auto-Canny (thresholds scaled to each photo's median intensity) → dilate to close border gaps → search edge contours for the best-scoring convex quadrilateral. This asks "where is the rectangle?" rather than "what does the artwork depict?", so it traces the puzzle border instead of the central subject.
- **Rework confidence for this path** (`_rect_confidence`) to fold in **edge support** — how much of the candidate outline actually lies on detected edges — alongside rectangularity and area coverage. This reflects *puzzle-ness* rather than mere tidiness. The old silent-high-confidence failures came specifically from the rembg path, which is now gone.
- Remove the `salient_fallback` constructor param, `_salient_mask`, and the `background_remover` import from the frame detector.

**Piece-level background removal is untouched** — `image_processor`, `classical_matcher`, `piece_detector`, and `piece_geometry` still use rembg, which is the right tool there (a lone piece on a background genuinely is a salient-object problem). rembg remains a dependency.

## Tests

- Dropped the three salient-fallback tests.
- Added `TestEdgeFallback`, including a regression for the exact failure mode: a tilted, bordered puzzle that fills the frame **with a large salient blob in the middle** must trace the puzzle rectangle (>0.5 area), not the ~0.09-area blob.
- All 275 backend tests pass; `make check-backend` is clean.

## Calibration caveat

The `network/datasets/north_star/*` overviews are gitignored, so the detector was built to be **robust by construction** rather than tuned against the real Dumbo/Simba/Frozen photos. Before merging, run the detector against the real overview set locally to confirm the crops trace the puzzle rectangle. Tuning knobs if needed: `EDGE_CANNY_SIGMA`, `EDGE_DILATE_KERNEL`, `EDGE_APPROX_EPSILONS`.

## Out of scope

The iOS `ConfirmTrimView` still offers no corner-drag UI, so a low-confidence result there remains unrecoverable until that UI exists — tracked separately from this backend fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkcQZho15RzVHoUxoVQqyi)_