### PR TITLE
Run live piece detection on-device with Vision

### DIFF
--- a/ios/Pussel/Features/Solve/PieceCameraSession.swift
+++ b/ios/Pussel/Features/Solve/PieceCameraSession.swift
@@ -40,10 +40,11 @@ final class PieceCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
   private static let ciContext = CIContext()
 
   /// Long side, in pixels, live-preview frames are downscaled to before
-  /// JPEG-encoding and sending — small enough to keep the ~4Hz stream
-  /// cheap, large enough for the backend's region detector to work with.
-  private static let previewFrameMaxLongSide: CGFloat = 480
-  private static let previewFrameJPEGQuality: CGFloat = 0.6
+  /// on-device analysis. Larger than the old 480px streaming size: no JPEG
+  /// crosses the network anymore, Vision's subject lift downsamples
+  /// internally anyway, and the extra resolution goes straight into contour
+  /// fidelity (the mask is upscaled to this size before tracing).
+  private static let previewFrameMaxLongSide: CGFloat = 720
 
   /// Wires the streamer this session forwards frames to. Call once after
   /// creating the session (before `start()`), from the main actor.
@@ -187,20 +188,19 @@ final class PieceCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
   }
 
   /// Downscales a captured frame to ~`previewFrameMaxLongSide` on its long
-  /// side and JPEG-encodes it for the preview endpoint. Pure/CPU-only, so
-  /// it's shared by both the real camera path (below) and the DEBUG
-  /// preview loop.
-  private static func downscaledJPEG(ciImage: CIImage) -> (data: Data, size: CGSize)? {
+  /// side and renders it to a CGImage for on-device analysis (the render
+  /// also detaches the frame from AVFoundation's recycled pixel-buffer
+  /// pool, so `PieceLiveDetector` can work on it asynchronously).
+  /// Pure/CPU-only, so it's shared by both the real camera path (below) and
+  /// the DEBUG preview loop.
+  private static func downscaledFrame(ciImage: CIImage) -> (cgImage: CGImage, size: CGSize)? {
     let extent = ciImage.extent
     guard extent.width > 0, extent.height > 0 else { return nil }
     let scale = min(1, previewFrameMaxLongSide / max(extent.width, extent.height))
     let scaled =
       scale < 1 ? ciImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale)) : ciImage
     guard let cgImage = ciContext.createCGImage(scaled, from: scaled.extent) else { return nil }
-    let size = CGSize(width: cgImage.width, height: cgImage.height)
-    guard let data = UIImage(cgImage: cgImage).jpegData(compressionQuality: previewFrameJPEGQuality)
-    else { return nil }
-    return (data, size)
+    return (cgImage, CGSize(width: cgImage.width, height: cgImage.height))
   }
 
   #if DEBUG
@@ -265,8 +265,8 @@ final class PieceCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
         }
         let now = Date()
         guard previewStreamer.shouldAcceptFrame(now: now) else { return }
-        guard let frame = Self.downscaledJPEG(ciImage: ciImage) else { return }
-        previewStreamer.submit(jpegData: frame.data, frameSize: frame.size, now: now)
+        guard let frame = Self.downscaledFrame(ciImage: ciImage) else { return }
+        previewStreamer.submit(cgImage: frame.cgImage, frameSize: frame.size, now: now)
       }
     }
   #endif
@@ -274,7 +274,7 @@ final class PieceCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
 
 extension PieceCameraSession: AVCaptureVideoDataOutputSampleBufferDelegate {
   /// Runs on `videoQueue`. Checks the throttle *before* downscaling so a
-  /// frame that would just be dropped never pays for the JPEG encode.
+  /// frame that would just be dropped never pays for the render.
   func captureOutput(
     _ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer,
     from connection: AVCaptureConnection
@@ -284,9 +284,9 @@ extension PieceCameraSession: AVCaptureVideoDataOutputSampleBufferDelegate {
     else { return }
     let now = Date()
     guard previewStreamer.shouldAcceptFrame(now: now) else { return }
-    guard let frame = Self.downscaledJPEG(ciImage: CIImage(cvPixelBuffer: pixelBuffer)) else {
+    guard let frame = Self.downscaledFrame(ciImage: CIImage(cvPixelBuffer: pixelBuffer)) else {
       return
     }
-    previewStreamer.submit(jpegData: frame.data, frameSize: frame.size, now: now)
+    previewStreamer.submit(cgImage: frame.cgImage, frameSize: frame.size, now: now)
   }
 }

--- a/ios/Pussel/Features/Solve/PieceLiveDetector.swift
+++ b/ios/Pussel/Features/Solve/PieceLiveDetector.swift
@@ -110,7 +110,12 @@ final class PieceLiveDetector: Sendable {
       maskBuffer = try observation.generateScaledMaskForImage(
         forInstances: observation.allInstances, from: handler)
     } catch {
-      return nil
+      // Classified like a `perform` failure: a genuine Vision error must not
+      // masquerade as "empty frame" (which would clear the overlay and dodge
+      // the caller's transient-failure demotion).
+      throw
+        Self.isUnavailable(error)
+        ? PieceLiveDetectorUnavailable() : PieceLiveDetectorTransientFailure()
     }
 
     guard let contours = Self.topLevelContours(ofMask: maskBuffer) else { return nil }

--- a/ios/Pussel/Features/Solve/PieceLiveDetector.swift
+++ b/ios/Pussel/Features/Solve/PieceLiveDetector.swift
@@ -23,10 +23,18 @@ struct PieceLiveDetection: Equatable {
 }
 
 /// Vision availability failure — subject lifting needs OS support that the
-/// Simulator (and very old hardware) may not provide. Distinct from "no piece
-/// in this frame" (a `nil` detection), so the caller can fall back to the
-/// server-side preview endpoint exactly once instead of per-frame.
+/// Simulator (and very old hardware) may not provide. Thrown only for error
+/// codes that mean the request can never run here (see
+/// `PieceLiveDetector.isUnavailable`); distinct from "no piece in this
+/// frame" (a `nil` detection), so the caller can latch its fallback to the
+/// server-side preview endpoint immediately instead of retrying per-frame.
 struct PieceLiveDetectorUnavailable: Error {}
+
+/// A Vision failure that doesn't prove the platform can't run subject
+/// lifting — the frame is lost, but the next one may well succeed. The
+/// caller should treat one of these like a dropped frame and only demote to
+/// the server path if they keep happening.
+struct PieceLiveDetectorTransientFailure: Error {}
 
 /// On-device replacement for the `/api/v1/piece/preview` round-trip: Apple's
 /// subject-lift segmentation (`VNGenerateForegroundInstanceMaskRequest`, the
@@ -81,14 +89,18 @@ final class PieceLiveDetector: Sendable {
   /// - Returns: The detection, or nil when nothing piece-like is in frame.
   /// - Throws: `PieceLiveDetectorUnavailable` when Vision's subject lifting
   ///   cannot run at all on this platform (the caller should fall back to
-  ///   the server preview endpoint).
+  ///   the server preview endpoint), or `PieceLiveDetectorTransientFailure`
+  ///   for any other Vision error (the caller should treat the frame as
+  ///   dropped).
   func detect(cgImage: CGImage) throws -> PieceLiveDetection? {
     let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
     let maskRequest = VNGenerateForegroundInstanceMaskRequest()
     do {
       try handler.perform([maskRequest])
     } catch {
-      throw PieceLiveDetectorUnavailable()
+      throw
+        Self.isUnavailable(error)
+        ? PieceLiveDetectorUnavailable() : PieceLiveDetectorTransientFailure()
     }
     guard let observation = maskRequest.results?.first, !observation.allInstances.isEmpty else {
       return nil
@@ -150,6 +162,22 @@ final class PieceLiveDetector: Sendable {
       confidence: max(areaScore * aspectScore, 0.001),
       lockable: lockable
     )
+  }
+
+  /// Whether a `perform` error proves the request can never run on this
+  /// platform (unsupported request/revision), as opposed to a one-off
+  /// failure worth retrying on the next frame.
+  static func isUnavailable(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    guard nsError.domain == VNErrorDomain,
+      let code = VNErrorCode(rawValue: nsError.code)
+    else { return false }
+    switch code {
+    case .unsupportedRequest, .unsupportedRevision, .notImplemented:
+      return true
+    default:
+      return false
+    }
   }
 
   // MARK: - Contour extraction

--- a/ios/Pussel/Features/Solve/PieceLiveDetector.swift
+++ b/ios/Pussel/Features/Solve/PieceLiveDetector.swift
@@ -132,7 +132,11 @@ final class PieceLiveDetector: Sendable {
     let outline = Self.resampled(
       Self.smoothed(contour, window: Self.smoothingWindow), count: Self.polygonPointCount)
 
-    let borderTouching = outline.contains { point in
+    // Border touching is judged on the RAW contour: smoothing pulls points
+    // inward, so a clipped piece could otherwise sneak past the margin and
+    // read as lockable (mirrors the backend, which checks the unsmoothed
+    // contour too).
+    let borderTouching = contour.contains { point in
       point.x <= Self.borderTouchMargin || point.y <= Self.borderTouchMargin
         || point.x >= 1.0 - Self.borderTouchMargin || point.y >= 1.0 - Self.borderTouchMargin
     }

--- a/ios/Pussel/Features/Solve/PieceLiveDetector.swift
+++ b/ios/Pussel/Features/Solve/PieceLiveDetector.swift
@@ -13,7 +13,9 @@ struct PieceLiveDetection: Equatable {
   let polygon: [NormalizedPoint]
   /// Axis-aligned bounding box of `polygon`, normalized to the frame.
   let bbox: CGRect
-  /// Product of the area and aspect band scores, in (0, 1].
+  /// Product of the area and aspect band scores, floored at 0.001 so an
+  /// accepted detection always reports a strictly positive confidence in
+  /// (0, 1] — mirrors the backend's `MIN_REPORTED_CONFIDENCE`.
   let confidence: Double
   /// On-device stand-in for the backend's quality gate: a single clean
   /// component, well inside the frame, in the full-confidence area/aspect
@@ -98,9 +100,7 @@ final class PieceLiveDetector: Sendable {
     do {
       try handler.perform([maskRequest])
     } catch {
-      throw
-        Self.isUnavailable(error)
-        ? PieceLiveDetectorUnavailable() : PieceLiveDetectorTransientFailure()
+      throw Self.classified(error)
     }
     guard let observation = maskRequest.results?.first, !observation.allInstances.isEmpty else {
       return nil
@@ -113,12 +113,10 @@ final class PieceLiveDetector: Sendable {
       // Classified like a `perform` failure: a genuine Vision error must not
       // masquerade as "empty frame" (which would clear the overlay and dodge
       // the caller's transient-failure demotion).
-      throw
-        Self.isUnavailable(error)
-        ? PieceLiveDetectorUnavailable() : PieceLiveDetectorTransientFailure()
+      throw Self.classified(error)
     }
 
-    guard let contours = Self.topLevelContours(ofMask: maskBuffer) else { return nil }
+    guard let contours = try Self.topLevelContours(ofMask: maskBuffer) else { return nil }
     let areas = contours.map { abs(Self.signedArea(of: $0.normalizedPoints)) }
     guard let largestIndex = areas.indices.max(by: { areas[$0] < areas[$1] }),
       areas[largestIndex] > 0
@@ -188,22 +186,34 @@ final class PieceLiveDetector: Sendable {
   // MARK: - Contour extraction
 
   /// Runs `VNDetectContoursRequest` over a subject-lift mask and returns the
-  /// top-level contours. The mask is a float pixel buffer (background 0,
-  /// subject 1) at the analyzed frame's resolution, so the contour tracer is
-  /// configured for a bright subject on a dark background with no contrast
-  /// boost.
-  private static func topLevelContours(ofMask maskBuffer: CVPixelBuffer) -> [VNContour]? {
+  /// top-level contours (nil when the mask genuinely traces to none). The
+  /// mask is a float pixel buffer (background 0, subject 1) at the analyzed
+  /// frame's resolution, so the contour tracer is configured for a bright
+  /// subject on a dark background with no contrast boost. Vision errors are
+  /// classified and rethrown like every other stage — they must not read as
+  /// "no detection".
+  private static func topLevelContours(ofMask maskBuffer: CVPixelBuffer) throws -> [VNContour]? {
     let request = VNDetectContoursRequest()
     request.contrastAdjustment = 1.0
     request.detectsDarkOnLight = false
     request.maximumImageDimension = 1024
     let handler = VNImageRequestHandler(
       ciImage: CIImage(cvPixelBuffer: maskBuffer), options: [:])
-    guard (try? handler.perform([request])) != nil,
-      let observation = request.results?.first
-    else { return nil }
+    do {
+      try handler.perform([request])
+    } catch {
+      throw classified(error)
+    }
+    guard let observation = request.results?.first else { return nil }
     let contours = observation.topLevelContours
     return contours.isEmpty ? nil : contours
+  }
+
+  /// Maps a raw Vision error onto the detector's two-error taxonomy:
+  /// provably-unavailable codes latch the caller's fallback, everything
+  /// else is a transient dropped frame.
+  private static func classified(_ error: Error) -> Error {
+    isUnavailable(error) ? PieceLiveDetectorUnavailable() : PieceLiveDetectorTransientFailure()
   }
 
   // MARK: - Geometry helpers

--- a/ios/Pussel/Features/Solve/PieceLiveDetector.swift
+++ b/ios/Pussel/Features/Solve/PieceLiveDetector.swift
@@ -1,0 +1,269 @@
+import CoreGraphics
+import CoreImage
+import Foundation
+import Vision
+import simd
+
+/// A piece candidate detected on-device in a live camera frame. The on-device
+/// analogue of the backend's `PiecePreviewResponse` (see `piece_detector.py`):
+/// same normalized coordinate contract (top-left origin, [0,1] of the frame),
+/// same area/aspect confidence semantics.
+struct PieceLiveDetection: Equatable {
+  /// Dense outline of the detected region, normalized to the analyzed frame.
+  let polygon: [NormalizedPoint]
+  /// Axis-aligned bounding box of `polygon`, normalized to the frame.
+  let bbox: CGRect
+  /// Product of the area and aspect band scores, in (0, 1].
+  let confidence: Double
+  /// On-device stand-in for the backend's quality gate: a single clean
+  /// component, well inside the frame, in the full-confidence area/aspect
+  /// bands. The final scan capture is still verified server-side, so this
+  /// only gates when the auto-capture is allowed to fire.
+  let lockable: Bool
+}
+
+/// Vision availability failure — subject lifting needs OS support that the
+/// Simulator (and very old hardware) may not provide. Distinct from "no piece
+/// in this frame" (a `nil` detection), so the caller can fall back to the
+/// server-side preview endpoint exactly once instead of per-frame.
+struct PieceLiveDetectorUnavailable: Error {}
+
+/// On-device replacement for the `/api/v1/piece/preview` round-trip: Apple's
+/// subject-lift segmentation (`VNGenerateForegroundInstanceMaskRequest`, the
+/// on-device counterpart of the backend's rembg) followed by contour
+/// extraction on the resulting mask (`VNDetectContoursRequest`) and the same
+/// area/aspect plausibility gates as `piece_detector.detect_region`.
+///
+/// Unlike the server path (320px working image, polygon simplified and capped
+/// at 60 points) this analyzes the frame at streaming resolution and returns a
+/// smoothed, arc-length-resampled 120-point outline, so the overlay follows
+/// tab curvature instead of cutting corners.
+///
+/// Stateless and thread-safe: each `detect` call builds its own Vision
+/// requests. Called from `PiecePreviewStreamer`'s background task, never the
+/// main thread.
+final class PieceLiveDetector: Sendable {
+  // MARK: - Gates ported from backend/app/services/piece_detector.py
+
+  /// The detected region must cover at least this fraction of the frame.
+  static let minPieceAreaRatio = 0.005
+  /// ... and at most this fraction (a face/torso covers far more).
+  static let maxPieceAreaRatio = 0.35
+  /// Area band (fraction of frame) that gets full confidence.
+  static let fullConfidenceAreaRange = 0.01...0.15
+  /// Bounding-box aspect ratio (long/short side) limits.
+  static let maxAspectRatio = 3.5
+  static let fullConfidenceMaxAspect = 2.0
+
+  // MARK: - Outline post-processing
+
+  /// Points in the returned outline. The backend preview capped at 60 by
+  /// dropping vertices; here the contour is arc-length-resampled, so every
+  /// point is equally spaced along the outline and 120 comfortably follows
+  /// tab curvature at overlay scale.
+  static let polygonPointCount = 120
+  /// Circular moving-average window (in contour samples) applied before
+  /// resampling, to soften mask-pixel staircase without eroding tabs.
+  static let smoothingWindow = 5
+  /// A contour point within this normalized distance of the frame edge marks
+  /// the detection as border-touching (segmentation likely clipped the
+  /// piece) — mirrors the backend's 2px margin on its ≤320px working image.
+  static let borderTouchMargin = 0.008
+  /// A secondary contour with at least this fraction of the largest
+  /// contour's area counts as a distinct component; more than one such
+  /// component means an unclean segmentation (mirrors
+  /// `piece_geometry.contour.LARGE_COMPONENT_AREA_FRAC`).
+  static let largeComponentAreaFrac = 0.02
+
+  /// Detects the most salient piece-like region in an upright frame.
+  ///
+  /// - Parameter cgImage: The downscaled, upright camera frame.
+  /// - Returns: The detection, or nil when nothing piece-like is in frame.
+  /// - Throws: `PieceLiveDetectorUnavailable` when Vision's subject lifting
+  ///   cannot run at all on this platform (the caller should fall back to
+  ///   the server preview endpoint).
+  func detect(cgImage: CGImage) throws -> PieceLiveDetection? {
+    let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+    let maskRequest = VNGenerateForegroundInstanceMaskRequest()
+    do {
+      try handler.perform([maskRequest])
+    } catch {
+      throw PieceLiveDetectorUnavailable()
+    }
+    guard let observation = maskRequest.results?.first, !observation.allInstances.isEmpty else {
+      return nil
+    }
+    let maskBuffer: CVPixelBuffer
+    do {
+      maskBuffer = try observation.generateScaledMaskForImage(
+        forInstances: observation.allInstances, from: handler)
+    } catch {
+      return nil
+    }
+
+    guard let contours = Self.topLevelContours(ofMask: maskBuffer) else { return nil }
+    let areas = contours.map { abs(Self.signedArea(of: $0.normalizedPoints)) }
+    guard let largestIndex = areas.indices.max(by: { areas[$0] < areas[$1] }),
+      areas[largestIndex] > 0
+    else { return nil }
+
+    // Flip Vision's lower-left-origin normalized points to the top-left
+    // origin the overlay (and the backend contract) use.
+    let contour = contours[largestIndex].normalizedPoints.map {
+      SIMD2<Double>(Double($0.x), 1.0 - Double($0.y))
+    }
+    guard contour.count >= 3 else { return nil }
+
+    // Area/aspect plausibility gates, identical bands to the backend.
+    let areaRatio = areas[largestIndex]
+    let bbox = Self.boundingBox(of: contour)
+    let pixelWidth = bbox.width * Double(cgImage.width)
+    let pixelHeight = bbox.height * Double(cgImage.height)
+    let aspect = max(pixelWidth, pixelHeight) / max(1, min(pixelWidth, pixelHeight))
+    let areaScore = Self.bandScore(
+      areaRatio, hardLow: Self.minPieceAreaRatio,
+      fullLow: Self.fullConfidenceAreaRange.lowerBound,
+      fullHigh: Self.fullConfidenceAreaRange.upperBound, hardHigh: Self.maxPieceAreaRatio)
+    let aspectScore = Self.bandScore(
+      aspect, hardLow: 0.0, fullLow: 1.0,
+      fullHigh: Self.fullConfidenceMaxAspect, hardHigh: Self.maxAspectRatio)
+    guard areaScore > 0, aspectScore > 0 else { return nil }
+
+    let outline = Self.resampled(
+      Self.smoothed(contour, window: Self.smoothingWindow), count: Self.polygonPointCount)
+
+    let borderTouching = outline.contains { point in
+      point.x <= Self.borderTouchMargin || point.y <= Self.borderTouchMargin
+        || point.x >= 1.0 - Self.borderTouchMargin || point.y >= 1.0 - Self.borderTouchMargin
+    }
+    let largeComponents = areas.filter { $0 >= Self.largeComponentAreaFrac * areaRatio }.count
+    let lockable =
+      !borderTouching && largeComponents == 1 && areaScore >= 1.0 && aspectScore >= 1.0
+
+    return PieceLiveDetection(
+      polygon: outline.map { NormalizedPoint(x: $0.x, y: $0.y) },
+      bbox: CGRect(x: bbox.minX, y: bbox.minY, width: bbox.width, height: bbox.height),
+      confidence: max(areaScore * aspectScore, 0.001),
+      lockable: lockable
+    )
+  }
+
+  // MARK: - Contour extraction
+
+  /// Runs `VNDetectContoursRequest` over a subject-lift mask and returns the
+  /// top-level contours. The mask is a float pixel buffer (background 0,
+  /// subject 1) at the analyzed frame's resolution, so the contour tracer is
+  /// configured for a bright subject on a dark background with no contrast
+  /// boost.
+  private static func topLevelContours(ofMask maskBuffer: CVPixelBuffer) -> [VNContour]? {
+    let request = VNDetectContoursRequest()
+    request.contrastAdjustment = 1.0
+    request.detectsDarkOnLight = false
+    request.maximumImageDimension = 1024
+    let handler = VNImageRequestHandler(
+      ciImage: CIImage(cvPixelBuffer: maskBuffer), options: [:])
+    guard (try? handler.perform([request])) != nil,
+      let observation = request.results?.first
+    else { return nil }
+    let contours = observation.topLevelContours
+    return contours.isEmpty ? nil : contours
+  }
+
+  // MARK: - Geometry helpers
+
+  /// Shoelace signed area of a closed polygon in normalized coordinates —
+  /// its magnitude is the covered fraction of the frame.
+  private static func signedArea(of points: [simd_float2]) -> Double {
+    guard points.count >= 3 else { return 0 }
+    var sum = 0.0
+    for index in points.indices {
+      let current = points[index]
+      let next = points[(index + 1) % points.count]
+      sum += Double(current.x) * Double(next.y) - Double(next.x) * Double(current.y)
+    }
+    return sum / 2
+  }
+
+  private static func boundingBox(of points: [SIMD2<Double>]) -> CGRect {
+    var minX = points[0].x
+    var maxX = points[0].x
+    var minY = points[0].y
+    var maxY = points[0].y
+    for point in points.dropFirst() {
+      minX = Swift.min(minX, point.x)
+      maxX = Swift.max(maxX, point.x)
+      minY = Swift.min(minY, point.y)
+      maxY = Swift.max(maxY, point.y)
+    }
+    return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+  }
+
+  /// Circular moving average over a closed contour — the cheap counterpart
+  /// of the backend's Gaussian contour smoothing, enough to soften the
+  /// mask-pixel staircase at overlay scale.
+  static func smoothed(_ points: [SIMD2<Double>], window: Int) -> [SIMD2<Double>] {
+    let count = points.count
+    guard count > window, window > 1 else { return points }
+    let half = window / 2
+    var result = [SIMD2<Double>]()
+    result.reserveCapacity(count)
+    for index in 0..<count {
+      var sum = SIMD2<Double>(0, 0)
+      for offset in -half...half {
+        sum += points[((index + offset) % count + count) % count]
+      }
+      result.append(sum / Double(2 * half + 1))
+    }
+    return result
+  }
+
+  /// Arc-length-equidistant resampling of a closed contour to `count`
+  /// points — the Swift port of `piece_geometry.contour.resample_contour`,
+  /// so every outline the overlay draws has evenly spaced vertices
+  /// regardless of how densely Vision traced each stretch.
+  static func resampled(_ points: [SIMD2<Double>], count: Int) -> [SIMD2<Double>] {
+    guard points.count >= 2, count >= 3 else { return points }
+    var cumulative = [0.0]
+    cumulative.reserveCapacity(points.count + 1)
+    for index in points.indices {
+      let current = points[index]
+      let next = points[(index + 1) % points.count]
+      cumulative.append(cumulative[index] + simd_distance(current, next))
+    }
+    let total = cumulative[points.count]
+    guard total > 0 else { return points }
+
+    var result = [SIMD2<Double>]()
+    result.reserveCapacity(count)
+    var segment = 0
+    for sample in 0..<count {
+      let target = total * Double(sample) / Double(count)
+      while segment < points.count - 1, cumulative[segment + 1] < target {
+        segment += 1
+      }
+      let segmentLength = cumulative[segment + 1] - cumulative[segment]
+      let fraction = segmentLength > 0 ? (target - cumulative[segment]) / segmentLength : 0
+      let start = points[segment]
+      let end = points[(segment + 1) % points.count]
+      result.append(start + (end - start) * fraction)
+    }
+    return result
+  }
+
+  /// Confidence band scoring, ported verbatim from the backend's
+  /// `_band_score`: 1.0 inside [fullLow, fullHigh], tapering linearly to 0.0
+  /// at the hard limits.
+  static func bandScore(
+    _ value: Double, hardLow: Double, fullLow: Double, fullHigh: Double, hardHigh: Double
+  ) -> Double {
+    if value < fullLow {
+      if value <= hardLow { return 0.0 }
+      return (value - hardLow) / (fullLow - hardLow)
+    }
+    if value > fullHigh {
+      if value >= hardHigh { return 0.0 }
+      return (hardHigh - value) / (hardHigh - fullHigh)
+    }
+    return 1.0
+  }
+}

--- a/ios/Pussel/Features/Solve/PiecePreviewStreamer.swift
+++ b/ios/Pussel/Features/Solve/PiecePreviewStreamer.swift
@@ -61,8 +61,9 @@ final class PiecePreviewStreamer: @unchecked Sendable {
 
   @MainActor private(set) var state: PiecePreviewState = .none
   /// Pixel size of the frame `state`'s polygon was measured against — the
-  /// upright-portrait downscaled JPEG `PieceCameraSession` sent. Its aspect
-  /// ratio drives the overlay's aspect-fill mapping
+  /// upright-portrait downscaled CGImage `PieceCameraSession` handed to the
+  /// detector (or, on the server fallback path, JPEG-encoded and sent). Its
+  /// aspect ratio drives the overlay's aspect-fill mapping
   /// (`PiecePreviewGeometry.viewPolygon`).
   @MainActor private(set) var frameSize: CGSize = .zero
   /// When `state` was last updated. `PieceCaptureView` hides the overlay

--- a/ios/Pussel/Features/Solve/PiecePreviewStreamer.swift
+++ b/ios/Pussel/Features/Solve/PiecePreviewStreamer.swift
@@ -51,10 +51,18 @@ final class PiecePreviewStreamer: @unchecked Sendable {
   private let detector = PieceLiveDetector()
   private let lock = NSLock()
   private var throttle = PiecePreviewThrottle()
-  /// Latched (lock-guarded) after the first `PieceLiveDetectorUnavailable`,
-  /// so every later frame goes straight to the server path instead of paying
-  /// a doomed Vision attempt per frame.
+  /// Latched (lock-guarded) once on-device detection is judged unusable —
+  /// either an explicit `PieceLiveDetectorUnavailable`, or
+  /// `maxConsecutiveTransientFailures` transient Vision failures in a row —
+  /// so every later frame goes straight to the server path instead of
+  /// paying a doomed Vision attempt per frame.
   private var visionUnavailable = false
+  /// Lock-guarded run of `PieceLiveDetectorTransientFailure`s; reset by any
+  /// successful detection.
+  private var consecutiveTransientFailures = 0
+  /// One transient Vision failure is a dropped frame; this many in a row is
+  /// a platform that can't really do this, so demote to the server path.
+  private static let maxConsecutiveTransientFailures = 3
   /// JPEG quality for frames sent down the server fallback path (matches the
   /// pre-on-device streaming pipeline).
   private static let fallbackJPEGQuality: CGFloat = 0.6
@@ -102,6 +110,7 @@ final class PiecePreviewStreamer: @unchecked Sendable {
       if !fallBack {
         do {
           let detection = try self.detector.detect(cgImage: cgImage)
+          self.lock.withLock { self.consecutiveTransientFailures = 0 }
           await MainActor.run { self.apply(detection, frameSize: frameSize, now: Date()) }
         } catch is PieceLiveDetectorUnavailable {
           // Vision subject lifting can't run here at all (e.g. Simulator) —
@@ -109,9 +118,16 @@ final class PiecePreviewStreamer: @unchecked Sendable {
           self.lock.withLock { self.visionUnavailable = true }
           fallBack = true
         } catch {
-          // Any other error is transient — treat it like a dropped frame
-          // (keep the last-known state, retry on-device next frame) rather
-          // than permanently switching to the server path.
+          // A transient Vision failure is a dropped frame (keep the
+          // last-known state, retry on-device next frame) — unless they
+          // keep coming, which means this platform can't really do
+          // on-device detection and should demote to the server path.
+          fallBack = self.lock.withLock {
+            self.consecutiveTransientFailures += 1
+            let latch = self.consecutiveTransientFailures >= Self.maxConsecutiveTransientFailures
+            if latch { self.visionUnavailable = true }
+            return latch
+          }
         }
       }
       if fallBack {

--- a/ios/Pussel/Features/Solve/PiecePreviewStreamer.swift
+++ b/ios/Pussel/Features/Solve/PiecePreviewStreamer.swift
@@ -103,11 +103,15 @@ final class PiecePreviewStreamer: @unchecked Sendable {
         do {
           let detection = try self.detector.detect(cgImage: cgImage)
           await MainActor.run { self.apply(detection, frameSize: frameSize, now: Date()) }
-        } catch {
+        } catch is PieceLiveDetectorUnavailable {
           // Vision subject lifting can't run here at all (e.g. Simulator) —
           // latch so this and every later frame use the server path.
           self.lock.withLock { self.visionUnavailable = true }
           fallBack = true
+        } catch {
+          // Any other error is transient — treat it like a dropped frame
+          // (keep the last-known state, retry on-device next frame) rather
+          // than permanently switching to the server path.
         }
       }
       if fallBack {

--- a/ios/Pussel/Features/Solve/PiecePreviewStreamer.swift
+++ b/ios/Pussel/Features/Solve/PiecePreviewStreamer.swift
@@ -1,6 +1,7 @@
 import CoreGraphics
 import Foundation
 import Observation
+import UIKit
 
 /// The latest live-preview detection, published by `PiecePreviewStreamer`.
 /// Mirrors the backend's quality flags: a plain `detected` region (yellow
@@ -24,10 +25,17 @@ enum PiecePreviewState: Equatable {
   }
 }
 
-/// Owns the throttle/in-flight state machine for streaming live camera
-/// frames to `POST /api/v1/piece/preview`, and publishes the latest
-/// detection so `PieceCaptureView` can draw it. One instance per piece
-/// capture screen, created alongside its `PieceCameraSession`.
+/// Owns the throttle/in-flight state machine for the live piece-outline
+/// pipeline, and publishes the latest detection so `PieceCaptureView` can
+/// draw it. One instance per piece capture screen, created alongside its
+/// `PieceCameraSession`.
+///
+/// Frames are analyzed **on-device** by `PieceLiveDetector` (Vision
+/// subject-lift + contours) — no network round-trip, so the outline tracks
+/// the camera at inference speed rather than upload speed. When Vision's
+/// subject lifting isn't available at all (e.g. the Simulator), the streamer
+/// falls back — permanently, per instance — to the legacy
+/// `POST /api/v1/piece/preview` server path with a JPEG-encoded frame.
 ///
 /// Split isolation by design: `shouldAcceptFrame`/`submit` are safe to call
 /// from any thread (lock-guarded, matching `StubURLProtocol`'s precedent
@@ -40,8 +48,16 @@ enum PiecePreviewState: Equatable {
 @Observable
 final class PiecePreviewStreamer: @unchecked Sendable {
   private let api: APIClient
+  private let detector = PieceLiveDetector()
   private let lock = NSLock()
   private var throttle = PiecePreviewThrottle()
+  /// Latched (lock-guarded) after the first `PieceLiveDetectorUnavailable`,
+  /// so every later frame goes straight to the server path instead of paying
+  /// a doomed Vision attempt per frame.
+  private var visionUnavailable = false
+  /// JPEG quality for frames sent down the server fallback path (matches the
+  /// pre-on-device streaming pipeline).
+  private static let fallbackJPEGQuality: CGFloat = 0.6
 
   @MainActor private(set) var state: PiecePreviewState = .none
   /// Pixel size of the frame `state`'s polygon was measured against — the
@@ -64,28 +80,55 @@ final class PiecePreviewStreamer: @unchecked Sendable {
     lock.withLock { throttle.shouldSend(now: now) }
   }
 
-  /// Sends an already-downscaled JPEG frame and publishes the result. Safe
-  /// to call from any thread (typically the video-capture queue); the
-  /// network call and state publication both hop to the main actor
-  /// internally. A no-op if the throttle would reject the frame (e.g. it
-  /// raced another accepted frame between `shouldAcceptFrame` and here).
-  func submit(jpegData: Data, frameSize: CGSize, now: Date = Date()) {
+  /// Analyzes an already-downscaled upright frame and publishes the result.
+  /// Safe to call from any thread (typically the video-capture queue); the
+  /// detection runs on a detached background task and the state publication
+  /// hops to the main actor. A no-op if the throttle would reject the frame
+  /// (e.g. it raced another accepted frame between `shouldAcceptFrame` and
+  /// here).
+  func submit(cgImage: CGImage, frameSize: CGSize, now: Date = Date()) {
     let accepted = lock.withLock { () -> Bool in
       guard throttle.shouldSend(now: now) else { return false }
       throttle.markSent(at: now)
       return true
     }
     guard accepted else { return }
-    Task { @MainActor in
+    let useServerPath = lock.withLock { visionUnavailable }
+    Task.detached(priority: .userInitiated) { [weak self] in
+      guard let self else { return }
       defer { self.lock.withLock { self.throttle.markCompleted() } }
-      do {
-        let response = try await self.api.previewPiece(imageData: jpegData)
-        self.apply(response, frameSize: frameSize, now: Date())
-      } catch {
-        // Leave the last-known state on a transient error — a single
-        // dropped frame shouldn't blank the outline mid-track. The
-        // staleness check in PieceCaptureView hides it if errors persist.
+      var fallBack = useServerPath
+      if !fallBack {
+        do {
+          let detection = try self.detector.detect(cgImage: cgImage)
+          await MainActor.run { self.apply(detection, frameSize: frameSize, now: Date()) }
+        } catch {
+          // Vision subject lifting can't run here at all (e.g. Simulator) —
+          // latch so this and every later frame use the server path.
+          self.lock.withLock { self.visionUnavailable = true }
+          fallBack = true
+        }
       }
+      if fallBack {
+        await self.submitToServer(cgImage: cgImage, frameSize: frameSize)
+      }
+    }
+  }
+
+  /// Legacy server-side preview: JPEG-encode the frame and POST it to
+  /// `/api/v1/piece/preview`. Only reached when on-device Vision is
+  /// unavailable on this platform.
+  private func submitToServer(cgImage: CGImage, frameSize: CGSize) async {
+    let jpegData = UIImage(cgImage: cgImage).jpegData(
+      compressionQuality: Self.fallbackJPEGQuality)
+    guard let jpegData else { return }
+    do {
+      let response = try await api.previewPiece(imageData: jpegData)
+      await MainActor.run { self.apply(response, frameSize: frameSize, now: Date()) }
+    } catch {
+      // Leave the last-known state on a transient error — a single
+      // dropped frame shouldn't blank the outline mid-track. The
+      // staleness check in PieceCaptureView hides it if errors persist.
     }
   }
 
@@ -98,6 +141,20 @@ final class PiecePreviewStreamer: @unchecked Sendable {
     state = .none
     frameSize = .zero
     updatedAt = .distantPast
+  }
+
+  @MainActor
+  private func apply(_ detection: PieceLiveDetection?, frameSize: CGSize, now: Date) {
+    self.frameSize = frameSize
+    updatedAt = now
+    guard let detection, detection.polygon.count >= 3 else {
+      state = .none
+      return
+    }
+    state =
+      detection.lockable
+      ? .lockable(polygon: detection.polygon, confidence: detection.confidence)
+      : .detected(polygon: detection.polygon, confidence: detection.confidence)
   }
 
   @MainActor

--- a/ios/Pussel/Features/Solve/PiecePreviewThrottle.swift
+++ b/ios/Pussel/Features/Solve/PiecePreviewThrottle.swift
@@ -1,17 +1,21 @@
 import Foundation
 
-/// Pure decision logic for whether a new live-preview frame should be sent
-/// to the backend, given the current throttle state. No I/O, no timers, no
+/// Pure decision logic for whether a new live-preview frame should be
+/// analyzed, given the current throttle state. No I/O, no timers, no
 /// actor isolation — a plain value type, so it's directly unit-testable
-/// without mocking the network or a clock.
+/// without mocking the detector or a clock.
 ///
 /// `PiecePreviewStreamer` is the sole owner of a live instance and is
-/// responsible for calling `markSent`/`markCompleted` around each request;
+/// responsible for calling `markSent`/`markCompleted` around each analysis;
 /// this type only computes the yes/no answer and the state transitions.
 struct PiecePreviewThrottle: Equatable {
-  /// Minimum time between requests — the ~4Hz cadence M9 targets for
-  /// tracking responsiveness without hammering the backend.
-  static let minInterval: TimeInterval = 0.25
+  /// Minimum time between analyses. With on-device detection the real pacer
+  /// is the in-flight gate (one Vision inference at a time, typically
+  /// 50–150 ms); this floor just keeps the overlay's worst case at ~10Hz so
+  /// a very fast device doesn't spend the whole CPU on segmentation. The
+  /// server fallback path is additionally paced by its own round-trip,
+  /// which the in-flight gate serializes exactly as before.
+  static let minInterval: TimeInterval = 0.1
 
   private(set) var lastSend: Date?
   private(set) var isInFlight = false

--- a/ios/PusselTests/PieceLiveDetectorTests.swift
+++ b/ios/PusselTests/PieceLiveDetectorTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+import simd
+
+@testable import Pussel
+
+/// Tests for `PieceLiveDetector`'s pure geometry helpers — the band scoring
+/// ported from the backend and the contour smoothing/resampling. The Vision
+/// pipeline itself (subject lift + contours) is exercised on-device; these
+/// cover the math that turns its contour into the published outline.
+final class PieceLiveDetectorTests: XCTestCase {
+  // MARK: - bandScore (port of piece_detector._band_score)
+
+  func testBandScoreFullConfidenceInsideBand() {
+    XCTAssertEqual(
+      PieceLiveDetector.bandScore(
+        0.05, hardLow: 0.005, fullLow: 0.01, fullHigh: 0.15, hardHigh: 0.35), 1.0)
+  }
+
+  func testBandScoreZeroAtOrBelowHardLow() {
+    XCTAssertEqual(
+      PieceLiveDetector.bandScore(
+        0.005, hardLow: 0.005, fullLow: 0.01, fullHigh: 0.15, hardHigh: 0.35), 0.0)
+    XCTAssertEqual(
+      PieceLiveDetector.bandScore(
+        0.001, hardLow: 0.005, fullLow: 0.01, fullHigh: 0.15, hardHigh: 0.35), 0.0)
+  }
+
+  func testBandScoreZeroAtOrAboveHardHigh() {
+    XCTAssertEqual(
+      PieceLiveDetector.bandScore(
+        0.35, hardLow: 0.005, fullLow: 0.01, fullHigh: 0.15, hardHigh: 0.35), 0.0)
+    XCTAssertEqual(
+      PieceLiveDetector.bandScore(
+        0.5, hardLow: 0.005, fullLow: 0.01, fullHigh: 0.15, hardHigh: 0.35), 0.0)
+  }
+
+  func testBandScoreTapersLinearlyBelowFullBand() {
+    // Halfway between hardLow 0 and fullLow 1 → 0.5, matching the backend.
+    XCTAssertEqual(
+      PieceLiveDetector.bandScore(0.5, hardLow: 0.0, fullLow: 1.0, fullHigh: 2.0, hardHigh: 3.5),
+      0.5,
+      accuracy: 1e-9)
+  }
+
+  func testBandScoreTapersLinearlyAboveFullBand() {
+    // Halfway between fullHigh 2.0 and hardHigh 3.5 → 0.5.
+    XCTAssertEqual(
+      PieceLiveDetector.bandScore(2.75, hardLow: 0.0, fullLow: 1.0, fullHigh: 2.0, hardHigh: 3.5),
+      0.5,
+      accuracy: 1e-9)
+  }
+
+  // MARK: - resampled
+
+  func testResampledReturnsRequestedCount() {
+    let square: [SIMD2<Double>] = [.init(0, 0), .init(1, 0), .init(1, 1), .init(0, 1)]
+    XCTAssertEqual(PieceLiveDetector.resampled(square, count: 120).count, 120)
+  }
+
+  func testResampledPointsAreArcLengthEquidistant() {
+    // A unit square has perimeter 4; 8 samples → one every 0.5 along the
+    // outline, starting at the first vertex.
+    let square: [SIMD2<Double>] = [.init(0, 0), .init(1, 0), .init(1, 1), .init(0, 1)]
+    let result = PieceLiveDetector.resampled(square, count: 8)
+    let expected: [SIMD2<Double>] = [
+      .init(0, 0), .init(0.5, 0), .init(1, 0), .init(1, 0.5),
+      .init(1, 1), .init(0.5, 1), .init(0, 1), .init(0, 0.5),
+    ]
+    for (point, want) in zip(result, expected) {
+      XCTAssertEqual(point.x, want.x, accuracy: 1e-9)
+      XCTAssertEqual(point.y, want.y, accuracy: 1e-9)
+    }
+  }
+
+  func testResampledDegenerateContourReturnsInput() {
+    let stacked: [SIMD2<Double>] = [.init(0.5, 0.5), .init(0.5, 0.5), .init(0.5, 0.5)]
+    XCTAssertEqual(PieceLiveDetector.resampled(stacked, count: 10), stacked)
+  }
+
+  // MARK: - smoothed
+
+  func testSmoothedPreservesCountAndConstantContour() {
+    let constant = [SIMD2<Double>](repeating: .init(0.3, 0.7), count: 20)
+    let result = PieceLiveDetector.smoothed(constant, window: 5)
+    XCTAssertEqual(result.count, 20)
+    for point in result {
+      XCTAssertEqual(point.x, 0.3, accuracy: 1e-9)
+      XCTAssertEqual(point.y, 0.7, accuracy: 1e-9)
+    }
+  }
+
+  func testSmoothedPullsSpikeTowardNeighbors() {
+    // A single outlier vertex on an otherwise flat run gets averaged down.
+    var points = [SIMD2<Double>](repeating: .init(0.5, 0.5), count: 20)
+    points[10] = .init(0.5, 0.9)
+    let result = PieceLiveDetector.smoothed(points, window: 5)
+    XCTAssertEqual(result[10].y, 0.58, accuracy: 1e-9)
+    XCTAssertEqual(result[0].y, 0.5, accuracy: 1e-9)
+  }
+
+  func testSmoothedTinyContourPassesThrough() {
+    let triangle: [SIMD2<Double>] = [.init(0, 0), .init(1, 0), .init(0, 1)]
+    XCTAssertEqual(PieceLiveDetector.smoothed(triangle, window: 5), triangle)
+  }
+}

--- a/ios/PusselTests/PiecePreviewThrottleTests.swift
+++ b/ios/PusselTests/PiecePreviewThrottleTests.swift
@@ -21,7 +21,8 @@ final class PiecePreviewThrottleTests: XCTestCase {
     let t0 = Date()
     throttle.markSent(at: t0)
     throttle.markCompleted()
-    XCTAssertFalse(throttle.shouldSend(now: t0.addingTimeInterval(0.1)))
+    XCTAssertFalse(
+      throttle.shouldSend(now: t0.addingTimeInterval(PiecePreviewThrottle.minInterval / 2)))
   }
 
   func testResumesOnceMinIntervalElapsesAfterCompletion() {


### PR DESCRIPTION
## Summary

The continuous piece scanner previously streamed ~4Hz JPEG frames to `POST /api/v1/piece/preview`, where rembg segmented a 320px working image and returned a rough outline (`approxPolyDP` capped at 60 points by naive index subsampling). The overlay looked blocky and trailed the camera by a full network round-trip.

This PR moves live detection fully on-device:

- **`PieceLiveDetector`** (new): Vision subject-lift segmentation (`VNGenerateForegroundInstanceMaskRequest`, the on-device counterpart of rembg) → `VNDetectContoursRequest` traced over the mask → the backend's area/aspect confidence bands ported verbatim from `piece_detector.py` → circular smoothing + arc-length resampling to a dense **120-point outline**.
- **`PiecePreviewStreamer`**: runs the detector locally instead of POSTing JPEGs. The server endpoint survives as a per-instance latched fallback for platforms without subject lifting (e.g. the Simulator).
- **`PieceCameraSession`**: analysis frames are 720px CGImages (up from 480px JPEG); no encode, no upload.
- **`PiecePreviewThrottle`**: floor lowered 0.25s → 0.1s — the pacer is now one Vision inference at a time rather than the network round-trip.
- "Lockable" (green outline / auto-capture arming) is an on-device heuristic: single clean component, not border-touching, full-confidence area/aspect bands. Scan captures are still verified by the server-side calibrated geometry pipeline, so verdict quality is unchanged.

## Testing

- 159 unit tests pass, including new coverage for the ported band scoring, contour smoothing, and arc-length resampling; `make check-ios` clean.
- **Device-verified on iPhone 15**: outline hugs tabs/blanks (night-and-day vs the 60-point server polygon), backend access log shows zero `/piece/preview` traffic from the new build, and the scan-and-lock flow still completes end-to-end (matched/"Already scanned" dedupe verdicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)