### PR TITLE
Snap predicted piece positions to the puzzle grid for display

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,6 +42,7 @@ from app.models.puzzle_model import (
 from app.models.user_model import GoogleAuthRequest, TokenResponse, User
 from app.rate_limit import FixedWindowRateLimiter, rate_limit_by_ip, rate_limit_by_user
 from app.services.classical_matcher import get_classical_matcher
+from app.services.grid_snap import snap_to_grid
 from app.services.image_processor import get_image_processor
 from app.services.piece_detector import get_piece_detector
 from app.services.piece_geometry.service import (
@@ -444,7 +445,9 @@ async def process_piece(
         remove_bg: Whether to remove background from piece image (default: True).
 
     Returns:
-        PieceResponse: Response containing position, confidence, and optionally cleaned image.
+        PieceResponse: Response containing position, confidence, and optionally cleaned image;
+        when the puzzle's grid is known, also the nearest grid cell and its center
+        (grid_row/grid_col/snapped_position) for display.
 
     Raises:
         HTTPException: If puzzle not found or file type is invalid.
@@ -453,13 +456,14 @@ async def process_piece(
         raise HTTPException(status_code=400, detail="No file provided")
 
     if settings.MATCHER == "cnn":
-        return await get_image_processor().process_piece(file, puzzle_id, remove_background=remove_bg)
-
-    # Pass along the grid estimated at upload time (if any) so the NCC fallback's
-    # nominal template size uses the puzzle's real grid instead of the defaults.
-    return await get_classical_matcher().process_piece(
-        file, puzzle_id, remove_background=remove_bg, grid_hint=puzzle.grid
-    )
+        response = await get_image_processor().process_piece(file, puzzle_id, remove_background=remove_bg)
+    else:
+        # Pass along the grid estimated at upload time (if any) so the NCC fallback's
+        # nominal template size uses the puzzle's real grid instead of the defaults.
+        response = await get_classical_matcher().process_piece(
+            file, puzzle_id, remove_background=remove_bg, grid_hint=puzzle.grid
+        )
+    return snap_to_grid(response, puzzle.grid)
 
 
 def _normalize_points(points: np.ndarray, width: int, height: int) -> List[GeometryPoint]:

--- a/backend/app/models/puzzle_model.py
+++ b/backend/app/models/puzzle_model.py
@@ -35,6 +35,24 @@ class PieceResponse(BaseModel):
             "exists (CNN path, or matcher failure fallback)."
         ),
     )
+    grid_row: Optional[int] = Field(
+        default=None,
+        description=(
+            "0-based row of the grid cell nearest to the predicted position. Null when the "
+            "puzzle's grid is unknown (no piece_count at upload)."
+        ),
+    )
+    grid_col: Optional[int] = Field(
+        default=None, description="0-based column of the nearest grid cell; null when the grid is unknown"
+    )
+    snapped_position: Optional[Position] = Field(
+        default=None,
+        description=(
+            "Center of the (grid_row, grid_col) cell, normalized to the puzzle image — the "
+            "display position, always inside the puzzle. `position` remains the raw prediction. "
+            "Null when the grid is unknown."
+        ),
+    )
 
 
 class PuzzleResponse(BaseModel):

--- a/backend/app/services/grid_snap.py
+++ b/backend/app/services/grid_snap.py
@@ -1,0 +1,40 @@
+"""Snap predicted piece positions onto the puzzle's estimated grid.
+
+The matchers predict a continuous piece center that can land anywhere —
+including slightly outside the puzzle for edge and corner pieces. The client
+displays pieces at real grid slots, so the piece endpoint attaches the nearest
+cell and its center here; the raw prediction is kept untouched alongside.
+"""
+
+from typing import Optional, Tuple
+
+from app.models.puzzle_model import PieceResponse, Position
+
+
+def snap_to_grid(response: PieceResponse, grid: Optional[Tuple[int, int]]) -> PieceResponse:
+    """Attach the nearest grid cell and its center to a piece prediction.
+
+    Args:
+        response: The matcher's prediction, with a continuous `position`.
+        grid: The puzzle's estimated (rows, cols), or None when unknown.
+
+    Returns:
+        The response with `grid_row`, `grid_col`, and `snapped_position` set
+        (a copy), or the response unchanged when no grid is known.
+    """
+    if grid is None:
+        return response
+    rows, cols = grid
+    if rows <= 0 or cols <= 0:
+        return response
+    # A center at exactly 1.0 (or a prediction outside [0, 1]) clamps to the
+    # nearest edge cell, so edge/corner pieces always land inside the puzzle.
+    row = min(max(int(response.position.y * rows), 0), rows - 1)
+    col = min(max(int(response.position.x * cols), 0), cols - 1)
+    return response.model_copy(
+        update={
+            "grid_row": row,
+            "grid_col": col,
+            "snapped_position": Position(x=(col + 0.5) / cols, y=(row + 0.5) / rows),
+        }
+    )

--- a/backend/tests/test_grid_snap.py
+++ b/backend/tests/test_grid_snap.py
@@ -1,0 +1,53 @@
+"""Tests for snapping predicted piece positions onto the estimated grid."""
+
+import pytest
+
+from app.models.puzzle_model import PieceResponse, Position
+from app.services.grid_snap import snap_to_grid
+
+
+def make_response(x: float, y: float) -> PieceResponse:
+    """Build a minimal PieceResponse with the given predicted center."""
+    return PieceResponse(
+        position=Position(x=x, y=y),
+        position_confidence=0.8,
+        rotation=0,
+        rotation_confidence=0.9,
+    )
+
+
+def test_no_grid_leaves_response_unchanged() -> None:
+    """Without a known grid, the response passes through with null snap fields."""
+    response = snap_to_grid(make_response(0.3, 0.7), None)
+    assert response.grid_row is None
+    assert response.grid_col is None
+    assert response.snapped_position is None
+
+
+def test_interior_position_snaps_to_containing_cell_center() -> None:
+    """A prediction inside the puzzle snaps to the center of its cell."""
+    response = snap_to_grid(make_response(0.3, 0.7), (4, 6))
+    assert (response.grid_row, response.grid_col) == (2, 1)
+    assert response.snapped_position is not None
+    assert response.snapped_position.x == pytest.approx(1.5 / 6)
+    assert response.snapped_position.y == pytest.approx(2.5 / 4)
+    # The raw prediction is kept as-is.
+    assert (response.position.x, response.position.y) == (0.3, 0.7)
+
+
+@pytest.mark.parametrize(
+    ("x", "y", "expected_row", "expected_col"),
+    [
+        (-0.1, -0.2, 0, 0),  # beyond the top-left corner
+        (1.1, 1.3, 3, 5),  # beyond the bottom-right corner
+        (1.0, 1.0, 3, 5),  # exactly on the far edges
+        (0.0, 0.0, 0, 0),  # exactly on the near edges
+    ],
+)
+def test_out_of_range_positions_clamp_to_edge_cells(x: float, y: float, expected_row: int, expected_col: int) -> None:
+    """Predictions outside [0, 1] snap to the nearest edge cell, never outside the puzzle."""
+    response = snap_to_grid(make_response(x, y), (4, 6))
+    assert (response.grid_row, response.grid_col) == (expected_row, expected_col)
+    assert response.snapped_position is not None
+    assert 0.0 < response.snapped_position.x < 1.0
+    assert 0.0 < response.snapped_position.y < 1.0

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -205,6 +205,52 @@ def test_piece_grid_hint_reaches_classical_matcher() -> None:
     assert kwargs["grid_hint"] == expected_grid
 
 
+def test_process_piece_snaps_to_grid() -> None:
+    """When the puzzle's grid is known, the prediction is snapped to the nearest cell for display."""
+    # A prediction slightly outside the puzzle, as happens for corner pieces.
+    mock_response = PieceResponse(
+        position=Position(x=1.02, y=-0.03),
+        position_confidence=0.85,
+        rotation=90,
+        rotation_confidence=0.90,
+    )
+    mock_matcher = MagicMock()
+    mock_matcher.process_piece = AsyncMock(return_value=mock_response)
+
+    upload_response = client.post(
+        "/api/v1/puzzle/upload",
+        files=photo_files(make_photo_jpeg()),
+        data={"piece_count": "24"},
+        headers=get_auth_header(),
+    )
+    puzzle_id = upload_response.json()["puzzle_id"]
+    rows, cols = calculate_grid_dimensions(800, 600, 24)
+
+    with (
+        patch.object(settings, "MATCHER", "classical"),
+        patch("app.main.get_classical_matcher", return_value=mock_matcher),
+    ):
+        with tempfile.NamedTemporaryFile(suffix=".jpg") as temp_file:
+            temp_file.write(b"fake piece content")
+            temp_file.seek(0)
+            file_tuple = cast(FileUpload, ("test_piece.jpg", temp_file, "image/jpeg"))
+            response = client.post(
+                f"/api/v1/puzzle/{puzzle_id}/piece",
+                files={"file": file_tuple},
+                headers=get_auth_header(),
+            )
+
+    assert response.status_code == 200
+    result = response.json()
+    # The raw prediction is preserved untouched...
+    assert result["position"] == {"x": 1.02, "y": -0.03}
+    # ...while the snap clamps to the top-right corner cell and its center.
+    assert result["grid_row"] == 0
+    assert result["grid_col"] == cols - 1
+    assert result["snapped_position"]["x"] == pytest.approx((cols - 0.5) / cols)
+    assert result["snapped_position"]["y"] == pytest.approx(0.5 / rows)
+
+
 def test_process_piece_invalid_puzzle() -> None:
     """Test processing a piece with an invalid puzzle ID."""
     with tempfile.NamedTemporaryFile(suffix=".jpg") as temp_file:
@@ -283,6 +329,12 @@ def test_process_piece() -> None:
         assert result["rotation"] == 90
         assert result["rotation_confidence"] == 0.90
         assert result["piece_span"] is None
+
+        # The puzzle was uploaded without a piece_count, so no grid is known
+        # and the snap fields stay null.
+        assert result["grid_row"] is None
+        assert result["grid_col"] is None
+        assert result["snapped_position"] is None
 
     finally:
         # Cleanup test image

--- a/ios/Pussel/Features/Solve/PieceQueueView.swift
+++ b/ios/Pussel/Features/Solve/PieceQueueView.swift
@@ -373,7 +373,7 @@ private struct QueueTile: View {
       Text("Predicting…").font(.caption2).foregroundStyle(.secondary)
     case .done:
       if let piece = entry.result {
-        Text("(\(Int(piece.position.x * 100))%, \(Int(piece.position.y * 100))%)")
+        Text("(\(Int(piece.displayPosition.x * 100))%, \(Int(piece.displayPosition.y * 100))%)")
           .font(.caption2.monospacedDigit())
           .foregroundStyle(.green)
       }

--- a/ios/Pussel/Features/Solve/PuzzleOverlayView.swift
+++ b/ios/Pussel/Features/Solve/PuzzleOverlayView.swift
@@ -121,7 +121,7 @@ private struct PieceMarker: View {
         .frame(height: 4)
     }
     .rotationEffect(.degrees(-Double(piece.rotation)))
-    .position(x: canvas.width * piece.position.x, y: canvas.height * piece.position.y)
+    .position(x: canvas.width * piece.displayPosition.x, y: canvas.height * piece.displayPosition.y)
     .opacity(isDimmed ? 0.25 : 1)
   }
 }

--- a/ios/Pussel/Features/Solve/PuzzleZoomView.swift
+++ b/ios/Pussel/Features/Solve/PuzzleZoomView.swift
@@ -69,7 +69,7 @@ struct PuzzleZoomView: View {
       return nil
     }
     return PuzzleFocusGeometry.focusRect(
-      position: CGPoint(x: piece.position.x, y: piece.position.y),
+      position: CGPoint(x: piece.displayPosition.x, y: piece.displayPosition.y),
       rows: session.rows,
       cols: session.cols)
   }

--- a/ios/Pussel/Models/PieceModels.swift
+++ b/ios/Pussel/Models/PieceModels.swift
@@ -23,6 +23,13 @@ struct PieceResponse: Codable, Equatable {
   /// Measured size of the full piece image frame, when available. See
   /// `PieceSpan`.
   let pieceSpan: PieceSpan?
+  /// 0-based grid cell nearest to the prediction; nil when the backend didn't
+  /// know the puzzle's grid (and for results stored before these fields).
+  let gridRow: Int?
+  let gridCol: Int?
+  /// Center of the (gridRow, gridCol) cell — always inside the puzzle, unlike
+  /// the raw `position`, which can spill past the edge for border pieces.
+  let snappedPosition: NormalizedPoint?
 }
 
 extension PieceResponse {
@@ -37,6 +44,12 @@ extension PieceResponse {
   var uprightRotationDegrees: Double {
     let degrees = (360 - rotation % 360) % 360
     return Double(degrees > 180 ? degrees - 360 : degrees)
+  }
+
+  /// Where to draw the piece on the puzzle: the grid-snapped cell center when
+  /// the backend provided one, otherwise the raw prediction.
+  var displayPosition: NormalizedPoint {
+    snappedPosition ?? position
   }
 }
 

--- a/ios/Pussel/Persistence/PuzzleStore.swift
+++ b/ios/Pussel/Persistence/PuzzleStore.swift
@@ -52,6 +52,11 @@ private struct StoredResult: Codable {
   let rotation: Int
   let rotationConfidence: Double
   let pieceSpan: PieceSpan?
+  /// Grid snap fields; nil for manifests written before they existed
+  /// (optional Codable decodes missing keys as nil).
+  let gridRow: Int?
+  let gridCol: Int?
+  let snappedPosition: NormalizedPoint?
 }
 
 /// Local, on-device persistence for solved/in-progress puzzles. Everything is
@@ -163,7 +168,10 @@ final class PuzzleStore {
               positionConfidence: $0.positionConfidence,
               rotation: $0.rotation,
               rotationConfidence: $0.rotationConfidence,
-              pieceSpan: $0.pieceSpan
+              pieceSpan: $0.pieceSpan,
+              gridRow: $0.gridRow,
+              gridCol: $0.gridCol,
+              snappedPosition: $0.snappedPosition
             )
           },
           scanPieceId: entry.scanPieceId
@@ -261,7 +269,10 @@ final class PuzzleStore {
           rotation: $0.rotation,
           rotationConfidence: $0.rotationConfidence,
           cleanedImage: nil,
-          pieceSpan: $0.pieceSpan
+          pieceSpan: $0.pieceSpan,
+          gridRow: $0.gridRow,
+          gridCol: $0.gridCol,
+          snappedPosition: $0.snappedPosition
         )
       }
       return CaptureEntry(

--- a/ios/PusselTests/ModelDecodingTests.swift
+++ b/ios/PusselTests/ModelDecodingTests.swift
@@ -90,6 +90,53 @@ final class ModelDecodingTests: XCTestCase {
     XCTAssertEqual(response.rotation, 270)
     XCTAssertEqual(response.positionConfidence, 0.91)
     XCTAssertEqual(ImageUtilities.decodeDataURL(response.cleanedImage!), Data("pie".utf8))
+    // Grid snap fields absent entirely (old backend): nil, and display falls
+    // back to the raw prediction.
+    XCTAssertNil(response.gridRow)
+    XCTAssertNil(response.gridCol)
+    XCTAssertNil(response.snappedPosition)
+    XCTAssertEqual(response.displayPosition, response.position)
+  }
+
+  func testDecodePieceResponseWithGridSnap() throws {
+    let json = """
+      {
+        "position": {"x": 1.02, "y": -0.03},
+        "position_confidence": 0.91,
+        "rotation": 0,
+        "rotation_confidence": 0.66,
+        "cleaned_image": null,
+        "grid_row": 0,
+        "grid_col": 5,
+        "snapped_position": {"x": 0.9166, "y": 0.125}
+      }
+      """
+    let response = try decoder.decode(PieceResponse.self, from: Data(json.utf8))
+    XCTAssertEqual(response.gridRow, 0)
+    XCTAssertEqual(response.gridCol, 5)
+    XCTAssertEqual(response.snappedPosition, NormalizedPoint(x: 0.9166, y: 0.125))
+    // Display uses the snapped center; the raw out-of-bounds prediction is kept.
+    XCTAssertEqual(response.displayPosition, NormalizedPoint(x: 0.9166, y: 0.125))
+    XCTAssertEqual(response.position, NormalizedPoint(x: 1.02, y: -0.03))
+  }
+
+  func testDecodePieceResponseWithNullGridSnap() throws {
+    // The backend's shape when the puzzle's grid is unknown: keys present, null.
+    let json = """
+      {
+        "position": {"x": 0.25, "y": 0.75},
+        "position_confidence": 0.91,
+        "rotation": 0,
+        "rotation_confidence": 0.66,
+        "cleaned_image": null,
+        "grid_row": null,
+        "grid_col": null,
+        "snapped_position": null
+      }
+      """
+    let response = try decoder.decode(PieceResponse.self, from: Data(json.utf8))
+    XCTAssertNil(response.snappedPosition)
+    XCTAssertEqual(response.displayPosition, NormalizedPoint(x: 0.25, y: 0.75))
   }
 
   func testDecodePieceResponseWithoutCleanedImage() throws {

--- a/ios/PusselTests/PieceRotationTests.swift
+++ b/ios/PusselTests/PieceRotationTests.swift
@@ -15,7 +15,10 @@ final class PieceRotationTests: XCTestCase {
       rotation: rotation,
       rotationConfidence: 0.9,
       cleanedImage: nil,
-      pieceSpan: nil
+      pieceSpan: nil,
+      gridRow: nil,
+      gridCol: nil,
+      snappedPosition: nil
     )
   }
 

--- a/ios/PusselTests/PuzzleStoreTests.swift
+++ b/ios/PusselTests/PuzzleStoreTests.swift
@@ -125,7 +125,10 @@ final class PuzzleStoreTests: XCTestCase {
           rotation: 90,
           rotationConfidence: 0.77,
           cleanedImage: nil,
-          pieceSpan: PieceSpan(width: 0.34, height: 0.25)
+          pieceSpan: PieceSpan(width: 0.34, height: 0.25),
+          gridRow: 2,
+          gridCol: 3,
+          snappedPosition: NormalizedPoint(x: 0.4375, y: 0.4167)
         ),
         scanPieceId: "p001"
       )
@@ -156,6 +159,9 @@ final class PuzzleStoreTests: XCTestCase {
     XCTAssertEqual(entry.result?.position, NormalizedPoint(x: 0.34, y: 0.4))
     XCTAssertEqual(entry.result?.rotation, 90)
     XCTAssertEqual(entry.result?.pieceSpan, PieceSpan(width: 0.34, height: 0.25))
+    XCTAssertEqual(entry.result?.gridRow, 2)
+    XCTAssertEqual(entry.result?.gridCol, 3)
+    XCTAssertEqual(entry.result?.snappedPosition, NormalizedPoint(x: 0.4375, y: 0.4167))
     // The scan-and-lock link survives the round trip, so the scan gallery
     // can restore this entry's photo as its thumbnail on a later visit.
     XCTAssertEqual(entry.scanPieceId, "p001")


### PR DESCRIPTION
## Summary

Predictions from the matchers are continuous and can place edge/corner pieces partly outside the puzzle image. This PR adds a grid snap step on the server and uses it for display in the iOS app, while keeping the raw predicted position and rotation untouched.

### Backend
- New `app/services/grid_snap.py`: maps the predicted center to the nearest grid cell, clamping out-of-range predictions into the border cells.
- `PieceResponse` gains optional `grid_row`, `grid_col` (0-based nearest cell) and `snapped_position` (that cell's center, normalized). Null when the puzzle was uploaded without a `piece_count` (no grid known), so existing clients/flows are unaffected.
- `POST /api/v1/puzzle/{puzzle_id}/piece` applies the snap after either matcher (classical or CNN) returns, using the grid estimated at upload time.

### iOS
- `PieceResponse` decodes the new fields and exposes `displayPosition` (`snappedPosition ?? position`).
- Overlay markers, the zoom viewer focus, and the queue coordinate label display at the snapped center; results predicted before this change fall back to the raw position.
- The on-disk manifest persists the snap fields, tolerating older manifests without them.

## Testing
- Backend: full suite passes (283 tests), including new unit tests for the snap helper (interior snap, clamping, no-grid passthrough) and endpoint tests for grid and no-grid paths. `make check-backend` clean.
- iOS: full unit test suite passes on the Simulator, including new decoding tests (fields present/null/absent), `displayPosition` fallback, and store round-trip. `make check-ios` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)