### PR TITLE
Display pieces at grid-snapped positions in the web frontend

### DIFF
--- a/frontend/src/components/puzzle/piece-card.test.tsx
+++ b/frontend/src/components/puzzle/piece-card.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PieceCard } from './piece-card';
+import type { Piece } from '@/types';
+
+function makePiece(overrides: Partial<Piece> = {}): Piece {
+  return {
+    position: { x: 0.42, y: 0.13, normalized: true },
+    positionConfidence: 0.9,
+    rotation: 90,
+    rotationConfidence: 0.8,
+    ...overrides,
+  };
+}
+
+describe('PieceCard', () => {
+  it('shows the snapped position when the grid is known', () => {
+    render(
+      <PieceCard
+        piece={makePiece({ snappedPosition: { x: 0.5, y: 0.25, normalized: true } })}
+        index={0}
+      />
+    );
+
+    expect(screen.getByText('(50%, 25%)')).toBeInTheDocument();
+  });
+
+  it('shows the raw predicted position when the grid is unknown', () => {
+    render(<PieceCard piece={makePiece({ snappedPosition: null })} index={0} />);
+
+    expect(screen.getByText('(42%, 13%)')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/puzzle/piece-card.tsx
+++ b/frontend/src/components/puzzle/piece-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { Piece } from '@/types';
+import { getDisplayPosition } from '@/types';
 import { Card, CardContent } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 
@@ -41,7 +42,8 @@ export function PieceCard({ piece, index, className }: PieceCardProps) {
           <div className="flex justify-between">
             <span className="text-muted-foreground">Position:</span>
             <span>
-              ({(piece.position.x * 100).toFixed(0)}%, {(piece.position.y * 100).toFixed(0)}%)
+              ({(getDisplayPosition(piece).x * 100).toFixed(0)}%,{' '}
+              {(getDisplayPosition(piece).y * 100).toFixed(0)}%)
             </span>
           </div>
           <div className="flex justify-between">

--- a/frontend/src/components/puzzle/piece-queue.tsx
+++ b/frontend/src/components/puzzle/piece-queue.tsx
@@ -3,6 +3,7 @@
 import { AlertCircle, Check, Loader2, RotateCcw, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import type { CaptureEntry } from '@/stores/capture-queue-store';
+import { getDisplayPosition } from '@/types';
 import { cn } from '@/lib/utils';
 
 interface PieceQueueProps {
@@ -92,8 +93,8 @@ export function PieceQueue({ entries, onRetry, onDelete, className }: PieceQueue
                   <>
                     <Check className="h-3 w-3 text-green-600" />
                     <span>
-                      ({(entry.piece.position.x * 100).toFixed(0)}%,{' '}
-                      {(entry.piece.position.y * 100).toFixed(0)}%)
+                      ({(getDisplayPosition(entry.piece).x * 100).toFixed(0)}%,{' '}
+                      {(getDisplayPosition(entry.piece).y * 100).toFixed(0)}%)
                     </span>
                   </>
                 )}

--- a/frontend/src/components/puzzle/puzzle-detail.test.tsx
+++ b/frontend/src/components/puzzle/puzzle-detail.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PuzzleDetail } from './puzzle-detail';
+import type { Piece } from '@/types';
+
+function makePiece(overrides: Partial<Piece> = {}): Piece {
+  return {
+    position: { x: 0.42, y: 0.13, normalized: true },
+    positionConfidence: 0.9,
+    rotation: 0,
+    rotationConfidence: 0.8,
+    imageData: 'data:image/png;base64,test',
+    ...overrides,
+  };
+}
+
+describe('PuzzleDetail', () => {
+  it('places a piece at its snapped position when the grid is known', () => {
+    render(
+      <PuzzleDetail
+        puzzleImage="data:image/jpeg;base64,puzzle"
+        pieces={[
+          makePiece({
+            gridRow: 0,
+            gridCol: 1,
+            snappedPosition: { x: 0.5, y: 0.25, normalized: true },
+          }),
+        ]}
+      />
+    );
+
+    const piece = screen.getByAltText('Piece 1').parentElement!;
+    expect(piece).toHaveStyle({ left: '50%', top: '25%' });
+  });
+
+  it('falls back to the raw predicted position when the grid is unknown', () => {
+    render(
+      <PuzzleDetail
+        puzzleImage="data:image/jpeg;base64,puzzle"
+        pieces={[makePiece({ gridRow: null, gridCol: null, snappedPosition: null })]}
+      />
+    );
+
+    const piece = screen.getByAltText('Piece 1').parentElement!;
+    expect(piece).toHaveStyle({ left: '42%', top: '13%' });
+  });
+});

--- a/frontend/src/components/puzzle/puzzle-detail.tsx
+++ b/frontend/src/components/puzzle/puzzle-detail.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 import type { Piece, GridSize } from '@/types';
-import { GRID_DIMENSIONS } from '@/types';
+import { GRID_DIMENSIONS, getDisplayPosition } from '@/types';
 import { cn } from '@/lib/utils';
 
 interface PuzzleDetailProps {
@@ -58,8 +58,8 @@ export function PuzzleDetail({
               key={index}
               className="absolute border-2 border-green-500 shadow-lg"
               style={{
-                left: `${piece.position.x * 100}%`,
-                top: `${piece.position.y * 100}%`,
+                left: `${getDisplayPosition(piece).x * 100}%`,
+                top: `${getDisplayPosition(piece).y * 100}%`,
                 width: `${pieceSize}%`,
                 height: `${pieceSize}%`,
                 transform: `translate(-50%, -50%) rotate(${-piece.rotation}deg)`,

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,8 +1,77 @@
-import { describe, it, expect } from 'vitest';
-import { API_BASE } from './api';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { API_BASE, processPiece } from './api';
 
 describe('API Client', () => {
   it('should have correct API base URL', () => {
     expect(API_BASE).toBe('http://localhost:8000');
+  });
+});
+
+describe('processPiece', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockPieceResponse(body: Record<string, unknown>) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(body),
+      })
+    );
+  }
+
+  it('maps grid snap fields from the API response', async () => {
+    mockPieceResponse({
+      position: { x: 0.42, y: 0.13 },
+      position_confidence: 0.9,
+      rotation: 90,
+      rotation_confidence: 0.8,
+      grid_row: 0,
+      grid_col: 1,
+      snapped_position: { x: 0.5, y: 0.16667 },
+    });
+
+    const piece = await processPiece('puzzle-1', new Blob());
+
+    expect(piece.position).toEqual({ x: 0.42, y: 0.13, normalized: true });
+    expect(piece.gridRow).toBe(0);
+    expect(piece.gridCol).toBe(1);
+    expect(piece.snappedPosition).toEqual({ x: 0.5, y: 0.16667, normalized: true });
+  });
+
+  it('returns null grid snap fields when the puzzle grid is unknown', async () => {
+    mockPieceResponse({
+      position: { x: 0.42, y: 0.13 },
+      position_confidence: 0.9,
+      rotation: 0,
+      rotation_confidence: 0.8,
+      grid_row: null,
+      grid_col: null,
+      snapped_position: null,
+    });
+
+    const piece = await processPiece('puzzle-1', new Blob());
+
+    expect(piece.gridRow).toBeNull();
+    expect(piece.gridCol).toBeNull();
+    expect(piece.snappedPosition).toBeNull();
+  });
+
+  it('tolerates responses without the grid snap fields', async () => {
+    mockPieceResponse({
+      position: { x: 0.42, y: 0.13 },
+      position_confidence: 0.9,
+      rotation: 0,
+      rotation_confidence: 0.8,
+    });
+
+    const piece = await processPiece('puzzle-1', new Blob());
+
+    expect(piece.gridRow).toBeNull();
+    expect(piece.gridCol).toBeNull();
+    expect(piece.snappedPosition).toBeNull();
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -162,6 +162,9 @@ interface PieceApiResponse {
   rotation: 0 | 90 | 180 | 270;
   rotation_confidence: number;
   cleaned_image?: string; // Base64 PNG with background removed
+  grid_row?: number | null; // 0-based nearest grid cell row; null when the grid is unknown
+  grid_col?: number | null; // 0-based nearest grid cell column; null when the grid is unknown
+  snapped_position?: { x: number; y: number } | null; // nearest cell center; null when the grid is unknown
 }
 
 export async function processPiece(
@@ -194,6 +197,9 @@ export async function processPiece(
     rotation: data.rotation,
     rotationConfidence: data.rotation_confidence,
     imageData: data.cleaned_image, // Use cleaned image with background removed
+    gridRow: data.grid_row ?? null,
+    gridCol: data.grid_col ?? null,
+    snappedPosition: data.snapped_position ? { ...data.snapped_position, normalized: true } : null,
   };
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -14,11 +14,19 @@ export interface Position {
 
 export interface Piece {
   id?: string; // stable identifier when the piece originates from the capture queue
-  position: Position;
+  position: Position; // raw predicted position
   positionConfidence: number; // 0-1
   rotation: 0 | 90 | 180 | 270;
   rotationConfidence: number; // 0-1
   imageData?: string; // base64 or blob URL
+  gridRow?: number | null; // 0-based nearest grid cell row; null when the puzzle grid is unknown
+  gridCol?: number | null; // 0-based nearest grid cell column; null when the puzzle grid is unknown
+  snappedPosition?: Position | null; // center of the nearest grid cell; null when the puzzle grid is unknown
+}
+
+/** Position to display the piece at: the grid-snapped position when known, else the raw prediction. */
+export function getDisplayPosition(piece: Piece): Position {
+  return piece.snappedPosition ?? piece.position;
 }
 
 export interface Puzzle {


### PR DESCRIPTION
## Summary

Brings the web frontend to parity with the iOS app for the backend's grid snap fields on `POST /api/v1/puzzle/{puzzle_id}/piece` (`grid_row`, `grid_col`, `snapped_position`). Pieces are now displayed at the nearest grid cell center when the puzzle's grid is known, falling back to the raw predicted position when it is not (puzzle uploaded without `piece_count`).

## Changes

- **`src/types/index.ts`** — `Piece` gains nullable `gridRow`, `gridCol`, and `snappedPosition`, plus a `getDisplayPosition(piece)` helper that returns `snappedPosition ?? position` so the fallback logic lives in one place.
- **`src/lib/api.ts`** — `PieceApiResponse` declares the new snake_case fields; `processPiece` maps them to camelCase and normalizes absent fields to `null`, so older backends without the fields still work.
- **Display sites** use the helper: piece placement in `puzzle-detail.tsx`, and the coordinate readouts in `piece-card.tsx` and `piece-queue.tsx`.

The raw predicted `position`/`rotation` values remain untouched in state — only display is affected.

## Tests

- `api.test.ts`: `processPiece` mapping with snap fields present, explicitly `null`, and absent entirely.
- New `puzzle-detail.test.tsx` and `piece-card.test.tsx`: snapped placement and raw-position fallback.

All 71 Vitest tests pass; `bun run check` (oxlint type-aware, tsc, prettier) is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)