### PR TITLE
Fetch clean puzzle motif image for barcode lookups

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -101,7 +101,7 @@ class Settings(BaseSettings):
     #
     # Known 3-digit series prefixes for the adult line (GS1 prefix 4005555),
     # whose 8-digit article numbers aren't fully recoverable from the EAN;
-    # each is probed against the CDN in order. Empirical list — a 4005555 EAN
+    # each is probed against ravensburger.org in order. Empirical list — a 4005555 EAN
     # that misses on all of these is logged so gaps become discoverable.
     RAVENSBURGER_SERIES_PREFIXES: list[str] = ["120", "130", "132", "150", "160", "170"]
     # Per-request timeout. Candidates are probed concurrently, so this also
@@ -110,8 +110,10 @@ class Settings(BaseSettings):
     RAVENSBURGER_CDN_TIMEOUT_SECONDS: float = Field(default=3.0, gt=0)
     # Requested image size bucket (long edge). NOT arbitrary: the site serves
     # pre-rendered buckets 75/100/240/360/1024 only and 404s every other size
-    # (verified live 2026-07-22); 1024 is the largest available.
-    RAVENSBURGER_IMAGE_SIZE: int = Field(default=1024, gt=0)
+    # (verified live 2026-07-22); 1024 is the largest available. Constrained
+    # to the supported buckets so a misconfigured size fails at startup
+    # instead of silently 404ing every lookup.
+    RAVENSBURGER_IMAGE_SIZE: Literal[75, 100, 240, 360, 1024] = 1024
     # Per-user, guards GET /api/v1/puzzle/barcode/{ean}. The iOS client
     # debounces to at most one lookup per stable barcode read and caches
     # misses per session, so normal use is a handful of requests per minute;

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -94,28 +94,24 @@ class Settings(BaseSettings):
     # never gets 429'd, while still bounding a runaway or malicious client.
     RATE_LIMIT_PREVIEW_PER_MINUTE: int = Field(default=300, ge=0)
 
-    # Ravensburger barcode lookup (GET /api/v1/puzzle/barcode/{ean}). The box
-    # image CDN (see app/services/ravensburger_client.py) serves images keyed
-    # by article number and returns a tiny placeholder (~458 bytes observed)
-    # with HTTP 200 for unknown articles, so hits are judged by payload size.
+    # Ravensburger barcode lookup (GET /api/v1/puzzle/barcode/{ean}). Product
+    # images (see app/services/ravensburger_client.py) are served as static
+    # files on www.ravensburger.org keyed by article number; misses are
+    # genuine HTTP 404s.
     #
     # Known 3-digit series prefixes for the adult line (GS1 prefix 4005555),
     # whose 8-digit article numbers aren't fully recoverable from the EAN;
     # each is probed against the CDN in order. Empirical list — a 4005555 EAN
     # that misses on all of these is logged so gaps become discoverable.
     RAVENSBURGER_SERIES_PREFIXES: list[str] = ["120", "130", "132", "150", "160", "170"]
-    # Per-request CDN timeout. Candidates are probed concurrently, so this
-    # also bounds the whole lookup's worst-case CDN wait.
+    # Per-request timeout. Candidates are probed concurrently, so this also
+    # bounds the whole lookup's worst-case wait (up to two sequential GETs
+    # per candidate: motif then box fallback).
     RAVENSBURGER_CDN_TIMEOUT_SECONDS: float = Field(default=3.0, gt=0)
-    # Requested image dimensions. NOT arbitrary: the CDN serves pre-rendered
-    # sizes only and answers every other size with the placeholder (verified
-    # live 2026-07-22: 520x445 returns real images for both 5- and 8-digit
-    # articles; 1000x850, 1040x890, 260x223 etc. all return the placeholder).
-    RAVENSBURGER_IMAGE_WIDTH: int = Field(default=520, gt=0)
-    RAVENSBURGER_IMAGE_HEIGHT: int = Field(default=445, gt=0)
-    # Responses at or below this size are treated as the "unknown article"
-    # placeholder (misses). Real box images observed at 15-45 KB.
-    RAVENSBURGER_PLACEHOLDER_MAX_BYTES: int = Field(default=2000, gt=0)
+    # Requested image size bucket (long edge). NOT arbitrary: the site serves
+    # pre-rendered buckets 75/100/240/360/1024 only and 404s every other size
+    # (verified live 2026-07-22); 1024 is the largest available.
+    RAVENSBURGER_IMAGE_SIZE: int = Field(default=1024, gt=0)
     # Per-user, guards GET /api/v1/puzzle/barcode/{ean}. The iOS client
     # debounces to at most one lookup per stable barcode read and caches
     # misses per session, so normal use is a handful of requests per minute;

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -357,14 +357,15 @@ async def detect_frame(
     ],
 )
 async def lookup_barcode(ean: str) -> BarcodeLookupResponse:
-    """Look up a Ravensburger box image by EAN-13 barcode.
+    """Look up a Ravensburger product image by EAN-13 barcode.
 
     Stateless from the caller's perspective: derives candidate article
     numbers from the EAN (see `app.services.ravensburger_lookup`), probes
-    the Ravensburger image CDN concurrently, and returns the first real
-    image (converted webp -> JPEG data URL). Results — hits and misses —
-    are cached in-process so a barcode held in front of the camera doesn't
-    re-probe the CDN.
+    ravensburger.org concurrently, and returns the first real image as a
+    JPEG data URL — the clean puzzle motif when the product has one, else
+    the box shot (see `image_kind`). Results — hits and misses — are
+    cached in-process so a barcode held in front of the camera doesn't
+    re-probe the site.
 
     Requires authentication and is rate-limited per-user (see the route's
     ``dependencies``); doesn't need the caller's identity beyond that.
@@ -373,9 +374,9 @@ async def lookup_barcode(ean: str) -> BarcodeLookupResponse:
         ean: The scanned EAN-13 barcode payload.
 
     Returns:
-        BarcodeLookupResponse with found=True plus the box image and
-        resolved article number, or found=False when the EAN isn't a
-        (known) Ravensburger product.
+        BarcodeLookupResponse with found=True plus the product image, its
+        kind, and the resolved article number, or found=False when the EAN
+        isn't a (known) Ravensburger product.
 
     Raises:
         HTTPException: If the EAN is malformed (400), or the caller has
@@ -390,50 +391,54 @@ async def lookup_barcode(ean: str) -> BarcodeLookupResponse:
         cached = await _resolve_barcode(ean)
         cache.put(ean, cached)
 
-    if not cached.found or cached.box_image_jpeg is None:
+    if not cached.found or cached.image_jpeg is None:
         return BarcodeLookupResponse(found=False)
-    box_image_base64 = base64.b64encode(cached.box_image_jpeg).decode()
+    image_base64 = base64.b64encode(cached.image_jpeg).decode()
     return BarcodeLookupResponse(
         found=True,
-        box_image=f"data:image/jpeg;base64,{box_image_base64}",
+        box_image=f"data:image/jpeg;base64,{image_base64}",
+        image_kind=cached.image_kind,
         article_number=cached.article_number,
     )
 
 
 async def _resolve_barcode(ean: str) -> BarcodeLookupRecord:
-    """Probe the Ravensburger CDN for a valid EAN and build a cacheable record.
+    """Probe ravensburger.org for a valid EAN and build a cacheable record.
 
     Args:
         ean: A checksum-valid EAN-13.
 
     Returns:
-        A BarcodeLookupRecord holding the JPEG-converted box image of the
-        first candidate article number that hit (in preference order), or a
-        miss record when no candidate produced a real image.
+        A BarcodeLookupRecord holding the JPEG-converted product image
+        (motif preferred, box fallback) of the first candidate article
+        number that hit (in preference order), or a miss record when no
+        candidate produced a real image.
     """
     candidates = candidate_article_numbers(ean, settings.RAVENSBURGER_SERIES_PREFIXES)
     if not candidates:
-        return BarcodeLookupRecord(found=False, box_image_jpeg=None, article_number=None)
+        return BarcodeLookupRecord(found=False, image_jpeg=None, image_kind=None, article_number=None)
 
     client = get_ravensburger_client()
-    results = await asyncio.gather(*(client.fetch_box_image(candidate) for candidate in candidates))
-    for candidate, image_bytes in zip(candidates, results):
-        if image_bytes is None:
+    results = await asyncio.gather(*(client.fetch_puzzle_image(candidate) for candidate in candidates))
+    for candidate, fetched in zip(candidates, results):
+        if fetched is None:
             continue
         try:
-            image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+            image = Image.open(io.BytesIO(fetched.content)).convert("RGB")
         except (UnidentifiedImageError, OSError, ValueError):
-            logger.warning("Ravensburger CDN returned an undecodable image for article %s", candidate)
+            logger.warning("ravensburger.org returned an undecodable image for article %s", candidate)
             continue
         buffer = io.BytesIO()
         image.save(buffer, format="JPEG", quality=90)
-        return BarcodeLookupRecord(found=True, box_image_jpeg=buffer.getvalue(), article_number=candidate)
+        return BarcodeLookupRecord(
+            found=True, image_jpeg=buffer.getvalue(), image_kind=fetched.kind, article_number=candidate
+        )
 
     if ean.startswith(RAVENSBURGER_ADULT_PREFIX):
         # Adult-line article numbers aren't fully derivable from the EAN; log
         # all-candidate misses so gaps in RAVENSBURGER_SERIES_PREFIXES surface.
-        logger.info("No box image for adult-line EAN %s (tried series prefixes %s)", ean, candidates)
-    return BarcodeLookupRecord(found=False, box_image_jpeg=None, article_number=None)
+        logger.info("No product image for adult-line EAN %s (tried series prefixes %s)", ean, candidates)
+    return BarcodeLookupRecord(found=False, image_jpeg=None, image_kind=None, article_number=None)
 
 
 @app.post(

--- a/backend/app/models/puzzle_model.py
+++ b/backend/app/models/puzzle_model.py
@@ -167,11 +167,18 @@ class DetectFrameResponse(BaseModel):
 
 
 class BarcodeLookupResponse(BaseModel):
-    """Response model for Ravensburger barcode box-image lookup."""
+    """Response model for Ravensburger barcode product-image lookup."""
 
-    found: bool = Field(..., description="Whether a Ravensburger box image was found for this EAN")
+    found: bool = Field(..., description="Whether a Ravensburger product image was found for this EAN")
     box_image: Optional[str] = Field(
-        default=None, description="Base64 data URL (JPEG) of the box image; present when found"
+        default=None,
+        description=(
+            "Base64 data URL (JPEG) of the product image; present when found. Despite the legacy name, "
+            "this is the clean puzzle motif when available (image_kind='motif') and the box shot otherwise."
+        ),
+    )
+    image_kind: Optional[str] = Field(
+        default=None, description="'motif' (clean puzzle artwork) or 'box' (box-shot fallback); present when found"
     )
     article_number: Optional[str] = Field(
         default=None, description="Resolved Ravensburger article number; present when found"

--- a/backend/app/models/puzzle_model.py
+++ b/backend/app/models/puzzle_model.py
@@ -1,6 +1,6 @@
 """Data models for puzzle-related operations."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -177,7 +177,7 @@ class BarcodeLookupResponse(BaseModel):
             "this is the clean puzzle motif when available (image_kind='motif') and the box shot otherwise."
         ),
     )
-    image_kind: Optional[str] = Field(
+    image_kind: Optional[Literal["motif", "box"]] = Field(
         default=None, description="'motif' (clean puzzle artwork) or 'box' (box-shot fallback); present when found"
     )
     article_number: Optional[str] = Field(

--- a/backend/app/services/barcode_lookup_cache.py
+++ b/backend/app/services/barcode_lookup_cache.py
@@ -21,13 +21,16 @@ class BarcodeLookupRecord:
     """The outcome of one EAN lookup, hit or miss.
 
     Attributes:
-        found: Whether a box image was found for the EAN.
-        box_image_jpeg: The JPEG-converted box image when found, else None.
+        found: Whether a product image was found for the EAN.
+        image_jpeg: The JPEG-converted product image when found, else None.
+        image_kind: "motif" (clean puzzle artwork) or "box" when found,
+            else None.
         article_number: The resolved article number when found, else None.
     """
 
     found: bool
-    box_image_jpeg: Optional[bytes]
+    image_jpeg: Optional[bytes]
+    image_kind: Optional[str]
     article_number: Optional[str]
 
 

--- a/backend/app/services/barcode_lookup_cache.py
+++ b/backend/app/services/barcode_lookup_cache.py
@@ -3,7 +3,7 @@
 Mirrors `app.services.puzzle_store`: an `OrderedDict` capped at `MAX_ENTRIES`
 with oldest-first eviction, exposed through an `@lru_cache()` singleton
 getter. Both hits and misses are cached, so a barcode held in front of the
-camera doesn't re-probe the Ravensburger CDN on every stable read.
+camera doesn't re-probe ravensburger.org on every stable read.
 """
 
 from collections import OrderedDict

--- a/backend/app/services/barcode_lookup_cache.py
+++ b/backend/app/services/barcode_lookup_cache.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import Optional
 
+from app.services.ravensburger_client import ImageKind
+
 # Cap on cached lookups. Each hit holds one ~1000px JPEG (~100-300 KB), so
 # 100 entries bounds memory at a few tens of MB in the worst case.
 MAX_ENTRIES = 100
@@ -30,7 +32,7 @@ class BarcodeLookupRecord:
 
     found: bool
     image_jpeg: Optional[bytes]
-    image_kind: Optional[str]
+    image_kind: Optional[ImageKind]
     article_number: Optional[str]
 
 

--- a/backend/app/services/ravensburger_client.py
+++ b/backend/app/services/ravensburger_client.py
@@ -1,17 +1,24 @@
-"""HTTP client for Ravensburger's public box-image CDN.
+"""HTTP client for Ravensburger's public product-image host.
 
-The CDN serves box art at
-``https://ravensburger.cloud/images/produktseiten/{W}x{H}/{article}.webp``
-keyed by bare article number, at a fixed set of pre-rendered sizes (see
-`Settings.RAVENSBURGER_IMAGE_WIDTH`/`_HEIGHT`). It never 404s: unknown
-articles — and unsupported sizes — get HTTP 200 with a tiny (~458-byte)
-placeholder, so a real hit is distinguished by payload size
-(`Settings.RAVENSBURGER_PLACEHOLDER_MAX_BYTES`), not status.
+The Ravensburger website serves product images as static files at
+``https://www.ravensburger.org/produktseiten/{size}/{article}{suffix}.jpg``
+keyed by bare article number, at a fixed set of pre-rendered size buckets
+(75, 100, 240, 360, 1024 — see `Settings.RAVENSBURGER_IMAGE_SIZE`). The
+suffix selects the shot: no suffix is the box, ``_1`` is the clean puzzle
+motif (the artwork without box, logo, or piece-count text), ``_2``/``_3``
+are lifestyle photos. Misses — unknown articles, absent suffixes,
+unsupported sizes — are genuine HTTP 404s (verified live 2026-07-22),
+unlike the old ravensburger.cloud CDN which answered everything with a
+200 placeholder.
+
+The motif is preferred because it doubles as the reference image for piece
+matching; the box shot is only a fallback for products without a ``_1``.
 """
 
 import logging
+from dataclasses import dataclass
 from functools import lru_cache
-from typing import Optional
+from typing import Literal, Optional
 
 import httpx
 
@@ -19,45 +26,68 @@ from app.config import settings
 
 logger = logging.getLogger(__name__)
 
+MOTIF_SUFFIX = "_1"
+BOX_SUFFIX = ""
+
+ImageKind = Literal["motif", "box"]
+
+# Fetch order: the motif when the product has one, else the box shot.
+_SHOT_ATTEMPTS: tuple[tuple[str, ImageKind], ...] = ((MOTIF_SUFFIX, "motif"), (BOX_SUFFIX, "box"))
+
+
+@dataclass(frozen=True)
+class RavensburgerImage:
+    """A fetched product image and which shot it is.
+
+    Attributes:
+        content: The raw JPEG bytes as served.
+        kind: "motif" for the clean puzzle artwork (``_1``), "box" for the
+            box-shot fallback.
+    """
+
+    content: bytes
+    kind: ImageKind
+
 
 class RavensburgerClient:
-    """Fetches box images from the Ravensburger CDN, treating placeholders as misses."""
+    """Fetches product images from ravensburger.org, preferring the puzzle motif."""
 
-    def cdn_url(self, article_number: str) -> str:
-        """Build the CDN URL for an article number.
+    def image_url(self, article_number: str, suffix: str = BOX_SUFFIX) -> str:
+        """Build the image URL for an article number and shot suffix.
 
         Args:
             article_number: The Ravensburger article number (5 or 8 digits).
+            suffix: The shot selector ("" for the box, "_1" for the motif).
 
         Returns:
-            The image URL at the configured size.
+            The image URL at the configured size bucket.
         """
-        size = f"{settings.RAVENSBURGER_IMAGE_WIDTH}x{settings.RAVENSBURGER_IMAGE_HEIGHT}"
-        return f"https://ravensburger.cloud/images/produktseiten/{size}/{article_number}.webp"
+        size = settings.RAVENSBURGER_IMAGE_SIZE
+        return f"https://www.ravensburger.org/produktseiten/{size}/{article_number}{suffix}.jpg"
 
-    async def fetch_box_image(self, article_number: str) -> Optional[bytes]:
-        """Fetch the box image for an article number, if one exists.
+    async def fetch_puzzle_image(self, article_number: str) -> Optional[RavensburgerImage]:
+        """Fetch the best available product image for an article number.
+
+        Tries the clean puzzle motif (``_1``) first and falls back to the
+        box shot, so a hit on either proves the article exists.
 
         Args:
             article_number: The candidate Ravensburger article number.
 
         Returns:
-            The image bytes (webp) on a real hit, or None when the CDN
-            returns a non-200, a placeholder-sized body, or any transport
-            error/timeout — a miss is never an exception.
+            The motif image when it exists, else the box image, else None
+            when neither exists or on any transport error/timeout — a miss
+            is never an exception.
         """
         try:
             async with httpx.AsyncClient(timeout=settings.RAVENSBURGER_CDN_TIMEOUT_SECONDS) as client:
-                response = await client.get(self.cdn_url(article_number))
+                for suffix, kind in _SHOT_ATTEMPTS:
+                    response = await client.get(self.image_url(article_number, suffix))
+                    if response.status_code == 200 and response.content:
+                        return RavensburgerImage(content=response.content, kind=kind)
         except httpx.HTTPError as exc:
-            logger.warning("Ravensburger CDN fetch failed for article %s: %s", article_number, exc)
-            return None
-
-        if response.status_code != 200:
-            return None
-        if len(response.content) <= settings.RAVENSBURGER_PLACEHOLDER_MAX_BYTES:
-            return None
-        return response.content
+            logger.warning("Ravensburger image fetch failed for article %s: %s", article_number, exc)
+        return None
 
 
 @lru_cache()

--- a/backend/app/services/ravensburger_lookup.py
+++ b/backend/app/services/ravensburger_lookup.py
@@ -1,8 +1,8 @@
 """Pure EAN-13 parsing for Ravensburger barcode lookups (no I/O).
 
 Ravensburger EAN-13 barcodes embed the article number that keys their public
-image CDN (see `app.services.ravensburger_client`). Two GS1 company prefixes
-are in use:
+product images (see `app.services.ravensburger_client`). Two GS1 company
+prefixes are in use:
 
 - ``4005556`` (standard line, e.g. kids puzzles): the 5-digit payload
   (digits 8-12) *is* the full article number. Example: EAN 4005556050093 ->
@@ -10,7 +10,7 @@ are in use:
 - ``4005555`` (adult/1000-piece line): article numbers are 8 digits, and the
   EAN payload carries only their *last 5* digits — the leading 3-digit series
   prefix (e.g. ``120``) is not recoverable from the EAN alone, so callers
-  probe a small list of known series prefixes against the CDN.
+  probe a small list of known series prefixes against ravensburger.org.
 
 Any other prefix is not a Ravensburger product.
 """

--- a/backend/tests/test_barcode_endpoint.py
+++ b/backend/tests/test_barcode_endpoint.py
@@ -125,7 +125,7 @@ class TestBarcodeLookupEndpoint:
         assert body["image_kind"] == "box"
 
     def test_standard_line_miss(self) -> None:
-        """A standard-line EAN whose article has no CDN image returns found=False."""
+        """A standard-line EAN whose article has no product image returns found=False."""
         fake = make_fake_ravensburger_client({})
         with patch("app.main.get_ravensburger_client", return_value=fake):
             response = client.get(f"/api/v1/puzzle/barcode/{FROZEN_EAN}", headers=auth_headers())
@@ -145,7 +145,7 @@ class TestBarcodeLookupEndpoint:
         assert probed == [f"{series}00622" for series in settings.RAVENSBURGER_SERIES_PREFIXES]
 
     def test_non_ravensburger_prefix_never_probes_cdn(self) -> None:
-        """A valid EAN with a foreign GS1 prefix is a miss without any CDN call."""
+        """A valid EAN with a foreign GS1 prefix is a miss without contacting ravensburger.org."""
         fake = make_fake_ravensburger_client({"anything": make_jpeg_bytes()})
         with patch("app.main.get_ravensburger_client", return_value=fake):
             response = client.get(f"/api/v1/puzzle/barcode/{OTHER_BRAND_EAN}", headers=auth_headers())
@@ -154,7 +154,7 @@ class TestBarcodeLookupEndpoint:
         fake.fetch_puzzle_image.assert_not_awaited()
 
     def test_second_lookup_served_from_cache(self) -> None:
-        """Repeating a lookup (hit or miss) doesn't re-probe the CDN."""
+        """Repeating a lookup (hit or miss) doesn't re-probe ravensburger.org."""
         fake = make_fake_ravensburger_client({"05009": make_jpeg_bytes()})
         with patch("app.main.get_ravensburger_client", return_value=fake):
             first = client.get(f"/api/v1/puzzle/barcode/{FROZEN_EAN}", headers=auth_headers())
@@ -164,7 +164,7 @@ class TestBarcodeLookupEndpoint:
         assert fake.fetch_puzzle_image.await_count == 1
 
     def test_undecodable_cdn_image_is_a_miss(self) -> None:
-        """Bytes the CDN returns that aren't a decodable image yield found=False."""
+        """Fetched bytes that aren't a decodable image yield found=False."""
         fake = make_fake_ravensburger_client({"05009": b"not-an-image" * 400})
         with patch("app.main.get_ravensburger_client", return_value=fake):
             response = client.get(f"/api/v1/puzzle/barcode/{FROZEN_EAN}", headers=auth_headers())

--- a/backend/tests/test_barcode_endpoint.py
+++ b/backend/tests/test_barcode_endpoint.py
@@ -10,7 +10,7 @@ Mirrors the token helper in tests/test_rate_limit.py.
 
 import io
 from datetime import datetime, timedelta, timezone
-from typing import Generator, Optional, cast
+from typing import Generator, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import jwt
@@ -56,7 +56,7 @@ def auth_headers(user_id: str = "test-user-id") -> dict[str, str]:
     return {"Authorization": f"Bearer {create_test_token(user_id)}"}
 
 
-def make_fake_ravensburger_client(hit_articles: dict[str, bytes], kind: str = "motif") -> MagicMock:
+def make_fake_ravensburger_client(hit_articles: dict[str, bytes], kind: ImageKind = "motif") -> MagicMock:
     """Build a fake RavensburgerClient hitting only the given article numbers.
 
     Args:
@@ -72,7 +72,7 @@ def make_fake_ravensburger_client(hit_articles: dict[str, bytes], kind: str = "m
         content = hit_articles.get(article_number)
         if content is None:
             return None
-        return RavensburgerImage(content=content, kind=cast(ImageKind, kind))
+        return RavensburgerImage(content=content, kind=kind)
 
     fake = MagicMock()
     fake.fetch_puzzle_image = AsyncMock(side_effect=fetch_puzzle_image)

--- a/backend/tests/test_barcode_endpoint.py
+++ b/backend/tests/test_barcode_endpoint.py
@@ -1,7 +1,7 @@
-"""Tests for GET /api/v1/puzzle/barcode/{ean} (Ravensburger box-image lookup).
+"""Tests for GET /api/v1/puzzle/barcode/{ean} (Ravensburger product-image lookup).
 
-The Ravensburger CDN is never contacted: `app.main.get_ravensburger_client`
-is patched with a fake whose `fetch_box_image` is an AsyncMock. The
+ravensburger.org is never contacted: `app.main.get_ravensburger_client` is
+patched with a fake whose `fetch_puzzle_image` is an AsyncMock. The
 process-global lookup cache singleton is cleared around every test so cached
 hits/misses can't leak between tests.
 
@@ -10,7 +10,7 @@ Mirrors the token helper in tests/test_rate_limit.py.
 
 import io
 from datetime import datetime, timedelta, timezone
-from typing import Generator, Optional
+from typing import Generator, Optional, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import jwt
@@ -21,6 +21,7 @@ from PIL import Image
 from app.config import settings
 from app.main import app
 from app.services.barcode_lookup_cache import get_barcode_lookup_cache
+from app.services.ravensburger_client import ImageKind, RavensburgerImage
 
 client = TestClient(app)
 
@@ -29,11 +30,11 @@ ADULT_EAN = "4005555006220"  # adult line, payload 00622, article 12000622
 OTHER_BRAND_EAN = "4006381333931"  # valid checksum, non-Ravensburger prefix
 
 
-def make_webp_bytes() -> bytes:
-    """Create a tiny in-memory webp standing in for a real CDN box image."""
+def make_jpeg_bytes() -> bytes:
+    """Create a tiny in-memory JPEG standing in for a real product image."""
     image = Image.new("RGB", (64, 64), (30, 60, 120))
     buffer = io.BytesIO()
-    image.save(buffer, format="WEBP")
+    image.save(buffer, format="JPEG")
     return buffer.getvalue()
 
 
@@ -55,21 +56,26 @@ def auth_headers(user_id: str = "test-user-id") -> dict[str, str]:
     return {"Authorization": f"Bearer {create_test_token(user_id)}"}
 
 
-def make_fake_ravensburger_client(hit_articles: dict[str, bytes]) -> MagicMock:
+def make_fake_ravensburger_client(hit_articles: dict[str, bytes], kind: str = "motif") -> MagicMock:
     """Build a fake RavensburgerClient hitting only the given article numbers.
 
     Args:
         hit_articles: Article number -> image bytes for articles that exist.
+        kind: The image kind ("motif" or "box") every hit reports.
 
     Returns:
-        A MagicMock whose async `fetch_box_image` resolves per `hit_articles`.
+        A MagicMock whose async `fetch_puzzle_image` resolves per
+        `hit_articles`.
     """
 
-    async def fetch_box_image(article_number: str) -> Optional[bytes]:
-        return hit_articles.get(article_number)
+    async def fetch_puzzle_image(article_number: str) -> Optional[RavensburgerImage]:
+        content = hit_articles.get(article_number)
+        if content is None:
+            return None
+        return RavensburgerImage(content=content, kind=cast(ImageKind, kind))
 
     fake = MagicMock()
-    fake.fetch_box_image = AsyncMock(side_effect=fetch_box_image)
+    fake.fetch_puzzle_image = AsyncMock(side_effect=fetch_puzzle_image)
     return fake
 
 
@@ -97,7 +103,7 @@ class TestBarcodeLookupEndpoint:
 
     def test_standard_line_hit(self) -> None:
         """A standard-line EAN resolves to its payload article with a JPEG data URL."""
-        fake = make_fake_ravensburger_client({"05009": make_webp_bytes()})
+        fake = make_fake_ravensburger_client({"05009": make_jpeg_bytes()})
         with patch("app.main.get_ravensburger_client", return_value=fake):
             response = client.get(f"/api/v1/puzzle/barcode/{FROZEN_EAN}", headers=auth_headers())
         assert response.status_code == 200
@@ -105,7 +111,18 @@ class TestBarcodeLookupEndpoint:
         assert body["found"] is True
         assert body["article_number"] == "05009"
         assert body["box_image"].startswith("data:image/jpeg;base64,")
-        fake.fetch_box_image.assert_awaited_once_with("05009")
+        assert body["image_kind"] == "motif"
+        fake.fetch_puzzle_image.assert_awaited_once_with("05009")
+
+    def test_box_fallback_kind_reported(self) -> None:
+        """When only the box shot exists, the response reports image_kind='box'."""
+        fake = make_fake_ravensburger_client({"05009": make_jpeg_bytes()}, kind="box")
+        with patch("app.main.get_ravensburger_client", return_value=fake):
+            response = client.get(f"/api/v1/puzzle/barcode/{FROZEN_EAN}", headers=auth_headers())
+        assert response.status_code == 200
+        body = response.json()
+        assert body["found"] is True
+        assert body["image_kind"] == "box"
 
     def test_standard_line_miss(self) -> None:
         """A standard-line EAN whose article has no CDN image returns found=False."""
@@ -113,38 +130,38 @@ class TestBarcodeLookupEndpoint:
         with patch("app.main.get_ravensburger_client", return_value=fake):
             response = client.get(f"/api/v1/puzzle/barcode/{FROZEN_EAN}", headers=auth_headers())
         assert response.status_code == 200
-        assert response.json() == {"found": False, "box_image": None, "article_number": None}
+        assert response.json() == {"found": False, "box_image": None, "image_kind": None, "article_number": None}
 
     def test_adult_line_probes_series_prefixes(self) -> None:
         """An adult-line EAN probes series candidates and resolves the hit's article."""
-        fake = make_fake_ravensburger_client({"12000622": make_webp_bytes()})
+        fake = make_fake_ravensburger_client({"12000622": make_jpeg_bytes()})
         with patch("app.main.get_ravensburger_client", return_value=fake):
             response = client.get(f"/api/v1/puzzle/barcode/{ADULT_EAN}", headers=auth_headers())
         assert response.status_code == 200
         body = response.json()
         assert body["found"] is True
         assert body["article_number"] == "12000622"
-        probed = [call.args[0] for call in fake.fetch_box_image.await_args_list]
+        probed = [call.args[0] for call in fake.fetch_puzzle_image.await_args_list]
         assert probed == [f"{series}00622" for series in settings.RAVENSBURGER_SERIES_PREFIXES]
 
     def test_non_ravensburger_prefix_never_probes_cdn(self) -> None:
         """A valid EAN with a foreign GS1 prefix is a miss without any CDN call."""
-        fake = make_fake_ravensburger_client({"anything": make_webp_bytes()})
+        fake = make_fake_ravensburger_client({"anything": make_jpeg_bytes()})
         with patch("app.main.get_ravensburger_client", return_value=fake):
             response = client.get(f"/api/v1/puzzle/barcode/{OTHER_BRAND_EAN}", headers=auth_headers())
         assert response.status_code == 200
         assert response.json()["found"] is False
-        fake.fetch_box_image.assert_not_awaited()
+        fake.fetch_puzzle_image.assert_not_awaited()
 
     def test_second_lookup_served_from_cache(self) -> None:
         """Repeating a lookup (hit or miss) doesn't re-probe the CDN."""
-        fake = make_fake_ravensburger_client({"05009": make_webp_bytes()})
+        fake = make_fake_ravensburger_client({"05009": make_jpeg_bytes()})
         with patch("app.main.get_ravensburger_client", return_value=fake):
             first = client.get(f"/api/v1/puzzle/barcode/{FROZEN_EAN}", headers=auth_headers())
             second = client.get(f"/api/v1/puzzle/barcode/{FROZEN_EAN}", headers=auth_headers())
         assert first.status_code == second.status_code == 200
         assert first.json() == second.json()
-        assert fake.fetch_box_image.await_count == 1
+        assert fake.fetch_puzzle_image.await_count == 1
 
     def test_undecodable_cdn_image_is_a_miss(self) -> None:
         """Bytes the CDN returns that aren't a decodable image yield found=False."""

--- a/backend/tests/test_barcode_lookup_cache.py
+++ b/backend/tests/test_barcode_lookup_cache.py
@@ -2,8 +2,8 @@
 
 from app.services.barcode_lookup_cache import MAX_ENTRIES, BarcodeLookupCache, BarcodeLookupRecord
 
-HIT = BarcodeLookupRecord(found=True, box_image_jpeg=b"jpeg-bytes", article_number="05009")
-MISS = BarcodeLookupRecord(found=False, box_image_jpeg=None, article_number=None)
+HIT = BarcodeLookupRecord(found=True, image_jpeg=b"jpeg-bytes", image_kind="motif", article_number="05009")
+MISS = BarcodeLookupRecord(found=False, image_jpeg=None, image_kind=None, article_number=None)
 
 
 class TestBarcodeLookupCache:

--- a/backend/tests/test_ravensburger_client.py
+++ b/backend/tests/test_ravensburger_client.py
@@ -1,9 +1,10 @@
-"""Tests for the Ravensburger CDN client (app/services/ravensburger_client.py).
+"""Tests for the Ravensburger image client (app/services/ravensburger_client.py).
 
-The CDN is never contacted: `httpx.AsyncClient` is replaced with a mock
-supporting the async-context-manager protocol, per the suite's convention of
-mocking at the outbound boundary with unittest.mock (no respx). The suite has
-no pytest-asyncio, so async methods are driven with `asyncio.run`.
+ravensburger.org is never contacted: `httpx.AsyncClient` is replaced with a
+mock supporting the async-context-manager protocol, per the suite's
+convention of mocking at the outbound boundary with unittest.mock (no respx).
+The suite has no pytest-asyncio, so async methods are driven with
+`asyncio.run`.
 """
 
 import asyncio
@@ -13,17 +14,18 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 
 from app.config import settings
-from app.services.ravensburger_client import RavensburgerClient
+from app.services.ravensburger_client import RavensburgerClient, RavensburgerImage
 
-REAL_IMAGE_BYTES = b"x" * (settings.RAVENSBURGER_PLACEHOLDER_MAX_BYTES + 1)
-PLACEHOLDER_BYTES = b"x" * 458
+MOTIF_BYTES = b"motif-jpeg-bytes"
+BOX_BYTES = b"box-jpeg-bytes"
+NOT_FOUND = MagicMock(status_code=404, content=b"")
 
 
-def mock_async_client(response: Optional[MagicMock] = None, exc: Optional[Exception] = None) -> MagicMock:
+def mock_async_client(responses: Optional[list[MagicMock]] = None, exc: Optional[Exception] = None) -> MagicMock:
     """Build a stand-in for the httpx.AsyncClient class.
 
     Args:
-        response: The response `get()` should resolve to.
+        responses: The responses successive `get()` calls should resolve to.
         exc: An exception `get()` should raise instead.
 
     Returns:
@@ -31,15 +33,15 @@ def mock_async_client(response: Optional[MagicMock] = None, exc: Optional[Except
         whose instances work as async context managers.
     """
     inner = MagicMock()
-    inner.get = AsyncMock(side_effect=exc) if exc else AsyncMock(return_value=response)
+    inner.get = AsyncMock(side_effect=exc) if exc else AsyncMock(side_effect=responses)
     context_manager = MagicMock()
     context_manager.__aenter__ = AsyncMock(return_value=inner)
     context_manager.__aexit__ = AsyncMock(return_value=False)
     return MagicMock(return_value=context_manager)
 
 
-def fetch(article_number: str) -> Optional[bytes]:
-    """Run fetch_box_image synchronously.
+def fetch(article_number: str) -> Optional[RavensburgerImage]:
+    """Run fetch_puzzle_image synchronously.
 
     Args:
         article_number: The article number to fetch.
@@ -47,28 +49,34 @@ def fetch(article_number: str) -> Optional[bytes]:
     Returns:
         The fetch result.
     """
-    return asyncio.run(RavensburgerClient().fetch_box_image(article_number))
+    return asyncio.run(RavensburgerClient().fetch_puzzle_image(article_number))
 
 
-class TestFetchBoxImage:
-    """Hit/miss behavior of RavensburgerClient.fetch_box_image."""
+class TestFetchPuzzleImage:
+    """Hit/miss and fallback behavior of RavensburgerClient.fetch_puzzle_image."""
 
-    def test_real_image_returned(self) -> None:
-        """A 200 with a body above the placeholder threshold is a hit."""
-        response = MagicMock(status_code=200, content=REAL_IMAGE_BYTES)
-        with patch("app.services.ravensburger_client.httpx.AsyncClient", mock_async_client(response)):
-            assert fetch("05009") == REAL_IMAGE_BYTES
+    def test_motif_returned_when_present(self) -> None:
+        """A 200 on the _1 motif URL is a hit; the box URL is never tried."""
+        response = MagicMock(status_code=200, content=MOTIF_BYTES)
+        constructor = mock_async_client([response])
+        with patch("app.services.ravensburger_client.httpx.AsyncClient", constructor):
+            assert fetch("12000877") == RavensburgerImage(content=MOTIF_BYTES, kind="motif")
 
-    def test_placeholder_sized_body_is_a_miss(self) -> None:
-        """A 200 with a placeholder-sized body (unknown article) is a miss."""
-        response = MagicMock(status_code=200, content=PLACEHOLDER_BYTES)
-        with patch("app.services.ravensburger_client.httpx.AsyncClient", mock_async_client(response)):
+    def test_falls_back_to_box_when_motif_missing(self) -> None:
+        """A 404 on the motif falls back to the box shot."""
+        box = MagicMock(status_code=200, content=BOX_BYTES)
+        with patch("app.services.ravensburger_client.httpx.AsyncClient", mock_async_client([NOT_FOUND, box])):
+            assert fetch("05009") == RavensburgerImage(content=BOX_BYTES, kind="box")
+
+    def test_unknown_article_is_a_miss(self) -> None:
+        """404s on both the motif and box URLs (unknown article) are a miss."""
+        with patch("app.services.ravensburger_client.httpx.AsyncClient", mock_async_client([NOT_FOUND, NOT_FOUND])):
             assert fetch("99999") is None
 
-    def test_non_200_is_a_miss(self) -> None:
-        """Non-200 statuses are misses regardless of body size."""
-        response = MagicMock(status_code=503, content=REAL_IMAGE_BYTES)
-        with patch("app.services.ravensburger_client.httpx.AsyncClient", mock_async_client(response)):
+    def test_empty_body_is_a_miss(self) -> None:
+        """A 200 with an empty body is not treated as an image."""
+        empty = MagicMock(status_code=200, content=b"")
+        with patch("app.services.ravensburger_client.httpx.AsyncClient", mock_async_client([empty, empty])):
             assert fetch("05009") is None
 
     def test_timeout_is_a_miss(self) -> None:
@@ -83,8 +91,22 @@ class TestFetchBoxImage:
         with patch("app.services.ravensburger_client.httpx.AsyncClient", constructor):
             assert fetch("05009") is None
 
-    def test_cdn_url_uses_configured_size(self) -> None:
-        """The CDN URL embeds the configured dimensions and the article number."""
-        assert RavensburgerClient().cdn_url("05009") == (
-            "https://ravensburger.cloud/images/produktseiten/520x445/05009.webp"
-        )
+    def test_requests_motif_then_box_urls(self) -> None:
+        """The motif (_1) URL is requested first, the bare box URL second."""
+        constructor = mock_async_client([NOT_FOUND, NOT_FOUND])
+        with patch("app.services.ravensburger_client.httpx.AsyncClient", constructor):
+            fetch("12000877")
+        inner = constructor.return_value.__aenter__.return_value
+        requested = [call.args[0] for call in inner.get.await_args_list]
+        size = settings.RAVENSBURGER_IMAGE_SIZE
+        assert requested == [
+            f"https://www.ravensburger.org/produktseiten/{size}/12000877_1.jpg",
+            f"https://www.ravensburger.org/produktseiten/{size}/12000877.jpg",
+        ]
+
+    def test_image_url_uses_configured_size_bucket(self) -> None:
+        """The image URL embeds the configured size bucket and the article number."""
+        with patch.object(settings, "RAVENSBURGER_IMAGE_SIZE", 360):
+            assert RavensburgerClient().image_url("05009", "_1") == (
+                "https://www.ravensburger.org/produktseiten/360/05009_1.jpg"
+            )

--- a/backend/tests/test_ravensburger_client.py
+++ b/backend/tests/test_ravensburger_client.py
@@ -26,14 +26,16 @@ def mock_async_client(responses: Optional[list[MagicMock]] = None, exc: Optional
 
     Args:
         responses: The responses successive `get()` calls should resolve to.
+            Exactly one of `responses` and `exc` must be provided.
         exc: An exception `get()` should raise instead.
 
     Returns:
         A MagicMock usable as a replacement for the AsyncClient constructor,
         whose instances work as async context managers.
     """
+    assert (responses is None) != (exc is None), "provide exactly one of responses/exc"
     inner = MagicMock()
-    inner.get = AsyncMock(side_effect=exc) if exc else AsyncMock(side_effect=responses)
+    inner.get = AsyncMock(side_effect=exc if exc is not None else responses)
     context_manager = MagicMock()
     context_manager.__aenter__ = AsyncMock(return_value=inner)
     context_manager.__aexit__ = AsyncMock(return_value=False)


### PR DESCRIPTION
## Summary

The barcode auto-lookup previously returned the **box shot** from the ravensburger.cloud CDN (max 520×445, misses detected by sniffing a ~458-byte 200-placeholder). This PR switches the client to www.ravensburger.org's static image buckets, which serve the **clean puzzle motif** — the artwork without box, logo, or piece-count text — at up to 1024px, exactly the reference image piece matching wants.

- `RavensburgerClient.fetch_puzzle_image()` tries `produktseiten/1024/{article}_1.jpg` (motif) first and falls back to the bare box URL; misses are genuine HTTP 404s, so the placeholder-size heuristic is gone.
- Config: `RAVENSBURGER_IMAGE_WIDTH/_HEIGHT` and `RAVENSBURGER_PLACEHOLDER_MAX_BYTES` replaced by `RAVENSBURGER_IMAGE_SIZE` (default 1024 — the largest bucket the site serves; only 75/100/240/360/1024 exist).
- `GET /api/v1/puzzle/barcode/{ean}` now includes `image_kind` (`"motif"` or `"box"`). The `box_image` field name is unchanged for iOS compatibility (Swift Codable ignores the new field).

URL scheme verified live 2026-07-22 across 13 products (adult 8-digit and legacy 5-digit articles): `_1` is consistently the motif; base is always the box; unknown articles/suffixes/sizes 404.

## Testing

- `make check-backend` clean (black, isort, flake8, pyright)
- Full backend suite: 314 passed, including rewritten client tests (motif hit, box fallback, URL order, 404/timeout misses) and new `image_kind` endpoint assertions
- Live smoke test: article 12000877 → motif 143 KB, 05009 → motif 107 KB, 99999999 → miss

🤖 Generated with [Claude Code](https://claude.com/claude-code)