### PR TITLE
Fix box barcode scanning for rotated barcodes

### DIFF
--- a/ios/Pussel/Features/Capture/BarcodeDetector.swift
+++ b/ios/Pussel/Features/Capture/BarcodeDetector.swift
@@ -7,8 +7,8 @@ struct EAN13Detection: Equatable {
   /// The 13-digit barcode payload.
   let payload: String
   /// Vision's normalized bounding box of the barcode within the frame
-  /// (bottom-left origin, [0,1]); only its width is used, as a proxy for
-  /// "close enough to trust the read".
+  /// (bottom-left origin, [0,1]); only its long side is used, as a proxy
+  /// for "close enough to trust the read".
   let boundingBox: CGRect
 }
 
@@ -25,16 +25,19 @@ struct EAN13Detection: Equatable {
 /// Called from `BarcodeScanStreamer`'s background task, never the main
 /// thread.
 final class BarcodeDetector: Sendable {
-  /// Detections whose bounding box spans less than this fraction of the
-  /// frame width are ignored: EAN-13's fine bar modules need several pixels
-  /// each to resolve, and far-away reads are where misreads live.
-  static let minBoundingBoxWidth: CGFloat = 0.15
+  /// Detections whose bounding box's long side spans less than this
+  /// fraction of the frame are ignored: EAN-13's fine bar modules need
+  /// several pixels each to resolve, and far-away reads are where misreads
+  /// live. The long side is the barcode's bar-to-bar axis whichever way the
+  /// code is rotated — for a vertical barcode the box is narrow and tall,
+  /// so gating on width alone would reject every rotated read.
+  static let minBoundingBoxLongSide: CGFloat = 0.15
 
   /// Reads an EAN-13 from an upright frame, or nil when none is legible.
   ///
   /// Only payloads that pass the local checksum (`EAN13.isValidChecksum`)
-  /// and the `minBoundingBoxWidth` size gate are returned; a failed Vision
-  /// request throws and the caller drops the frame.
+  /// and the `minBoundingBoxLongSide` size gate are returned; a failed
+  /// Vision request throws and the caller drops the frame.
   func detect(cgImage: CGImage) throws -> EAN13Detection? {
     let request = VNDetectBarcodesRequest()
     request.revision = VNDetectBarcodesRequestRevision1
@@ -45,7 +48,8 @@ final class BarcodeDetector: Sendable {
     for observation in observations {
       guard let payload = observation.payloadStringValue,
         EAN13.isValidChecksum(payload),
-        observation.boundingBox.width >= Self.minBoundingBoxWidth
+        max(observation.boundingBox.width, observation.boundingBox.height)
+          >= Self.minBoundingBoxLongSide
       else { continue }
       return EAN13Detection(payload: payload, boundingBox: observation.boundingBox)
     }

--- a/ios/PusselTests/BarcodeDetectorTests.swift
+++ b/ios/PusselTests/BarcodeDetectorTests.swift
@@ -60,7 +60,12 @@ final class BarcodeDetectorTests: XCTestCase {
 
   /// The 95-module bar pattern (1 = dark) for a 13-digit payload.
   private static func modules(for payload: String) -> String {
-    let digits = payload.compactMap { $0.wholeNumberValue }
+    let digits = payload.map { character -> Int in
+      guard let digit = character.wholeNumberValue, (0...9).contains(digit) else {
+        preconditionFailure("payload must be 13 digits")
+      }
+      return digit
+    }
     precondition(digits.count == 13, "payload must be 13 digits")
     var bits = "101"
     for (index, parity) in parities[digits[0]].enumerated() {

--- a/ios/PusselTests/BarcodeDetectorTests.swift
+++ b/ios/PusselTests/BarcodeDetectorTests.swift
@@ -1,0 +1,118 @@
+import CoreGraphics
+import XCTest
+
+@testable import Pussel
+
+/// End-to-end tests for `BarcodeDetector` against synthetically rendered
+/// EAN-13 codes — the renderer below draws the real L/G/R module pattern, so
+/// these run the actual Vision request (revision 1, classic CV, available in
+/// the test host) rather than mocking it. The rotated cases are the
+/// regression tests for the vertical-barcode bug: Vision decodes a rotated
+/// EAN-13 fine, but reports a narrow-and-tall bounding box, which the old
+/// width-only size gate rejected.
+final class BarcodeDetectorTests: XCTestCase {
+  /// The Frozen II 2x12 box code used across the barcode tests.
+  private let payload = "4005556050093"
+
+  private let detector = BarcodeDetector()
+
+  func testDetectsHorizontalBarcode() throws {
+    let frame = try XCTUnwrap(
+      Self.renderFrame(payload: payload, rotatedDegrees: 0, barcodeFraction: 0.6))
+    let detection = try detector.detect(cgImage: frame)
+    XCTAssertEqual(detection?.payload, payload)
+  }
+
+  func testDetectsRotatedBarcodes() throws {
+    for degrees in [90, 180, 270] {
+      let frame = try XCTUnwrap(
+        Self.renderFrame(payload: payload, rotatedDegrees: degrees, barcodeFraction: 0.6))
+      let detection = try detector.detect(cgImage: frame)
+      XCTAssertEqual(detection?.payload, payload, "no detection at \(degrees) degrees")
+    }
+  }
+
+  func testFarAwayBarcodeRejectedBySizeGate() throws {
+    // Well below minBoundingBoxLongSide in both orientations: decodable in a
+    // clean synthetic render, but too small to trust from a real camera.
+    for degrees in [0, 90] {
+      let frame = try XCTUnwrap(
+        Self.renderFrame(payload: payload, rotatedDegrees: degrees, barcodeFraction: 0.1))
+      XCTAssertNil(try detector.detect(cgImage: frame), "size gate passed at \(degrees) degrees")
+    }
+  }
+
+  // MARK: - EAN-13 rendering
+
+  /// Standard EAN-13 left-odd (L) digit patterns; R is L complemented, G is
+  /// R reversed.
+  private static let lCodes = [
+    "0001101", "0011001", "0010011", "0111101", "0100011",
+    "0110001", "0101111", "0111011", "0110111", "0001011",
+  ]
+  private static let rCodes = lCodes.map { String($0.map { $0 == "0" ? "1" : "0" }) }
+  private static let gCodes = rCodes.map { String($0.reversed()) }
+  /// First-digit parity patterns for the left half.
+  private static let parities = [
+    "LLLLLL", "LLGLGG", "LLGGLG", "LLGGGL", "LGLLGG",
+    "LGGLLG", "LGGGLL", "LGLGLG", "LGLGGL", "LGGLGL",
+  ]
+
+  /// The 95-module bar pattern (1 = dark) for a 13-digit payload.
+  private static func modules(for payload: String) -> String {
+    let digits = payload.compactMap { $0.wholeNumberValue }
+    precondition(digits.count == 13, "payload must be 13 digits")
+    var bits = "101"
+    for (index, parity) in parities[digits[0]].enumerated() {
+      let digit = digits[1 + index]
+      bits += parity == "L" ? lCodes[digit] : gCodes[digit]
+    }
+    bits += "01010"
+    for digit in digits[7...] {
+      bits += rCodes[digit]
+    }
+    return bits + "101"
+  }
+
+  /// Renders `payload` as an EAN-13 centered in a portrait 810x1080 frame
+  /// (matching the downscaled camera frame's shape), rotated by
+  /// `rotatedDegrees`, with the barcode's bar-to-bar axis spanning
+  /// `barcodeFraction` of the frame width before rotation.
+  private static func renderFrame(
+    payload: String, rotatedDegrees: Int, barcodeFraction: CGFloat
+  ) -> CGImage? {
+    let frameWidth = 810
+    let frameHeight = 1080
+    guard
+      let context = CGContext(
+        data: nil, width: frameWidth, height: frameHeight, bitsPerComponent: 8, bytesPerRow: 0,
+        space: CGColorSpaceCreateDeviceRGB(), bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue)
+    else { return nil }
+    // A light non-white background so the barcode's quiet zone is distinct.
+    context.setFillColor(red: 0.9, green: 0.9, blue: 0.85, alpha: 1)
+    context.fill(CGRect(x: 0, y: 0, width: frameWidth, height: frameHeight))
+
+    let bits = modules(for: payload)
+    let barcodeLength = barcodeFraction * CGFloat(frameWidth)
+    let moduleWidth = barcodeLength / CGFloat(bits.count)
+    let barcodeHeight = barcodeLength * 0.4
+
+    context.saveGState()
+    context.translateBy(x: CGFloat(frameWidth) / 2, y: CGFloat(frameHeight) / 2)
+    context.rotate(by: CGFloat(rotatedDegrees) * .pi / 180)
+    context.setFillColor(red: 1, green: 1, blue: 1, alpha: 1)
+    context.fill(
+      CGRect(
+        x: -barcodeLength / 2 - 10 * moduleWidth, y: -barcodeHeight / 2 - 8,
+        width: barcodeLength + 20 * moduleWidth, height: barcodeHeight + 16))
+    context.setFillColor(red: 0, green: 0, blue: 0, alpha: 1)
+    for (index, bit) in bits.enumerated() where bit == "1" {
+      context.fill(
+        CGRect(
+          x: -barcodeLength / 2 + CGFloat(index) * moduleWidth, y: -barcodeHeight / 2,
+          width: moduleWidth, height: barcodeHeight))
+    }
+    context.restoreGState()
+    return context.makeImage()
+  }
+}


### PR DESCRIPTION
## What changed

The live box-capture barcode scanner only fired when the EAN-13 was horizontal in the frame. The root cause was not Vision: revision 1 of `VNDetectBarcodesRequest` decodes rotated barcodes fine, but for a vertical code it reports a narrow-and-tall axis-aligned bounding box (observed widths as low as 0.004 of the frame), so the width-only "close enough to trust" size gate in `BarcodeDetector` silently discarded every vertical read.

The gate now checks the bounding box's **long side** (`max(width, height) >= 0.15`) — the bar-to-bar axis whichever way the code is rotated — and the constant is renamed `minBoundingBoxWidth` → `minBoundingBoxLongSide`. Nothing downstream consumes the bounding box, so the change is fully contained in the detector.

## Tests

New `BarcodeDetectorTests` render a real EAN-13 (proper L/G/R module encoding of the Frozen II code used by the other barcode tests) into a portrait frame and run the actual Vision request in the test host:

- horizontal read decodes (sanity),
- 90°/180°/270° reads decode — the regression; these fail under the old width-only gate,
- a far-away barcode is still rejected in both orientations, preserving the misread protection the gate exists for.

All 186 iOS tests pass (`make ios-test`); `make check-ios` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)