### PR TITLE
feat(ios): guided glare-free puzzle capture with ARKit world-anchored guidance

### DIFF
--- a/ios/Pussel/App/AppFlow.swift
+++ b/ios/Pussel/App/AppFlow.swift
@@ -83,6 +83,10 @@ final class AppFlowStore {
     /// `pusseldebug://boxcamera` can drive the barcode capture flow there —
     /// mirrors `SolveSession.debugCameraOpen` for the piece camera.
     var debugBoxCameraOpen = false
+    /// Forces CapturePuzzleView's glare-free capture cover open on the
+    /// Simulator, so `pusseldebug://glarecamera` + `glareshot` can drive
+    /// the five-shot flow there — mirrors `debugBoxCameraOpen`.
+    var debugGlareCameraOpen = false
   #endif
 
   func reset() {

--- a/ios/Pussel/Features/Capture/BoxCameraSession.swift
+++ b/ios/Pussel/Features/Capture/BoxCameraSession.swift
@@ -4,8 +4,9 @@ import UIKit
 
 /// Persistent camera session for the live box-capture screen: a manual
 /// shutter for photographing the puzzle box, plus a live low-res frame
-/// stream that feeds `BarcodeScanStreamer` so a box barcode held in view is
-/// read and looked up automatically. Device-only for the photo/streaming
+/// stream that feeds the attached `LiveFrameConsumer` — the barcode
+/// streamer on the box screen, the glare-guide tracker on the glare-free
+/// screen. Device-only for the photo/streaming
 /// path — on the Simulator `isCameraAvailable` is false and the UI falls
 /// back to PhotosPicker (the DEBUG preview loop below is the Simulator's
 /// stand-in for live frames; see `startDebugPreviewLoop`).
@@ -41,9 +42,9 @@ final class BoxCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
   private let videoQueue = DispatchQueue(label: "dk.delectosoft.pussel.box-camera.video")
   /// videoQueue-confined.
   private var isStreaming = false
-  /// videoQueue-confined. `BarcodeScanStreamer` itself is thread-safe for
-  /// the calls made here (see its doc comment).
-  private weak var barcodeStreamer: BarcodeScanStreamer?
+  /// videoQueue-confined. Consumers themselves are thread-safe for the
+  /// calls made here (see `LiveFrameConsumer`).
+  private weak var frameConsumer: (any LiveFrameConsumer)?
   private static let ciContext = CIContext()
 
   /// Long side, in pixels, live frames are downscaled to before barcode
@@ -52,15 +53,17 @@ final class BoxCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
   /// go straight into decode reliability at arm's length.
   private static let frameMaxLongSide: CGFloat = 1080
 
-  /// Wires the streamer this session forwards frames to. Call once after
-  /// creating the session (before `start()`), from the main actor.
-  func attachBarcodeStreamer(_ streamer: BarcodeScanStreamer) {
+  /// Wires the consumer this session forwards frames to — the barcode
+  /// streamer or the glare-guide tracker, depending on the presenting
+  /// screen. Call once after creating the session (before `start()`), from
+  /// the main actor.
+  func attachFrameConsumer(_ consumer: any LiveFrameConsumer) {
     videoQueue.async { [weak self] in
-      self?.barcodeStreamer = streamer
+      self?.frameConsumer = consumer
     }
   }
 
-  /// Starts/stops forwarding camera frames to the barcode streamer. The
+  /// Starts/stops forwarding camera frames to the frame consumer. The
   /// capture view pauses this during photo capture (see `capturePhoto()`)
   /// and while it isn't visible.
   func setStreamingEnabled(_ enabled: Bool) {
@@ -243,13 +246,13 @@ final class BoxCameraSession: NSObject, AVCapturePhotoCaptureDelegate {
 
     private func feedDebugFrame(_ ciImage: CIImage) {
       videoQueue.async { [weak self] in
-        guard let self, self.isStreaming, let barcodeStreamer = self.barcodeStreamer else {
+        guard let self, self.isStreaming, let frameConsumer = self.frameConsumer else {
           return
         }
         let now = Date()
-        guard barcodeStreamer.shouldAcceptFrame(now: now) else { return }
+        guard frameConsumer.shouldAcceptFrame(now: now) else { return }
         guard let frame = Self.downscaledFrame(ciImage: ciImage) else { return }
-        barcodeStreamer.submit(cgImage: frame, now: now)
+        frameConsumer.submit(cgImage: frame, now: now)
       }
     }
   #endif
@@ -262,14 +265,14 @@ extension BoxCameraSession: AVCaptureVideoDataOutputSampleBufferDelegate {
     _ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer,
     from connection: AVCaptureConnection
   ) {
-    guard isStreaming, let barcodeStreamer,
+    guard isStreaming, let frameConsumer,
       let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
     else { return }
     let now = Date()
-    guard barcodeStreamer.shouldAcceptFrame(now: now) else { return }
+    guard frameConsumer.shouldAcceptFrame(now: now) else { return }
     guard let frame = Self.downscaledFrame(ciImage: CIImage(cvPixelBuffer: pixelBuffer)) else {
       return
     }
-    barcodeStreamer.submit(cgImage: frame, now: now)
+    frameConsumer.submit(cgImage: frame, now: now)
   }
 }

--- a/ios/Pussel/Features/Capture/BoxCameraView.swift
+++ b/ios/Pussel/Features/Capture/BoxCameraView.swift
@@ -56,7 +56,7 @@ struct BoxCameraView: View {
       streamer.onDetection = { [weak controller] detection in
         controller?.ingest(detection)
       }
-      camera.attachBarcodeStreamer(streamer)
+      camera.attachFrameConsumer(streamer)
       let started = await camera.start()
       // Dismissed while the permission prompt was up — the user left on
       // purpose, so there is nothing to complain about.

--- a/ios/Pussel/Features/Capture/CapturePuzzleView.swift
+++ b/ios/Pussel/Features/Capture/CapturePuzzleView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct CapturePuzzleView: View {
   @Environment(AppModel.self) private var model
   @State private var showCamera = false
+  @State private var showGlareCamera = false
   @State private var showLibrary = false
   @State private var photoItem: PhotosPickerItem?
 
@@ -31,6 +32,13 @@ struct CapturePuzzleView: View {
         },
         onBarcodeJPEG: { jpeg in
           model.startTrimFromBarcodeLookup(jpeg: jpeg)
+        }
+      )
+    }
+    .fullScreenCover(isPresented: glareCoverIsPresented) {
+      GlareFreeCaptureView(
+        onImage: { image in
+          Task { await handle(image: image, source: .camera) }
         }
       )
     }
@@ -83,6 +91,16 @@ struct CapturePuzzleView: View {
             .controlSize(.large)
           }
           if BoxCameraSession.isCameraAvailable {
+            // Experimental multi-shot capture for glossy puzzles — see
+            // GlareFreeCaptureView.
+            Button {
+              showGlareCamera = true
+            } label: {
+              Label("Glare-Free Scan", systemImage: "sparkles")
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.large)
             photoLibraryButton.buttonStyle(.bordered)
           } else {
             photoLibraryButton.buttonStyle(.borderedProminent)
@@ -154,6 +172,22 @@ struct CapturePuzzleView: View {
       )
     #else
       $showCamera
+    #endif
+  }
+
+  /// Mirrors `cameraCoverIsPresented` for the glare-free capture cover,
+  /// driven on the Simulator by `pusseldebug://glarecamera`.
+  private var glareCoverIsPresented: Binding<Bool> {
+    #if DEBUG
+      Binding(
+        get: { showGlareCamera || model.flow.debugGlareCameraOpen },
+        set: { newValue in
+          showGlareCamera = newValue
+          model.flow.debugGlareCameraOpen = newValue
+        }
+      )
+    #else
+      $showGlareCamera
     #endif
   }
 }

--- a/ios/Pussel/Features/Capture/GlareFree/ARGlareGuideSource.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/ARGlareGuideSource.swift
@@ -331,12 +331,20 @@ final class ARGlareGuideSource: NSObject, GlareGuideSource, ARSessionDelegate {
     return quad
   }
 
+  /// A hit's estimated surface normal must be at least this vertical to
+  /// count as the puzzle's surface — cos(~30°), rejecting walls without
+  /// demanding a perfectly level estimate.
+  private static let minSurfaceNormalY: Float = 0.85
+
   /// The center's hit on the puzzle's surface: a detected plane when one
   /// exists, otherwise ARKit's estimated plane from the current frame's
   /// scene geometry. The fallback is load-bearing — over a glossy puzzle
   /// filling the view, plane *detection* can take arbitrarily long or
   /// never converge (observed in the field: tracking normal, zero plane
   /// anchors for 30+ s), while the estimate is available almost at once.
+  /// The estimate is queried unconstrained (`.any` — the alignment filter
+  /// itself was unreliable in the field) but accepted only when its
+  /// normal is near-vertical, so a wall cannot masquerade as the surface.
   /// The quad is only frozen once at the shutter, so estimate jitter does
   /// not move anchored targets.
   private func raycastSurfacePoint(from point: CGPoint) -> SIMD3<Float>? {
@@ -344,17 +352,26 @@ final class ARGlareGuideSource: NSObject, GlareGuideSource, ARSessionDelegate {
       (.existingPlaneInfinite, .horizontal),
       (.estimatedPlane, .any),
     ]
+    // Default reason; a rejected hit below records a more specific one.
+    lastRaycastFailure = "no surface hit at \(Int(point.x)),\(Int(point.y))"
     for (target, alignment) in attempts {
       guard
         let query = sceneView.raycastQuery(from: point, allowing: target, alignment: alignment),
         let hit = session.raycast(query).first
       else { continue }
+      // The result's y-axis is the surface normal. The horizontal-plane
+      // attempt is constrained already; the unconstrained estimate must
+      // prove it hit a horizontal surface, not a wall.
+      guard alignment == .horizontal || hit.worldTransform.columns.1.y > Self.minSurfaceNormalY
+      else {
+        lastRaycastFailure = "non-horizontal hit at \(Int(point.x)),\(Int(point.y))"
+        continue
+      }
       return SIMD3(
         hit.worldTransform.columns.3.x,
         hit.worldTransform.columns.3.y,
         hit.worldTransform.columns.3.z)
     }
-    lastRaycastFailure = "no surface hit at \(Int(point.x)),\(Int(point.y))"
     return nil
   }
 

--- a/ios/Pussel/Features/Capture/GlareFree/ARGlareGuideSource.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/ARGlareGuideSource.swift
@@ -22,9 +22,13 @@ enum ARGuideGeometry {
   /// Whether a world point lies in front of the camera (ARKit cameras look
   /// along their −z axis). Projecting a behind-the-camera point yields a
   /// mirrored garbage position, so callers must filter with this first.
+  /// A dot product against the forward axis, not a matrix inverse — this
+  /// runs per projected point every AR frame, and a camera transform is
+  /// rigid, so the axis read is equivalent.
   static func isInFront(ofCameraAt transform: simd_float4x4, point: SIMD3<Float>) -> Bool {
-    let local = simd_mul(simd_inverse(transform), SIMD4(point, 1))
-    return local.z < 0
+    let position = SIMD3(transform.columns.3.x, transform.columns.3.y, transform.columns.3.z)
+    let forward = -SIMD3(transform.columns.2.x, transform.columns.2.y, transform.columns.2.z)
+    return simd_dot(point - position, forward) > 0
   }
 }
 

--- a/ios/Pussel/Features/Capture/GlareFree/ARGlareGuideSource.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/ARGlareGuideSource.swift
@@ -188,7 +188,7 @@ final class ARGlareGuideSource: NSObject, GlareGuideSource, ARSessionDelegate {
 
   // MARK: - GlareGuideSource
 
-  func beginGuiding(reference: UIImage) {
+  func beginGuiding(reference _: UIImage) {
     // The reference image itself is not needed — world tracking replaces
     // image registration. What matters is the quad under the screen at the
     // moment the shot fired, snapshotted by `captureStill`.

--- a/ios/Pussel/Features/Capture/GlareFree/ARGlareGuideSource.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/ARGlareGuideSource.swift
@@ -1,0 +1,372 @@
+import ARKit
+import CoreImage
+import Observation
+import SceneKit
+import UIKit
+import os
+import simd
+
+/// Pure geometry behind the AR guide source, split out so it is testable
+/// without an `ARSession`.
+enum ARGuideGeometry {
+  /// Bilinear interpolation of a world quad at a unit position (top-left
+  /// origin). Quad order matches the raycast screen corners: top left,
+  /// top right, bottom right, bottom left.
+  static func interpolated(quad: [SIMD3<Float>], at unit: CGPoint) -> SIMD3<Float> {
+    let across = SIMD3<Float>(repeating: Float(unit.x))
+    let top = simd_mix(quad[0], quad[1], across)
+    let bottom = simd_mix(quad[3], quad[2], across)
+    return simd_mix(top, bottom, SIMD3(repeating: Float(unit.y)))
+  }
+
+  /// Whether a world point lies in front of the camera (ARKit cameras look
+  /// along their −z axis). Projecting a behind-the-camera point yields a
+  /// mirrored garbage position, so callers must filter with this first.
+  static func isInFront(ofCameraAt transform: simd_float4x4, point: SIMD3<Float>) -> Bool {
+    let local = simd_mul(simd_inverse(transform), SIMD4(point, 1))
+    return local.z < 0
+  }
+}
+
+/// ARKit-backed guide source for the glare-free capture flow — the device
+/// path (`isSupported`), replacing live image registration with world
+/// tracking so the corner targets cannot drift or vanish while the phone
+/// tilts.
+///
+/// Before the center shot it raycasts the four screen corners onto the
+/// detected horizontal plane every frame; once all four hit (`isReady`),
+/// the shutter is worth pressing. `beginGuiding` freezes that quad as the
+/// puzzle outline (the user was told to fit the whole puzzle in frame) and
+/// interpolates the controller's step anchors into world targets on the
+/// plane. From then on each frame projects outline + targets into view
+/// points (`overlay`) and feeds the active step's target to `onUpdate` as
+/// the same `GlareGuideUpdate` shape the registration tracker emits — the
+/// controller's dwell auto-shutter is unchanged. Stills come from
+/// `captureHighResolutionFrame()`, so the composer keeps getting full-
+/// resolution photos.
+@Observable
+@MainActor
+final class ARGlareGuideSource: NSObject, GlareGuideSource, ARSessionDelegate {
+  /// Whether this device can run the AR guide. False on the Simulator —
+  /// there the flow falls back to `GlareGuideTracker`, which keeps the
+  /// `pusseldebug://previewloop` E2E path working.
+  static var isSupported: Bool { ARWorldTrackingConfiguration.isSupported }
+
+  /// Everything the view draws on top of the preview, in view points.
+  struct Overlay: Equatable {
+    /// The frozen puzzle outline — empty when a corner is behind the
+    /// camera (no partial quad: a 3-point "rectangle" reads as a glitch).
+    var outline: [CGPoint]
+    /// One entry per corner step (steps 1…4), nil when behind the camera.
+    var targets: [CGPoint?]
+  }
+
+  /// Corner raycasts landing farther than this from the camera are grazing
+  /// hits on the infinite plane (phone aimed at the horizon), not a
+  /// tabletop — treated as "surface not found".
+  private static let maxSurfaceDistance: Float = 3
+
+  private static let log = Logger(subsystem: "dk.delectosoft.pussel", category: "glare-guide")
+  private static let ciContext = CIContext()
+
+  /// The preview view. The source owns it so raycasts and projections use
+  /// the exact viewport ARKit renders into; `ARGuidePreview` just hosts it.
+  let sceneView = ARSCNView()
+  private var session: ARSession { sceneView.session }
+
+  @ObservationIgnored var onUpdate: ((GlareGuideUpdate) -> Void)?
+  /// Reports a fatal session failure (camera access, tracking) with a
+  /// user-facing message — the view surfaces it and dismisses.
+  @ObservationIgnored var onFailure: ((String) -> Void)?
+
+  /// Whether the puzzle's surface has been found (pre-shot): all four
+  /// screen corners currently raycast onto a horizontal plane. Gates the
+  /// reference shutter.
+  private(set) var isReady = false
+  /// The projected outline + targets, published every frame while guiding.
+  private(set) var overlay: Overlay?
+
+  /// The latest pre-shot corner quad, frozen by `beginGuiding`.
+  @ObservationIgnored private var pendingQuad: [SIMD3<Float>]?
+  @ObservationIgnored private var worldQuad: [SIMD3<Float>]?
+  @ObservationIgnored private var worldTargets: [SIMD3<Float>]?
+  @ObservationIgnored private var activeStep: Int?
+  /// Whether the previous frame had a usable fix for the active target, so
+  /// only acquired/lost transitions are logged — mirrors the tracker.
+  @ObservationIgnored private var wasTracking = false
+  /// The surface's world height, remembered from the last successful
+  /// center raycast. Estimated-plane raycasts over a glossy puzzle come
+  /// and go frame to frame (observed in the field: ready flickering
+  /// against misses), but the table itself does not move — once found,
+  /// the height keeps the quad available continuously and each success
+  /// merely refreshes it. Cleared when the session (re)starts.
+  @ObservationIgnored private var surfaceHeight: Float?
+  /// Throttle for the once-per-second scanning diagnostics.
+  @ObservationIgnored private var lastDiagnostic = Date.distantPast
+  /// Why the last `raycastQuad` returned nil — folded into the diagnostic.
+  @ObservationIgnored private var lastRaycastFailure = "no raycast yet"
+
+  func run() {
+    let configuration = ARWorldTrackingConfiguration()
+    configuration.planeDetection = [.horizontal]
+    // Video format whose still counterpart is full sensor resolution, so
+    // captureHighResolutionFrame() hands the composer ~12 MP photos.
+    if let format = ARWorldTrackingConfiguration
+      .recommendedVideoFormatForHighResolutionFrameCapturing
+    {
+      configuration.videoFormat = format
+    }
+    surfaceHeight = nil
+    session.delegate = self
+    session.run(configuration)
+    Self.log.notice(
+      "AR session started, video format \(configuration.videoFormat.imageResolution.debugDescription, privacy: .public)"
+    )
+  }
+
+  func pause() {
+    session.pause()
+  }
+
+  /// The current frame at full still resolution, rotated upright. Nil on
+  /// capture failure — the controller fails the step and offers a restart.
+  func captureStill() async -> UIImage? {
+    do {
+      let frame = try await session.captureHighResolutionFrame()
+      return Self.stillImage(from: frame.capturedImage)
+    } catch {
+      Self.log.error("high-resolution capture failed: \(error.localizedDescription)")
+      return nil
+    }
+  }
+
+  // MARK: - GlareGuideSource
+
+  func beginGuiding(reference: UIImage) {
+    // The reference image itself is not needed — world tracking replaces
+    // image registration. What matters is the quad under the screen at the
+    // moment the shot fired.
+    guard let quad = pendingQuad else {
+      Self.log.error("center shot landed without a surface quad — AR guiding cannot start")
+      return
+    }
+    worldQuad = quad
+    // The anchors live in unit coordinates of the reference photo; the quad
+    // corners are the *screen* corners at the center shot. The preview is
+    // an aspect-fill crop of the photo, so the two differ by a small crop —
+    // fine for guidance, and the composer re-registers the real offsets.
+    worldTargets = GlareFreeCaptureController.steps.dropFirst().map {
+      ARGuideGeometry.interpolated(quad: quad, at: $0.anchor)
+    }
+    wasTracking = false
+  }
+
+  func setActiveStep(_ step: Int?) {
+    activeStep = step
+  }
+
+  func stopGuiding() {
+    worldQuad = nil
+    worldTargets = nil
+    activeStep = nil
+    overlay = nil
+    wasTracking = false
+  }
+
+  // MARK: - ARSessionDelegate
+
+  // ARSession calls its delegate on the main queue (delegateQueue is nil),
+  // so hopping back into the actor is an assertion, not a dispatch.
+  nonisolated func session(_ session: ARSession, didUpdate frame: ARFrame) {
+    MainActor.assumeIsolated { handle(frame) }
+  }
+
+  nonisolated func session(_ session: ARSession, didFailWithError error: Error) {
+    MainActor.assumeIsolated {
+      Self.log.error("AR session failed: \(error.localizedDescription)")
+      let message =
+        (error as? ARError)?.code == .cameraUnauthorized
+        ? "Pussel cannot use the camera. Check camera access in Settings."
+        : "The camera's motion tracking failed."
+      onFailure?(message)
+    }
+  }
+
+  private func handle(_ frame: ARFrame) {
+    let size = sceneView.bounds.size
+    guard size.width > 0, size.height > 0 else {
+      logDiagnostic("view not laid out yet", frame: frame)
+      return
+    }
+    let aspect = size.width / size.height
+    guard case .normal = frame.camera.trackingState else {
+      isReady = false
+      pendingQuad = nil
+      logDiagnostic("tracking not normal", frame: frame)
+      if worldQuad != nil {
+        overlay = nil
+        emit(offset: nil, aspect: aspect)
+      }
+      return
+    }
+    if worldQuad == nil {
+      pendingQuad = raycastQuad(frame: frame, size: size)
+      isReady = pendingQuad != nil
+      logDiagnostic(isReady ? "surface ready" : lastRaycastFailure, frame: frame)
+    } else {
+      publishGuidance(frame: frame, size: size, aspect: aspect)
+    }
+  }
+
+  /// One state line per second while the surface is being sought — enough
+  /// to tell a stuck session from missing planes from failing raycasts
+  /// when scanning misbehaves in the field.
+  private func logDiagnostic(_ detail: String, frame: ARFrame) {
+    let now = Date()
+    guard now.timeIntervalSince(lastDiagnostic) >= 1 else { return }
+    lastDiagnostic = now
+    let tracking: String
+    switch frame.camera.trackingState {
+    case .normal: tracking = "normal"
+    case .notAvailable: tracking = "notAvailable"
+    case .limited(let reason): tracking = "limited(\(String(describing: reason)))"
+    }
+    let planes = frame.anchors.count(where: { $0 is ARPlaneAnchor })
+    Self.log.notice(
+      "AR scan: \(detail, privacy: .public); tracking=\(tracking, privacy: .public) planes=\(planes)"
+    )
+  }
+
+  /// The four screen corners projected onto the puzzle's surface plane —
+  /// nil until the surface has been found.
+  ///
+  /// Only the screen *center* is raycast (that is where the puzzle is —
+  /// the one spot guaranteed to have scene coverage; the extreme corners
+  /// of the field of view often have none, and corner raycasts were
+  /// observed to fail indefinitely in the field). The hit fixes the
+  /// surface's height; the world is gravity-aligned, so the surface is the
+  /// horizontal plane at that height, and each corner is its screen ray
+  /// intersected with that plane analytically.
+  private func raycastQuad(frame: ARFrame, size: CGSize) -> [SIMD3<Float>]? {
+    let camera = SIMD3(
+      frame.camera.transform.columns.3.x,
+      frame.camera.transform.columns.3.y,
+      frame.camera.transform.columns.3.z)
+    if let surface = raycastSurfacePoint(from: CGPoint(x: size.width / 2, y: size.height / 2)),
+      simd_distance(surface, camera) < Self.maxSurfaceDistance
+    {
+      surfaceHeight = surface.y
+    }
+    guard let height = surfaceHeight else { return nil }
+    let corners = [
+      CGPoint(x: 0, y: 0),
+      CGPoint(x: size.width, y: 0),
+      CGPoint(x: size.width, y: size.height),
+      CGPoint(x: 0, y: size.height),
+    ]
+    var quad: [SIMD3<Float>] = []
+    for corner in corners {
+      guard let point = intersection(ofScreenPoint: corner, withHorizontalPlaneAtY: height),
+        simd_distance(point, camera) < Self.maxSurfaceDistance
+      else {
+        lastRaycastFailure = "corner ray misses surface at \(Int(corner.x)),\(Int(corner.y))"
+        return nil
+      }
+      quad.append(point)
+    }
+    return quad
+  }
+
+  /// The center's hit on the puzzle's surface: a detected plane when one
+  /// exists, otherwise ARKit's estimated plane from the current frame's
+  /// scene geometry. The fallback is load-bearing — over a glossy puzzle
+  /// filling the view, plane *detection* can take arbitrarily long or
+  /// never converge (observed in the field: tracking normal, zero plane
+  /// anchors for 30+ s), while the estimate is available almost at once.
+  /// The quad is only frozen once at the shutter, so estimate jitter does
+  /// not move anchored targets.
+  private func raycastSurfacePoint(from point: CGPoint) -> SIMD3<Float>? {
+    let attempts: [(ARRaycastQuery.Target, ARRaycastQuery.TargetAlignment)] = [
+      (.existingPlaneInfinite, .horizontal),
+      (.estimatedPlane, .any),
+    ]
+    for (target, alignment) in attempts {
+      guard
+        let query = sceneView.raycastQuery(from: point, allowing: target, alignment: alignment),
+        let hit = session.raycast(query).first
+      else { continue }
+      return SIMD3(
+        hit.worldTransform.columns.3.x,
+        hit.worldTransform.columns.3.y,
+        hit.worldTransform.columns.3.z)
+    }
+    lastRaycastFailure = "no surface hit at \(Int(point.x)),\(Int(point.y))"
+    return nil
+  }
+
+  /// Where the ray through a screen point meets the horizontal plane at
+  /// world height `planeY` — nil when the ray points away from it.
+  private func intersection(
+    ofScreenPoint point: CGPoint, withHorizontalPlaneAtY planeY: Float
+  ) -> SIMD3<Float>? {
+    let near = sceneView.unprojectPoint(SCNVector3(Float(point.x), Float(point.y), 0))
+    let far = sceneView.unprojectPoint(SCNVector3(Float(point.x), Float(point.y), 1))
+    let origin = SIMD3(near.x, near.y, near.z)
+    let direction = SIMD3(far.x - near.x, far.y - near.y, far.z - near.z)
+    guard abs(direction.y) > .ulpOfOne else { return nil }
+    let along = (planeY - origin.y) / direction.y
+    guard along > 0 else { return nil }
+    return origin + along * direction
+  }
+
+  /// Projects the frozen outline and targets into view points and feeds
+  /// the active step's target to the controller.
+  private func publishGuidance(frame: ARFrame, size: CGSize, aspect: CGFloat) {
+    guard let worldQuad, let worldTargets else { return }
+    let cameraTransform = frame.camera.transform
+    func projected(_ world: SIMD3<Float>) -> CGPoint? {
+      guard ARGuideGeometry.isInFront(ofCameraAt: cameraTransform, point: world) else {
+        return nil
+      }
+      return frame.camera.projectPoint(world, orientation: .portrait, viewportSize: size)
+    }
+    let outline = worldQuad.compactMap(projected)
+    let targets = worldTargets.map(projected)
+    overlay = Overlay(
+      outline: outline.count == worldQuad.count ? outline : [],
+      targets: targets)
+    guard let step = activeStep, step >= 1, step - 1 < targets.count else { return }
+    let offset: CGSize?
+    if let view = targets[step - 1] {
+      // Synthesized so the controller's `anchor + offset` lands on the
+      // projected view-unit position; with frameAspect equal to the view's
+      // aspect, the view's aspect-fill mapping becomes the identity.
+      let anchor = GlareFreeCaptureController.steps[step].anchor
+      offset = CGSize(
+        width: view.x / size.width - anchor.x,
+        height: view.y / size.height - anchor.y)
+    } else {
+      offset = nil
+    }
+    emit(offset: offset, aspect: aspect)
+  }
+
+  private func emit(offset: CGSize?, aspect: CGFloat) {
+    let isTracking = offset != nil
+    if isTracking != wasTracking {
+      wasTracking = isTracking
+      Self.log.notice("AR guidance \(isTracking ? "acquired" : "lost")")
+    }
+    onUpdate?(GlareGuideUpdate(offset: offset, frameAspect: aspect))
+  }
+
+  /// The captured buffer rotated upright: AR frames arrive in the sensor's
+  /// landscape orientation, and the app is portrait-only, so `.right` is
+  /// the one rotation in play — same convention as the camera sessions'
+  /// `videoRotationAngle = 90`.
+  private static func stillImage(from buffer: CVPixelBuffer) -> UIImage? {
+    let upright = CIImage(cvPixelBuffer: buffer).oriented(.right)
+    guard let cgImage = ciContext.createCGImage(upright, from: upright.extent) else { return nil }
+    return UIImage(cgImage: cgImage)
+  }
+}

--- a/ios/Pussel/Features/Capture/GlareFree/ARGlareGuideSource.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/ARGlareGuideSource.swift
@@ -86,8 +86,12 @@ final class ARGlareGuideSource: NSObject, GlareGuideSource, ARSessionDelegate {
   /// The projected outline + targets, published every frame while guiding.
   private(set) var overlay: Overlay?
 
-  /// The latest pre-shot corner quad, frozen by `beginGuiding`.
+  /// The latest pre-shot corner quad, kept fresh by the live scan.
   @ObservationIgnored private var pendingQuad: [SIMD3<Float>]?
+  /// The quad snapshotted at the reference photo's own camera pose —
+  /// what `beginGuiding` freezes (the live scan may have moved on while
+  /// the high-res capture was in flight).
+  @ObservationIgnored private var quadAtCapture: [SIMD3<Float>]?
   @ObservationIgnored private var worldQuad: [SIMD3<Float>]?
   @ObservationIgnored private var worldTargets: [SIMD3<Float>]?
   @ObservationIgnored private var activeStep: Int?
@@ -131,8 +135,20 @@ final class ARGlareGuideSource: NSObject, GlareGuideSource, ARSessionDelegate {
   /// The current frame at full still resolution, rotated upright. Nil on
   /// capture failure — the controller fails the step and offers a restart.
   func captureStill() async -> UIImage? {
+    let size = sceneView.bounds.size
     do {
       let frame = try await session.captureHighResolutionFrame()
+      if worldQuad == nil {
+        // This is the reference shot: freeze the quad from the *returned*
+        // frame's camera pose — the pose at the moment the photo actually
+        // fired — not from whatever the live scan measures once the async
+        // capture returns. The user may move the phone while the high-res
+        // capture is in flight, and the outline must match the photo.
+        quadAtCapture =
+          Self.quad(
+            onPlaneAtHeight: surfaceHeight, camera: frame.camera, viewportSize: size)
+          ?? pendingQuad
+      }
       return Self.stillImage(from: frame.capturedImage)
     } catch {
       Self.log.error("high-resolution capture failed: \(error.localizedDescription)")
@@ -140,16 +156,43 @@ final class ARGlareGuideSource: NSObject, GlareGuideSource, ARSessionDelegate {
     }
   }
 
+  /// The screen-corner quad as seen by `camera`, unprojected onto the
+  /// horizontal plane at `height` — nil when the surface is unknown or a
+  /// corner ray misses the plane.
+  private static func quad(
+    onPlaneAtHeight height: Float?, camera: ARCamera, viewportSize size: CGSize
+  ) -> [SIMD3<Float>]? {
+    guard let height, size.width > 0, size.height > 0 else { return nil }
+    var plane = matrix_identity_float4x4
+    plane.columns.3 = SIMD4(0, height, 0, 1)
+    let corners = [
+      CGPoint(x: 0, y: 0),
+      CGPoint(x: size.width, y: 0),
+      CGPoint(x: size.width, y: size.height),
+      CGPoint(x: 0, y: size.height),
+    ]
+    var quad: [SIMD3<Float>] = []
+    for corner in corners {
+      guard
+        let point = camera.unprojectPoint(
+          corner, ontoPlane: plane, orientation: .portrait, viewportSize: size)
+      else { return nil }
+      quad.append(point)
+    }
+    return quad
+  }
+
   // MARK: - GlareGuideSource
 
   func beginGuiding(reference: UIImage) {
     // The reference image itself is not needed — world tracking replaces
     // image registration. What matters is the quad under the screen at the
-    // moment the shot fired.
-    guard let quad = pendingQuad else {
+    // moment the shot fired, snapshotted by `captureStill`.
+    guard let quad = quadAtCapture ?? pendingQuad else {
       Self.log.error("center shot landed without a surface quad — AR guiding cannot start")
       return
     }
+    quadAtCapture = nil
     worldQuad = quad
     // The anchors live in unit coordinates of the reference photo; the quad
     // corners are the *screen* corners at the center shot. The preview is
@@ -175,6 +218,7 @@ final class ARGlareGuideSource: NSObject, GlareGuideSource, ARSessionDelegate {
     // surface, and reacquiring one takes only a couple of seconds — better
     // than a ready state resting on a stale height.
     pendingQuad = nil
+    quadAtCapture = nil
     surfaceHeight = nil
     isReady = false
   }

--- a/ios/Pussel/Features/Capture/GlareFree/ARGlareGuideSource.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/ARGlareGuideSource.swift
@@ -171,6 +171,12 @@ final class ARGlareGuideSource: NSObject, GlareGuideSource, ARSessionDelegate {
     activeStep = nil
     overlay = nil
     wasTracking = false
+    // Drop the scanning state too: the restart may happen over a different
+    // surface, and reacquiring one takes only a couple of seconds — better
+    // than a ready state resting on a stale height.
+    pendingQuad = nil
+    surfaceHeight = nil
+    isReady = false
   }
 
   // MARK: - ARSessionDelegate

--- a/ios/Pussel/Features/Capture/GlareFree/GlareAimStabilityTracker.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/GlareAimStabilityTracker.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Pure decision logic for the glare-free auto-shutter: fires exactly once
+/// when the guide dot has stayed on target long enough, then latches until
+/// `reset()` (called when the flow moves to the next step). A single
+/// on-target frame is not a steady hand — requiring a short dwell keeps
+/// the shutter from firing while the dot merely sweeps through the ring.
+///
+/// The `PieceScanStabilityTracker` idea reduced to one boolean signal: no
+/// I/O, no timers, directly unit-testable with injected dates.
+struct GlareAimStabilityTracker: Equatable {
+  /// How long the dot must stay continuously on target.
+  static let minDuration: TimeInterval = 0.4
+  /// Minimum on-target measurements in the streak, so a stalled frame
+  /// stream (two updates 0.4 s apart) cannot fake a steady aim.
+  static let minSamples = 2
+
+  private var streakStart: Date?
+  private var samples = 0
+  private var hasFired = false
+
+  init() {}
+
+  /// Feeds one measurement; returns true exactly once, when the on-target
+  /// streak first satisfies both thresholds.
+  mutating func ingest(onTarget: Bool, at date: Date) -> Bool {
+    guard !hasFired else { return false }
+    guard onTarget else {
+      streakStart = nil
+      samples = 0
+      return false
+    }
+    let start = streakStart ?? date
+    streakStart = start
+    samples += 1
+    guard samples >= Self.minSamples, date.timeIntervalSince(start) >= Self.minDuration else {
+      return false
+    }
+    hasFired = true
+    return true
+  }
+
+  /// Re-arms the tracker for the next step's aim.
+  mutating func reset() {
+    self = GlareAimStabilityTracker()
+  }
+}

--- a/ios/Pussel/Features/Capture/GlareFree/GlareFreeCaptureController.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/GlareFreeCaptureController.swift
@@ -41,8 +41,8 @@ final class GlareFreeCaptureController {
     GlareFreeStep(title: "Center", anchor: CGPoint(x: 0.5, y: 0.5)),
     GlareFreeStep(title: "Top left", anchor: CGPoint(x: 0.25, y: 0.32)),
     GlareFreeStep(title: "Top right", anchor: CGPoint(x: 0.75, y: 0.32)),
-    GlareFreeStep(title: "Bottom left", anchor: CGPoint(x: 0.25, y: 0.68)),
     GlareFreeStep(title: "Bottom right", anchor: CGPoint(x: 0.75, y: 0.68)),
+    GlareFreeStep(title: "Bottom left", anchor: CGPoint(x: 0.25, y: 0.68)),
   ]
 
   /// How close (unit distance) the tracked dot must be to the screen

--- a/ios/Pussel/Features/Capture/GlareFree/GlareFreeCaptureController.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/GlareFreeCaptureController.swift
@@ -1,0 +1,189 @@
+import Observation
+import UIKit
+
+/// One step of the guided five-shot glare-free capture: a name for the
+/// progress line and the spot on the puzzle the guide dot is pinned to.
+struct GlareFreeStep: Equatable {
+  let title: String
+  /// The dot's anchor in unit coordinates *of the center reference shot*
+  /// (0…1, top-left origin). For the first step there is no reference yet,
+  /// so the anchor doubles as a static screen position; for the corner
+  /// steps the live tracker moves the dot so it stays glued to this spot
+  /// on the puzzle while the phone moves.
+  let anchor: CGPoint
+}
+
+/// State machine for the glare-free capture flow: a manual center shot,
+/// then four corner shots that fire automatically — the guide dot is
+/// anchored to a fixed spot on the puzzle (`ingestGuide`), and once the
+/// user has steered it into the screen-center ring and held it there, the
+/// step's photo is taken and the next anchor lights up. A background
+/// composition pass (`GlareFreeComposer`) then fuses the burst.
+/// Dependency-injected capture and compose closures keep it unit-testable
+/// without a camera — mirrors `PieceScanController`.
+@Observable
+@MainActor
+final class GlareFreeCaptureController {
+  enum Phase: Equatable {
+    case capturing(step: Int)
+    case composing
+    case done
+    case failed(String)
+  }
+
+  /// The capture sequence. The center shot comes first because it becomes
+  /// the composite's reference frame — the output keeps its viewpoint. The
+  /// corner anchors are modest offsets (~a quarter of the frame): steering
+  /// one to the screen center shifts the camera by that same fraction,
+  /// which keeps the puzzle fully in frame while still displacing a
+  /// specular reflection a long way.
+  static let steps: [GlareFreeStep] = [
+    GlareFreeStep(title: "Center", anchor: CGPoint(x: 0.5, y: 0.5)),
+    GlareFreeStep(title: "Top left", anchor: CGPoint(x: 0.25, y: 0.32)),
+    GlareFreeStep(title: "Top right", anchor: CGPoint(x: 0.75, y: 0.32)),
+    GlareFreeStep(title: "Bottom left", anchor: CGPoint(x: 0.25, y: 0.68)),
+    GlareFreeStep(title: "Bottom right", anchor: CGPoint(x: 0.75, y: 0.68)),
+  ]
+
+  /// How close (unit distance) the tracked dot must be to the screen
+  /// center for the auto-shutter's dwell to count.
+  static let aimTolerance: CGFloat = 0.06
+
+  private(set) var phase: Phase = .capturing(step: 0)
+  private(set) var isCapturing = false
+  /// The finished composite; set as `phase` becomes `.done`.
+  private(set) var composite: GlareFreeComposer.Composite?
+  /// The center shot, once taken — the view hands it to the guide tracker
+  /// as the registration reference for the corner steps.
+  private(set) var referenceShot: UIImage?
+  /// The latest tracker measurement (corner steps only). Nil before the
+  /// first measurement and after each step advance; a non-nil update with
+  /// a nil offset means tracking is currently lost.
+  private(set) var guide: GlareGuideUpdate?
+
+  private let capture: () async -> UIImage?
+  private let compose: (UIImage, [UIImage], [CGSize?]) async -> GlareFreeComposer.Composite?
+  private var captured: [UIImage] = []
+  private var aim = GlareAimStabilityTracker()
+
+  #if DEBUG
+    /// The controller of the currently presented glare-free screen, so
+    /// `pusseldebug://glareshot` can drive the shutter on the Simulator —
+    /// mirrors `PieceScanController.debugActive`. Registered by
+    /// `GlareFreeCaptureView` while it is presented.
+    static weak var debugActive: GlareFreeCaptureController?
+  #endif
+
+  init(
+    capture: @escaping () async -> UIImage?,
+    compose: @escaping (UIImage, [UIImage], [CGSize?]) async -> GlareFreeComposer.Composite? =
+      { reference, others, expectedShifts in
+        await Task.detached(priority: .userInitiated) {
+          GlareFreeComposer.compose(
+            reference: reference, others: others, expectedShifts: expectedShifts)
+        }.value
+      }
+  ) {
+    self.capture = capture
+    self.compose = compose
+  }
+
+  var currentStep: GlareFreeStep? {
+    guard case .capturing(let index) = phase else { return nil }
+    return Self.steps[index]
+  }
+
+  var capturedCount: Int { captured.count }
+
+  /// Where the guide dot currently sits, in unit coordinates of the live
+  /// frame: the screen center while aiming the reference shot, and the
+  /// tracked anchor position afterwards — nil there until tracking has a
+  /// fix, so the view can show "looking for the puzzle" instead of a dot
+  /// pinned to a stale spot.
+  var dotUnitPosition: CGPoint? {
+    guard case .capturing(let index) = phase else { return nil }
+    guard index > 0 else { return CGPoint(x: 0.5, y: 0.5) }
+    guard let offset = guide?.offset else { return nil }
+    let anchor = Self.steps[index].anchor
+    return CGPoint(x: anchor.x + offset.width, y: anchor.y + offset.height)
+  }
+
+  /// The content displacement expected of step `index`'s shot relative to
+  /// the reference (unit coordinates, top-left origin): the shot fires
+  /// with the step's anchor steered to the frame center, so the content
+  /// has moved by exactly that steering distance. Seeds the composer's
+  /// registration.
+  static func expectedShift(step index: Int) -> CGSize? {
+    guard index > 0, index < steps.count else { return nil }
+    let anchor = steps[index].anchor
+    return CGSize(width: 0.5 - anchor.x, height: 0.5 - anchor.y)
+  }
+
+  /// Feeds one tracker measurement: remembers it for the view's dot and,
+  /// when the dot has dwelt on the screen center long enough, fires the
+  /// step's photo. Corner steps only — the reference shot is manual.
+  func ingestGuide(_ update: GlareGuideUpdate, at date: Date = Date()) {
+    guard case .capturing(let index) = phase, index > 0, !isCapturing else { return }
+    guide = update
+    let onTarget: Bool
+    if let dot = dotUnitPosition {
+      onTarget = hypot(dot.x - 0.5, dot.y - 0.5) <= Self.aimTolerance
+    } else {
+      onTarget = false
+    }
+    guard aim.ingest(onTarget: onTarget, at: date) else { return }
+    Task { await self.captureShot() }
+  }
+
+  /// Takes the current step's photo and advances; the last step triggers
+  /// composition. Fired by the shutter button on the reference step and by
+  /// the aim dwell on the corner steps; shots while one is already
+  /// developing are ignored, so each step captures exactly once.
+  func captureShot() async {
+    guard case .capturing(let index) = phase, !isCapturing else { return }
+    isCapturing = true
+    defer { isCapturing = false }
+    guard let image = await capture() else {
+      phase = .failed("Could not take that photo.")
+      return
+    }
+    captured.append(image)
+    if index == 0 {
+      referenceShot = image
+    }
+    guard index + 1 < Self.steps.count else {
+      await composeCaptured()
+      return
+    }
+    // Re-arm the aim for the next anchor; the stale dot would otherwise
+    // still sit at the screen center and instantly re-fire.
+    aim.reset()
+    guide = nil
+    phase = .capturing(step: index + 1)
+  }
+
+  private func composeCaptured() async {
+    phase = .composing
+    let reference = captured[0]
+    let others = Array(captured.dropFirst())
+    let shifts = (1..<Self.steps.count).map(Self.expectedShift(step:))
+    // A composer failure still leaves the reference shot — degrade to a
+    // normal single-photo capture rather than dead-ending the flow. The
+    // view surfaces the degradation via `alignedFrameCount == 0`.
+    composite =
+      await compose(reference, others, shifts)
+      ?? GlareFreeComposer.Composite(image: reference, alignedFrameCount: 0)
+    phase = .done
+  }
+
+  /// Restarts the five-shot sequence (offered after a failed capture).
+  func restart() {
+    guard !isCapturing else { return }
+    captured = []
+    composite = nil
+    referenceShot = nil
+    guide = nil
+    aim.reset()
+    phase = .capturing(step: 0)
+  }
+}

--- a/ios/Pussel/Features/Capture/GlareFree/GlareFreeCaptureView.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/GlareFreeCaptureView.swift
@@ -1,18 +1,20 @@
+import ARKit
 import SwiftUI
 import UIKit
 
 /// Guided five-shot glare-free capture of the full puzzle, presented from
 /// CapturePuzzleView. The user photographs the puzzle once from the
-/// center; after that the guide dot is anchored to a fixed spot *on the
-/// puzzle* (live-tracked by `GlareGuideTracker`), and each corner shot
-/// fires automatically once the user has steered that spot into the
-/// screen-center ring and held it there. `GlareFreeComposer` then fuses
-/// the burst into one glare-free image that continues down the normal
-/// detect-frame path via `onImage`.
+/// center; after that each corner shot fires automatically once the
+/// current target has been steered into the screen-center ring and held
+/// there. `GlareFreeComposer` then fuses the burst into one glare-free
+/// image that continues down the normal detect-frame path via `onImage`.
 ///
-/// Reuses `BoxCameraSession` with the tracker attached as its live frame
-/// consumer — the "third live-camera screen" the session's extraction
-/// note anticipated.
+/// Guidance comes from one of two `GlareGuideSource` backends: on devices,
+/// `ARGlareGuideSource` world-anchors the puzzle outline and all four
+/// corner targets over an AR preview; on the Simulator (no ARKit),
+/// `GlareGuideTracker` live-registers `BoxCameraSession` frames against
+/// the center shot and moves a single dot — which keeps the
+/// `pusseldebug://previewloop` E2E flow working.
 struct GlareFreeCaptureView: View {
   /// The composite (or, if no frames registered, the center shot) — routed
   /// to the existing detect-frame path.
@@ -22,13 +24,25 @@ struct GlareFreeCaptureView: View {
   @Environment(\.dismiss) private var dismiss
   @State private var camera = BoxCameraSession()
   @State private var tracker = GlareGuideTracker()
+  @State private var arSource: ARGlareGuideSource?
   @State private var controller: GlareFreeCaptureController?
+
+  /// The active guidance backend — AR once `startSession` chose it, the
+  /// registration tracker otherwise.
+  private var guideSource: any GlareGuideSource {
+    if let arSource { arSource } else { tracker }
+  }
 
   var body: some View {
     ZStack {
       Color.black.ignoresSafeArea()
-      BoxCameraPreview(session: camera.session)
-        .ignoresSafeArea()
+      if let arSource {
+        ARGuidePreview(source: arSource)
+          .ignoresSafeArea()
+      } else {
+        BoxCameraPreview(session: camera.session)
+          .ignoresSafeArea()
+      }
       guidanceOverlay
     }
     .overlay(alignment: .top) { topBar }
@@ -36,6 +50,7 @@ struct GlareFreeCaptureView: View {
     .task { await startSession() }
     .onDisappear {
       camera.stop()
+      arSource?.pause()
       #if DEBUG
         if GlareFreeCaptureController.debugActive === controller {
           GlareFreeCaptureController.debugActive = nil
@@ -45,18 +60,16 @@ struct GlareFreeCaptureView: View {
     .onChange(of: controller?.phase) { _, phase in
       switch phase {
       case .capturing(step: 0):
-        // Back at the start (restart after a failure) — stop tracking
+        // Back at the start (restart after a failure) — stop guiding
         // until a new reference is taken.
-        tracker.clearReference()
+        guideSource.stopGuiding()
       case .capturing(let step):
-        // The center shot just landed — it becomes the tracking reference
-        // for the corner steps.
+        // The center shot just landed — the guide source starts guiding
+        // from it (registration reference, or the frozen AR world quad).
         if step == 1, let reference = controller?.referenceShot {
-          tracker.setReference(reference)
+          guideSource.beginGuiding(reference: reference)
         }
-        // Tell the tracker where this step steers the content, so it can
-        // use the expectation as a registration prior.
-        tracker.setExpectedOffset(GlareFreeCaptureController.expectedShift(step: step))
+        guideSource.setActiveStep(step)
       case .done:
         guard let composite = controller?.composite else { return }
         dismiss()
@@ -73,6 +86,40 @@ struct GlareFreeCaptureView: View {
   }
 
   private func startSession() async {
+    if ARGlareGuideSource.isSupported {
+      startARSession()
+    } else {
+      await startRegistrationSession()
+    }
+  }
+
+  /// The device path: ARKit world tracking supplies both the guidance and
+  /// the photos, so `BoxCameraSession` stays idle.
+  private func startARSession() {
+    let source = arSource ?? ARGlareGuideSource()
+    arSource = source
+    let controller =
+      self.controller
+      ?? GlareFreeCaptureController(capture: { [weak source] in
+        await source?.captureStill()
+      })
+    self.controller = controller
+    #if DEBUG
+      GlareFreeCaptureController.debugActive = controller
+    #endif
+    source.onUpdate = { update in
+      controller.ingestGuide(update)
+    }
+    source.onFailure = { message in
+      model.flow.errorMessage = message
+      dismiss()
+    }
+    source.run()
+  }
+
+  /// The Simulator/E2E fallback: `GlareGuideTracker` registers the camera
+  /// session's live frames against the center shot.
+  private func startRegistrationSession() async {
     let controller =
       self.controller
       ?? GlareFreeCaptureController(capture: { [camera] in
@@ -108,14 +155,17 @@ struct GlareFreeCaptureView: View {
 
   /// The guide graphics over the preview. While aiming the reference shot
   /// the pulsing dot simply marks the screen center; on the corner steps a
-  /// fixed ring marks the target and the dot moves with the puzzle — the
-  /// tracker pins it to the current step's anchor spot, so steering it
-  /// into the ring is steering the phone.
+  /// fixed ring marks the target and the guidance moves with the puzzle,
+  /// so steering it into the ring is steering the phone. The AR backend
+  /// additionally shows the puzzle outline and all four world-anchored
+  /// targets at once.
   private var guidanceOverlay: some View {
     GeometryReader { proxy in
       if let controller, case .capturing(let step) = controller.phase {
         let center = CGPoint(x: proxy.size.width / 2, y: proxy.size.height / 2)
-        if step == 0 {
+        if let arSource {
+          arOverlay(source: arSource, step: step, center: center, size: proxy.size)
+        } else if step == 0 {
           GuideDot(onTarget: false)
             .position(center)
         } else {
@@ -135,6 +185,42 @@ struct GlareFreeCaptureView: View {
     }
     .allowsHitTesting(false)
     .ignoresSafeArea()
+  }
+
+  /// The AR backend's overlay: the world-anchored puzzle outline at all
+  /// times, every corner target visible at once — completed ones checked
+  /// off, the current one as the pulsing dot to steer into the ring.
+  @ViewBuilder
+  private func arOverlay(
+    source: ARGlareGuideSource, step: Int, center: CGPoint, size: CGSize
+  ) -> some View {
+    if step == 0 {
+      if source.isReady {
+        SurfaceReadyFrame()
+        GuideDot(onTarget: false)
+          .position(center)
+      }
+    } else if let overlay = source.overlay {
+      if overlay.outline.count == 4 {
+        PuzzleOutline(points: overlay.outline)
+      }
+      TargetRing(onTarget: dotIsOnTarget)
+        .position(center)
+      ForEach(Array(overlay.targets.enumerated()), id: \.offset) { index, point in
+        if let point {
+          if index == step - 1 {
+            GuideDot(onTarget: dotIsOnTarget)
+              .position(clamped(point, within: size))
+          } else {
+            CornerTargetMark(completed: index < step - 1)
+              .position(point)
+          }
+        }
+      }
+    } else {
+      TargetRing(onTarget: false)
+        .position(center)
+    }
   }
 
   /// Whether the tracked dot currently sits inside the aim tolerance — for
@@ -203,7 +289,13 @@ struct GlareFreeCaptureView: View {
   private func instructionBanner(step: Int) -> some View {
     let text: String
     if step == 0 {
-      text = "Fit the whole puzzle in the frame, then tap the shutter."
+      // The AR backend needs its surface first — a brief scanning state
+      // before the shutter is worth pressing.
+      if let arSource, !arSource.isReady {
+        text = "Move the phone slowly over the puzzle while it finds the surface…"
+      } else {
+        text = "Fit the whole puzzle in the frame, then tap the shutter."
+      }
     } else if controller?.guide?.offset == nil {
       text = "Looking for the puzzle — keep it fully in view."
     } else {
@@ -261,9 +353,19 @@ struct GlareFreeCaptureView: View {
         Circle().strokeBorder(.white, lineWidth: 3).frame(width: 70, height: 70)
       }
     }
-    .disabled(controller?.isCapturing ?? true)
+    .disabled((controller?.isCapturing ?? true) || !(arSource?.isReady ?? true))
     .accessibilityLabel("Take the reference shot")
   }
+}
+
+/// Hosts the AR source's `ARSCNView` — the source owns the view so its
+/// raycasts and projections share the exact rendered viewport.
+private struct ARGuidePreview: UIViewRepresentable {
+  let source: ARGlareGuideSource
+
+  func makeUIView(context: Context) -> ARSCNView { source.sceneView }
+
+  func updateUIView(_ uiView: ARSCNView, context: Context) {}
 }
 
 /// The pulsing guide dot. On the corner steps it is pinned to a spot on
@@ -286,6 +388,59 @@ private struct GuideDot: View {
     }
     .shadow(radius: 4)
     .onAppear { pulsing = true }
+  }
+}
+
+/// The world-anchored puzzle outline the AR backend keeps over the
+/// preview — the frozen center-shot quad, projected every frame.
+private struct PuzzleOutline: View {
+  let points: [CGPoint]
+
+  var body: some View {
+    Path { path in
+      guard let first = points.first else { return }
+      path.move(to: first)
+      for point in points.dropFirst() {
+        path.addLine(to: point)
+      }
+      path.closeSubpath()
+    }
+    .stroke(Color.white.opacity(0.7), style: StrokeStyle(lineWidth: 2, dash: [8, 6]))
+    .shadow(radius: 3)
+  }
+}
+
+/// A non-current corner target in the AR overlay: checked off once its
+/// shot has fired, a dim placeholder while it waits its turn.
+private struct CornerTargetMark: View {
+  let completed: Bool
+
+  var body: some View {
+    ZStack {
+      Circle()
+        .fill(completed ? Color.green.opacity(0.9) : Color.black.opacity(0.25))
+        .frame(width: 26, height: 26)
+      if completed {
+        Image(systemName: "checkmark")
+          .font(.system(size: 13, weight: .bold))
+          .foregroundStyle(.white)
+      } else {
+        Circle()
+          .stroke(Color.white.opacity(0.7), lineWidth: 2)
+          .frame(width: 26, height: 26)
+      }
+    }
+    .shadow(radius: 3)
+  }
+}
+
+/// The "surface found" hint while aiming the reference shot in AR mode —
+/// the screen-edge region that will freeze into the puzzle outline.
+private struct SurfaceReadyFrame: View {
+  var body: some View {
+    RoundedRectangle(cornerRadius: 24)
+      .strokeBorder(Color.green.opacity(0.6), style: StrokeStyle(lineWidth: 2, dash: [10, 8]))
+      .padding(24)
   }
 }
 

--- a/ios/Pussel/Features/Capture/GlareFree/GlareFreeCaptureView.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/GlareFreeCaptureView.swift
@@ -70,6 +70,11 @@ struct GlareFreeCaptureView: View {
           guideSource.beginGuiding(reference: reference)
         }
         guideSource.setActiveStep(step)
+      case .composing, .failed:
+        // No step is aiming — stop the per-frame guidance work, most
+        // importantly so the registration tracker's Vision passes don't
+        // compete with the composer for CPU.
+        guideSource.stopGuiding()
       case .done:
         guard let composite = controller?.composite else { return }
         dismiss()

--- a/ios/Pussel/Features/Capture/GlareFree/GlareFreeCaptureView.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/GlareFreeCaptureView.swift
@@ -1,0 +1,305 @@
+import SwiftUI
+import UIKit
+
+/// Guided five-shot glare-free capture of the full puzzle, presented from
+/// CapturePuzzleView. The user photographs the puzzle once from the
+/// center; after that the guide dot is anchored to a fixed spot *on the
+/// puzzle* (live-tracked by `GlareGuideTracker`), and each corner shot
+/// fires automatically once the user has steered that spot into the
+/// screen-center ring and held it there. `GlareFreeComposer` then fuses
+/// the burst into one glare-free image that continues down the normal
+/// detect-frame path via `onImage`.
+///
+/// Reuses `BoxCameraSession` with the tracker attached as its live frame
+/// consumer — the "third live-camera screen" the session's extraction
+/// note anticipated.
+struct GlareFreeCaptureView: View {
+  /// The composite (or, if no frames registered, the center shot) — routed
+  /// to the existing detect-frame path.
+  let onImage: (UIImage) -> Void
+
+  @Environment(AppModel.self) private var model
+  @Environment(\.dismiss) private var dismiss
+  @State private var camera = BoxCameraSession()
+  @State private var tracker = GlareGuideTracker()
+  @State private var controller: GlareFreeCaptureController?
+
+  var body: some View {
+    ZStack {
+      Color.black.ignoresSafeArea()
+      BoxCameraPreview(session: camera.session)
+        .ignoresSafeArea()
+      guidanceOverlay
+    }
+    .overlay(alignment: .top) { topBar }
+    .overlay(alignment: .bottom) { bottomBar }
+    .task { await startSession() }
+    .onDisappear {
+      camera.stop()
+      #if DEBUG
+        if GlareFreeCaptureController.debugActive === controller {
+          GlareFreeCaptureController.debugActive = nil
+        }
+      #endif
+    }
+    .onChange(of: controller?.phase) { _, phase in
+      switch phase {
+      case .capturing(step: 0):
+        // Back at the start (restart after a failure) — stop tracking
+        // until a new reference is taken.
+        tracker.clearReference()
+      case .capturing(let step):
+        // The center shot just landed — it becomes the tracking reference
+        // for the corner steps.
+        if step == 1, let reference = controller?.referenceShot {
+          tracker.setReference(reference)
+        }
+        // Tell the tracker where this step steers the content, so it can
+        // use the expectation as a registration prior.
+        tracker.setExpectedOffset(GlareFreeCaptureController.expectedShift(step: step))
+      case .done:
+        guard let composite = controller?.composite else { return }
+        dismiss()
+        if composite.alignedFrameCount == 0 {
+          model.flow.errorMessage =
+            "Could not align the extra shots — used the center photo as-is."
+        }
+        onImage(composite.image)
+      default:
+        break
+      }
+    }
+    .keepsScreenAwake()
+  }
+
+  private func startSession() async {
+    let controller =
+      self.controller
+      ?? GlareFreeCaptureController(capture: { [camera] in
+        await camera.capturePhoto()
+      })
+    self.controller = controller
+    #if DEBUG
+      GlareFreeCaptureController.debugActive = controller
+    #endif
+    tracker.onUpdate = { update in
+      controller.ingestGuide(update)
+    }
+    camera.attachFrameConsumer(tracker)
+    let started = await camera.start()
+    // Dismissed while the permission prompt was up — the user left on
+    // purpose, so there is nothing to complain about.
+    guard !Task.isCancelled else { return }
+    guard started else {
+      #if DEBUG
+        // The Simulator has no camera; stay on screen over the black
+        // background so `pusseldebug://previewloop` + `glareshot` can
+        // drive the flow. A real device failure still reports and
+        // dismisses — mirrors BoxCameraView.
+        if !BoxCameraSession.isCameraAvailable { return }
+      #endif
+      model.flow.errorMessage =
+        "Pussel cannot use the camera. Check camera access in Settings."
+      dismiss()
+      return
+    }
+    camera.setStreamingEnabled(true)
+  }
+
+  /// The guide graphics over the preview. While aiming the reference shot
+  /// the pulsing dot simply marks the screen center; on the corner steps a
+  /// fixed ring marks the target and the dot moves with the puzzle — the
+  /// tracker pins it to the current step's anchor spot, so steering it
+  /// into the ring is steering the phone.
+  private var guidanceOverlay: some View {
+    GeometryReader { proxy in
+      if let controller, case .capturing(let step) = controller.phase {
+        let center = CGPoint(x: proxy.size.width / 2, y: proxy.size.height / 2)
+        if step == 0 {
+          GuideDot(onTarget: false)
+            .position(center)
+        } else {
+          TargetRing(onTarget: dotIsOnTarget)
+            .position(center)
+          if let dot = controller.dotUnitPosition,
+            let aspect = controller.guide?.frameAspect
+          {
+            GuideDot(onTarget: dotIsOnTarget)
+              .position(
+                clamped(
+                  mapped(dot, frameAspect: aspect, into: proxy.size),
+                  within: proxy.size))
+          }
+        }
+      }
+    }
+    .allowsHitTesting(false)
+    .ignoresSafeArea()
+  }
+
+  /// Whether the tracked dot currently sits inside the aim tolerance — for
+  /// tinting only; the controller makes the actual shutter decision.
+  private var dotIsOnTarget: Bool {
+    guard let dot = controller?.dotUnitPosition else { return false }
+    return hypot(dot.x - 0.5, dot.y - 0.5) <= GlareFreeCaptureController.aimTolerance
+  }
+
+  /// Maps a unit point of the camera frame into view coordinates through
+  /// the preview's aspect-fill: the frame is scaled to cover the view and
+  /// centered, exactly as `AVCaptureVideoPreviewLayer` renders it.
+  private func mapped(_ unit: CGPoint, frameAspect: CGFloat, into size: CGSize) -> CGPoint {
+    guard size.width > 0, size.height > 0, frameAspect > 0 else { return .zero }
+    let filled =
+      size.width / size.height > frameAspect
+      ? CGSize(width: size.width, height: size.width / frameAspect)
+      : CGSize(width: size.height * frameAspect, height: size.height)
+    return CGPoint(
+      x: (size.width - filled.width) / 2 + unit.x * filled.width,
+      y: (size.height - filled.height) / 2 + unit.y * filled.height)
+  }
+
+  /// Keeps the dot visible even when its anchor is outside the view — a
+  /// dot pinned to the edge still tells the user which way to move.
+  private func clamped(_ point: CGPoint, within size: CGSize) -> CGPoint {
+    let inset: CGFloat = 44
+    return CGPoint(
+      x: min(max(point.x, inset), size.width - inset),
+      y: min(max(point.y, inset), size.height - inset))
+  }
+
+  private var topBar: some View {
+    HStack {
+      Button("Cancel") { dismiss() }
+        .foregroundStyle(.white)
+      Spacer()
+      if let controller, case .capturing(let step) = controller.phase {
+        Text("Photo \(step + 1) of \(GlareFreeCaptureController.steps.count)")
+          .font(.callout.weight(.semibold))
+          .foregroundStyle(.white)
+      }
+    }
+    .padding()
+  }
+
+  private var bottomBar: some View {
+    VStack(spacing: 16) {
+      switch controller?.phase {
+      case .capturing(let step):
+        instructionBanner(step: step)
+        if step == 0 {
+          shutterButton
+        }
+      case .composing:
+        progressBanner
+      case .failed(let message):
+        failureBanner(message)
+      case .done, nil:
+        EmptyView()
+      }
+    }
+    .padding(.bottom, 24)
+  }
+
+  private func instructionBanner(step: Int) -> some View {
+    let text: String
+    if step == 0 {
+      text = "Fit the whole puzzle in the frame, then tap the shutter."
+    } else if controller?.guide?.offset == nil {
+      text = "Looking for the puzzle — keep it fully in view."
+    } else {
+      text = "Move the phone until the dot sits in the ring — the photo takes itself."
+    }
+    return banner {
+      Text(text)
+        .font(.callout.weight(.semibold))
+        .foregroundStyle(.white)
+        .multilineTextAlignment(.center)
+    }
+  }
+
+  private var progressBanner: some View {
+    banner {
+      HStack(spacing: 10) {
+        ProgressView()
+          .tint(.white)
+        Text("Removing glare…")
+          .font(.callout.weight(.semibold))
+          .foregroundStyle(.white)
+      }
+    }
+  }
+
+  private func failureBanner(_ message: String) -> some View {
+    banner {
+      VStack(spacing: 10) {
+        Text(message)
+          .font(.callout.weight(.semibold))
+          .foregroundStyle(.white)
+        Button("Start Over") { controller?.restart() }
+          .buttonStyle(.borderedProminent)
+      }
+    }
+  }
+
+  /// Capsule chrome shared by the banners — styled after BoxCameraView's
+  /// lookup banner.
+  private func banner(@ViewBuilder content: () -> some View) -> some View {
+    content()
+      .padding(.horizontal, 16)
+      .padding(.vertical, 10)
+      .background(RoundedRectangle(cornerRadius: 16).fill(.ultraThinMaterial.opacity(0.9)))
+      .shadow(radius: 4)
+      .padding(.horizontal, 24)
+  }
+
+  private var shutterButton: some View {
+    Button {
+      Task { await controller?.captureShot() }
+    } label: {
+      ZStack {
+        Circle().fill(.white).frame(width: 58, height: 58)
+        Circle().strokeBorder(.white, lineWidth: 3).frame(width: 70, height: 70)
+      }
+    }
+    .disabled(controller?.isCapturing ?? true)
+    .accessibilityLabel("Take the reference shot")
+  }
+}
+
+/// The pulsing guide dot. On the corner steps it is pinned to a spot on
+/// the puzzle and turns green as it enters the target ring.
+private struct GuideDot: View {
+  let onTarget: Bool
+  @State private var pulsing = false
+
+  var body: some View {
+    ZStack {
+      Circle()
+        .stroke(onTarget ? .green : .white, lineWidth: 3)
+        .frame(width: 56, height: 56)
+        .scaleEffect(pulsing ? 1.15 : 0.9)
+        .opacity(pulsing ? 0.5 : 1)
+        .animation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true), value: pulsing)
+      Circle()
+        .fill(onTarget ? .green : .white)
+        .frame(width: 14, height: 14)
+    }
+    .shadow(radius: 4)
+    .onAppear { pulsing = true }
+  }
+}
+
+/// The fixed screen-center ring the tracked dot must be steered into.
+private struct TargetRing: View {
+  let onTarget: Bool
+
+  var body: some View {
+    Circle()
+      .stroke(
+        onTarget ? Color.green : Color.white.opacity(0.85),
+        style: StrokeStyle(lineWidth: 3, dash: [7, 6])
+      )
+      .frame(width: 84, height: 84)
+      .shadow(radius: 4)
+  }
+}

--- a/ios/Pussel/Features/Capture/GlareFree/GlareFreeComposer.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/GlareFreeComposer.swift
@@ -1,0 +1,411 @@
+import CoreImage
+import CoreImage.CIFilterBuiltins
+import UIKit
+import Vision
+import simd
+
+/// Fuses a burst of overview shots taken from slightly different camera
+/// positions into one glare-free composite — the technique behind Google's
+/// PhotoScan app.
+///
+/// Glare is specular: it moves across the print as the camera moves, while
+/// the artwork's own diffuse color stays put. So a patch that is washed out
+/// in one shot is clean in another taken a hand-width away. Each extra shot
+/// is registered onto the reference with a homography — exact for a flat
+/// puzzle — and the composite keeps the darkest value observed at each
+/// pixel, because glare only ever *adds* light on top of the surface.
+///
+/// Everything runs on-device: Vision computes the homographies
+/// (`VNHomographicImageRegistrationRequest`) and Core Image warps and
+/// min-composites the frames.
+enum GlareFreeComposer {
+  /// Long-side cap frames are downscaled to before compositing. Bounds
+  /// Core Image work on ~12 MP captures while staying above
+  /// `ImageUtilities.normalizedJPEG`'s 1920 upload cap, so the composite
+  /// loses nothing the backend would ever see.
+  static let workingMaxDimension: CGFloat = 2048
+
+  /// Long-side cap for the registration proxies (see
+  /// `registrationProxy`). Registration doesn't need compositing
+  /// resolution — halving it quarters Vision's work per pass, and the
+  /// found warp is rescaled onto the working frames.
+  static let proxyMaxDimension: CGFloat = 1024
+
+  struct Composite {
+    let image: UIImage
+    /// How many of the extra frames actually registered and joined the
+    /// composite. 0 means the result is just the reference shot.
+    let alignedFrameCount: Int
+  }
+
+  private static let context = CIContext()
+
+  /// Builds the glare-free composite. Synchronous and heavy (a few seconds
+  /// for five frames) — call it off the main actor.
+  ///
+  /// `expectedShifts` optionally carries, per extra frame, the content
+  /// displacement the guided capture flow expects (unit coordinates,
+  /// top-left origin — the shot was taken with a known puzzle anchor
+  /// steered to the screen center, so the shift is the anchor's offset
+  /// from center). Each becomes an extra registration seed hypothesis;
+  /// nil entries and a nil array mean "no expectation".
+  ///
+  /// Frames that fail to register (Vision throws, or refinement never
+  /// converges) are skipped rather than failing the whole composite: a
+  /// glare-free result from three frames still beats the single reference
+  /// shot. Returns nil only when the reference itself is unusable or the
+  /// final render fails.
+  static func compose(
+    reference: UIImage, others: [UIImage], expectedShifts: [CGSize?]? = nil
+  ) -> Composite? {
+    guard let referenceCG = downscaledUpright(reference),
+      let referenceProxies = registrationProxies(of: referenceCG)
+    else { return nil }
+    let extent = CGRect(x: 0, y: 0, width: referenceCG.width, height: referenceCG.height)
+
+    // Gaps a warped frame leaves at the edges become white, so the minimum
+    // there always keeps the reference pixel instead of an undefined black.
+    let white = CIImage(color: .white).cropped(to: extent)
+    var composite = CIImage(cgImage: referenceCG)
+    var alignedCount = 0
+    for (index, other) in others.enumerated() {
+      let expectedShift = expectedShifts.flatMap { $0.indices.contains(index) ? $0[index] : nil }
+      guard let otherCG = downscaledUpright(other),
+        let warp = homography(
+          mapping: otherCG, ontoReferenceProxies: referenceProxies,
+          expectedShift: expectedShift),
+        let warped = warpedImage(otherCG, by: warp)
+      else { continue }
+      let filled = warped.composited(over: white).cropped(to: extent)
+      let minimum = CIFilter.minimumCompositing()
+      minimum.inputImage = filled
+      minimum.backgroundImage = composite
+      guard let merged = minimum.outputImage else { continue }
+      composite = merged.cropped(to: extent)
+      alignedCount += 1
+    }
+
+    guard let outputCG = context.createCGImage(composite, from: extent) else { return nil }
+    return Composite(image: UIImage(cgImage: outputCG), alignedFrameCount: alignedCount)
+  }
+
+  // MARK: - Registration
+
+  /// Homographic refinement passes for
+  /// `homography(mapping:ontoReferenceProxies:)`. The translational
+  /// bootstrap lands within a few pixels, after which one or two passes
+  /// converge; anything still unconverged after 6 is treated as failed.
+  private static let maxRegistrationPasses = 6
+  /// A refinement step that moves the frame's central region by less than
+  /// this many proxy pixels counts as converged.
+  private static let convergenceThreshold: CGFloat = 3
+  /// Blur radii for the coarse and fine registration proxies, as fractions
+  /// of the proxy's long side so behavior is resolution-independent
+  /// (1024-long proxies blur at 16 and 4).
+  private static let coarseBlurFraction: CGFloat = 1.0 / 64.0
+  private static let fineBlurFraction: CGFloat = 1.0 / 256.0
+  /// Acceptance cap for `alignmentError`: mean absolute difference (in
+  /// linear RGB) between the reference proxy and the warped floating proxy
+  /// over the frame's central half. Well-aligned synthetic pairs measure
+  /// ~0.012 (resampling noise plus capped glare rims); a stuck-at-identity
+  /// misregistration measures ~0.075.
+  private static let maxAlignmentError: CGFloat = 0.04
+
+  /// The two registration proxies of one frame: heavily blurred for the
+  /// coarse passes (a wider convergence basin), lightly blurred for the
+  /// final sub-pixel refinement.
+  private struct RegistrationProxies {
+    let coarse: CGImage
+    let fine: CGImage
+  }
+
+  /// The homography mapping `floating`'s pixels into the reference's
+  /// working-resolution space, or nil when registration fails or never
+  /// converges.
+  ///
+  /// Vision's homographic registration is an intensity-based aligner, not
+  /// a feature matcher: it is sub-pixel exact for small displacements but
+  /// erratic for larger ones, and bright specular patches — the very
+  /// thing this composer exists to remove — are moving outliers that can
+  /// pull it off entirely. Four measures make it dependable here:
+  ///
+  /// 1. **Highlight-capped proxies** — registration runs on copies whose
+  ///    brightness is clamped to flat gray (`registrationProxies`), so
+  ///    glare interiors carry no gradients for the aligner to chase.
+  /// 2. **Translational bootstrap** — a translation-only registration on
+  ///    the strongly blurred proxies seeds the warp. Its search is far
+  ///    more constrained, so it lands within a few pixels even for
+  ///    displacements where the homographic aligner diverges.
+  /// 3. **Homographic refinement** — register, warp by the estimate,
+  ///    re-register on the lightly blurred proxies; each pass corrects
+  ///    what remains, including the perspective the bootstrap can't model.
+  /// 4. **Alignment verification** — "the step got small" also describes
+  ///    an aligner that has given up, so a converged warp must additionally
+  ///    pass a direct image comparison (`alignmentError`) before it is
+  ///    trusted.
+  ///
+  /// A pair that never converges, or whose converged warp fails
+  /// verification, is reported as failed rather than smearing a misaligned
+  /// frame into the composite.
+  private static func homography(
+    mapping floating: CGImage, ontoReferenceProxies reference: RegistrationProxies,
+    expectedShift: CGSize? = nil
+  ) -> matrix_float3x3? {
+    guard let floatingProxies = registrationProxies(of: floating) else { return nil }
+    let proxyExtent = CGRect(
+      x: 0, y: 0, width: reference.coarse.width, height: reference.coarse.height)
+    // Seed hypotheses, best first: the translational bootstrap usually
+    // lands within a few pixels, but a dominant specular patch can hijack
+    // its correlation entirely (it is the brightest structure in the
+    // frame even after capping), so the guided flow's geometric
+    // expectation (when it has one) and identity — right whenever the
+    // user barely moved between shots — back it up. The verification gate
+    // decides; a bad seed costs a few wasted passes, never a bad warp.
+    var seeds: [matrix_float3x3] = [matrix_identity_float3x3]
+    if let expectedShift {
+      seeds.insert(seedMatrix(expectedShift: expectedShift, proxyExtent: proxyExtent), at: 0)
+    }
+    if let bootstrap = translation(
+      mapping: floatingProxies.coarse, ontoReference: reference.coarse)
+    {
+      seeds.insert(bootstrap, at: 0)
+    }
+    for seed in seeds {
+      guard
+        let refined = refined(
+          from: seed, floatingProxies: floatingProxies, reference: reference,
+          proxyExtent: proxyExtent)
+      else { continue }
+      return rescaled(
+        refined, fromProxy: proxyExtent,
+        toWorking: CGRect(x: 0, y: 0, width: floating.width, height: floating.height))
+    }
+    return nil
+  }
+
+  /// Runs the homographic refinement loop from `seed` until convergence,
+  /// returning the verified proxy-space warp — or nil when refinement
+  /// never converges or the converged warp fails verification.
+  private static func refined(
+    from seed: matrix_float3x3, floatingProxies: RegistrationProxies,
+    reference: RegistrationProxies, proxyExtent: CGRect
+  ) -> matrix_float3x3? {
+    var total = seed
+    for pass in 1...maxRegistrationPasses {
+      guard
+        let current = rendered(floatingProxies.fine, warpedBy: total, extent: proxyExtent),
+        let step = homographyOnce(mapping: current, ontoReference: reference.fine)
+      else { return nil }
+      // `total` is applied first, then `step` corrects what remains —
+      // matrix product in application order.
+      total = step * total
+      let disp = displacement(of: step, in: proxyExtent)
+      if disp < convergenceThreshold {
+        let error = alignmentError(
+          of: total, floatingFine: floatingProxies.fine,
+          referenceFine: reference.fine, extent: proxyExtent)
+        guard let error, error < maxAlignmentError else { return nil }
+        return total
+      }
+    }
+    return nil
+  }
+
+  /// One Vision homographic registration pass: the warp aligning
+  /// `floating` onto `reference`, as far as Vision's search range reaches.
+  private static func homographyOnce(
+    mapping floating: CGImage, ontoReference reference: CGImage
+  ) -> matrix_float3x3? {
+    let request = VNHomographicImageRegistrationRequest(targetedCGImage: floating, options: [:])
+    let handler = VNImageRequestHandler(cgImage: reference, options: [:])
+    guard (try? handler.perform([request])) != nil else { return nil }
+    return request.results?.first?.warpTransform
+  }
+
+  /// The registration seed for a frame whose content is expected to sit
+  /// `expectedShift` away from the reference (unit coordinates, top-left
+  /// origin): the warp mapping floating pixels back onto the reference is
+  /// the inverse translation, expressed in the proxies' lower-left pixel
+  /// space (which flips the y term's sign along with negating it).
+  /// Internal so tests can pin the sign conventions — a wrong-signed seed
+  /// would fail silently, rescued by the other hypotheses.
+  static func seedMatrix(expectedShift: CGSize, proxyExtent: CGRect) -> matrix_float3x3 {
+    var matrix = matrix_identity_float3x3
+    matrix.columns.2 = SIMD3<Float>(
+      Float(-expectedShift.width * proxyExtent.width),
+      Float(expectedShift.height * proxyExtent.height),
+      1)
+    return matrix
+  }
+
+  /// Vision translation-only registration of `floating` onto `reference`,
+  /// as a 3×3 matrix so it can seed the homographic refinement.
+  private static func translation(
+    mapping floating: CGImage, ontoReference reference: CGImage
+  ) -> matrix_float3x3? {
+    let request = VNTranslationalImageRegistrationRequest(targetedCGImage: floating, options: [:])
+    let handler = VNImageRequestHandler(cgImage: reference, options: [:])
+    guard (try? handler.perform([request])) != nil,
+      let transform = request.results?.first?.alignmentTransform
+    else { return nil }
+    var matrix = matrix_identity_float3x3
+    matrix.columns.2 = SIMD3<Float>(Float(transform.tx), Float(transform.ty), 1)
+    return matrix
+  }
+
+  /// Builds the coarse and fine registration proxies of `image`:
+  /// downscaled to `proxyMaxDimension`, brightness capped at flat gray
+  /// (per-channel minimum against a constant — glare interiors flatten to
+  /// featureless gray), then Gaussian-blurred at the stage's radius.
+  private static func registrationProxies(of image: CGImage) -> RegistrationProxies? {
+    let width = CGFloat(image.width)
+    let height = CGFloat(image.height)
+    guard width > 0, height > 0 else { return nil }
+    let scale = min(1, proxyMaxDimension / max(width, height))
+    let extent = CGRect(
+      x: 0, y: 0, width: (width * scale).rounded(.down), height: (height * scale).rounded(.down))
+    let downscaled = CIImage(cgImage: image)
+      .transformed(by: CGAffineTransform(scaleX: extent.width / width, y: extent.height / height))
+    let cap = CIImage(color: CIColor(red: 0.55, green: 0.55, blue: 0.55)).cropped(to: extent)
+    let minimum = CIFilter.minimumCompositing()
+    minimum.inputImage = downscaled.cropped(to: extent)
+    minimum.backgroundImage = cap
+    guard let capped = minimum.outputImage else { return nil }
+
+    func blurred(radius: CGFloat) -> CGImage? {
+      let blur = CIFilter.gaussianBlur()
+      blur.inputImage = capped.clampedToExtent()
+      blur.radius = Float(radius)
+      guard let output = blur.outputImage else { return nil }
+      return context.createCGImage(output.cropped(to: extent), from: extent)
+    }
+    let longSide = max(extent.width, extent.height)
+    guard let coarse = blurred(radius: longSide * coarseBlurFraction),
+      let fine = blurred(radius: longSide * fineBlurFraction)
+    else { return nil }
+    return RegistrationProxies(coarse: coarse, fine: fine)
+  }
+
+  /// Verifies a candidate warp by comparing images directly: the mean
+  /// absolute difference (linear RGB) between the reference fine proxy and
+  /// the floating fine proxy warped by `warp`, over the central half of
+  /// the frame. Read in linear space because Core Image differences in its
+  /// linear working space, and re-encoding a small average to sRGB would
+  /// inflate it several-fold.
+  private static func alignmentError(
+    of warp: matrix_float3x3, floatingFine: CGImage, referenceFine: CGImage, extent: CGRect
+  ) -> CGFloat? {
+    guard let warped = rendered(floatingFine, warpedBy: warp, extent: extent) else { return nil }
+    let difference = CIFilter.differenceBlendMode()
+    difference.inputImage = CIImage(cgImage: warped)
+    difference.backgroundImage = CIImage(cgImage: referenceFine)
+    guard let diffImage = difference.outputImage else { return nil }
+    let average = CIFilter.areaAverage()
+    average.inputImage = diffImage
+    average.extent = extent.insetBy(dx: extent.width * 0.25, dy: extent.height * 0.25)
+    guard let output = average.outputImage,
+      let linear = CGColorSpace(name: CGColorSpace.linearSRGB)
+    else { return nil }
+    var pixel = [UInt8](repeating: 0, count: 4)
+    context.render(
+      output, toBitmap: &pixel, rowBytes: 4, bounds: CGRect(x: 0, y: 0, width: 1, height: 1),
+      format: .RGBA8, colorSpace: linear)
+    return (CGFloat(pixel[0]) + CGFloat(pixel[1]) + CGFloat(pixel[2])) / 3 / 255
+  }
+
+  /// Rescales a homography found at proxy resolution onto the working
+  /// resolution: conjugation by the proxy↔working scale, so the returned
+  /// matrix maps working-space points to working-space points.
+  private static func rescaled(
+    _ warp: matrix_float3x3, fromProxy proxy: CGRect, toWorking working: CGRect
+  ) -> matrix_float3x3 {
+    let scaleX = Float(proxy.width / working.width)
+    let scaleY = Float(proxy.height / working.height)
+    let toProxy = matrix_float3x3(diagonal: SIMD3<Float>(scaleX, scaleY, 1))
+    let toWorking = matrix_float3x3(diagonal: SIMD3<Float>(1 / scaleX, 1 / scaleY, 1))
+    return toWorking * warp * toProxy
+  }
+
+  /// How far `warp` moves the frame's central region: the maximum
+  /// displacement of the four quarter-inset points. Measured away from the
+  /// corners because a near-converged step can still carry projective
+  /// noise that only amplifies at the very edges.
+  private static func displacement(of warp: matrix_float3x3, in extent: CGRect) -> CGFloat {
+    var worst: CGFloat = 0
+    for unitX in [0.25, 0.75] {
+      for unitY in [0.25, 0.75] {
+        let x = extent.width * unitX
+        let y = extent.height * unitY
+        let projected = warp * SIMD3<Float>(Float(x), Float(y), 1)
+        guard abs(projected.z) > .ulpOfOne else { return .infinity }
+        worst = max(
+          worst,
+          hypot(CGFloat(projected.x / projected.z) - x, CGFloat(projected.y / projected.z) - y))
+      }
+    }
+    return worst
+  }
+
+  /// Renders `image` warped by `warp` over neutral gray, cropped to
+  /// `extent` — the input to the next refinement pass. Gray, not white:
+  /// this render is registered against, and a bright border would hand the
+  /// aligner false structure to latch onto.
+  private static func rendered(
+    _ image: CGImage, warpedBy warp: matrix_float3x3, extent: CGRect
+  ) -> CGImage? {
+    guard let warped = warpedImage(image, by: warp) else { return nil }
+    let gray = CIImage(color: CIColor(red: 0.5, green: 0.5, blue: 0.5)).cropped(to: extent)
+    return context.createCGImage(warped.composited(over: gray).cropped(to: extent), from: extent)
+  }
+
+  /// Applies `warp` with Core Image's perspective transform. A homography
+  /// is fully determined by where it sends four points, so mapping the
+  /// image's corners through the matrix and handing them to
+  /// `CIPerspectiveTransform` reproduces exactly the warp Vision computed.
+  /// Vision's registration transforms are expressed in the same
+  /// lower-left-origin pixel space Core Image renders in, so the corners
+  /// map straight through.
+  static func warpedImage(_ image: CGImage, by warp: matrix_float3x3) -> CIImage? {
+    let width = CGFloat(image.width)
+    let height = CGFloat(image.height)
+    func mapped(_ x: CGFloat, _ y: CGFloat) -> CGPoint? {
+      let projected = warp * SIMD3<Float>(Float(x), Float(y), 1)
+      guard abs(projected.z) > .ulpOfOne else { return nil }
+      return CGPoint(
+        x: CGFloat(projected.x / projected.z), y: CGFloat(projected.y / projected.z))
+    }
+    guard let bottomLeft = mapped(0, 0),
+      let bottomRight = mapped(width, 0),
+      let topLeft = mapped(0, height),
+      let topRight = mapped(width, height)
+    else { return nil }
+    let filter = CIFilter.perspectiveTransform()
+    filter.inputImage = CIImage(cgImage: image)
+    filter.topLeft = topLeft
+    filter.topRight = topRight
+    filter.bottomRight = bottomRight
+    filter.bottomLeft = bottomLeft
+    return filter.outputImage
+  }
+
+  /// Bakes EXIF orientation into the pixels and downscales so the long side
+  /// is at most `workingMaxDimension` — the same normalization for every
+  /// frame, so registration compares like with like.
+  private static func downscaledUpright(_ image: UIImage) -> CGImage? {
+    let pixelSize = CGSize(
+      width: image.size.width * image.scale, height: image.size.height * image.scale)
+    let longSide = max(pixelSize.width, pixelSize.height)
+    guard longSide > 0 else { return nil }
+    let ratio = min(1, workingMaxDimension / longSide)
+    let targetSize = CGSize(
+      width: (pixelSize.width * ratio).rounded(.down),
+      height: (pixelSize.height * ratio).rounded(.down))
+    guard targetSize.width >= 1, targetSize.height >= 1 else { return nil }
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    let upright = UIGraphicsImageRenderer(size: targetSize, format: format).image { _ in
+      image.draw(in: CGRect(origin: .zero, size: targetSize))
+    }
+    return upright.cgImage
+  }
+}

--- a/ios/Pussel/Features/Capture/GlareFree/GlareGuideSource.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/GlareGuideSource.swift
@@ -1,0 +1,43 @@
+import UIKit
+
+/// The guidance backend behind the glare-free capture screen: something
+/// that, once the center reference shot is taken, keeps telling the
+/// controller where the current step's puzzle-anchored target sits in the
+/// live view (as a `GlareGuideUpdate`).
+///
+/// Two implementations: `ARGlareGuideSource` (world-tracking ARKit — the
+/// device path, targets can never be "lost" while tracking holds) and
+/// `GlareGuideTracker` (Vision image registration — the Simulator/E2E
+/// fallback, driven by `pusseldebug://previewloop`).
+@MainActor
+protocol GlareGuideSource: AnyObject {
+  /// Called on the main actor with every guidance measurement. Set once by
+  /// the owning view before guiding starts.
+  var onUpdate: ((GlareGuideUpdate) -> Void)? { get set }
+
+  /// The center shot just landed — start guiding the corner steps.
+  /// `reference` is that shot (the registration tracker aligns live frames
+  /// against it; the AR source freezes its world quad instead).
+  func beginGuiding(reference: UIImage)
+
+  /// The corner step currently being aimed (index into
+  /// `GlareFreeCaptureController.steps`), nil when none is.
+  func setActiveStep(_ step: Int?)
+
+  /// The flow restarted — stop guiding until a new reference is taken.
+  func stopGuiding()
+}
+
+extension GlareGuideTracker: GlareGuideSource {
+  @MainActor func beginGuiding(reference: UIImage) {
+    setReference(reference)
+  }
+
+  @MainActor func setActiveStep(_ step: Int?) {
+    setExpectedOffset(step.flatMap { GlareFreeCaptureController.expectedShift(step: $0) })
+  }
+
+  @MainActor func stopGuiding() {
+    clearReference()
+  }
+}

--- a/ios/Pussel/Features/Capture/GlareFree/GlareGuideTracker.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/GlareGuideTracker.swift
@@ -5,7 +5,6 @@ import Foundation
 import UIKit
 import Vision
 import os
-import simd
 
 /// One measurement of where the reference shot's content currently sits in
 /// the live camera frame.

--- a/ios/Pussel/Features/Capture/GlareFree/GlareGuideTracker.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/GlareGuideTracker.swift
@@ -1,0 +1,367 @@
+import CoreGraphics
+import CoreImage
+import CoreImage.CIFilterBuiltins
+import Foundation
+import UIKit
+import Vision
+import os
+import simd
+
+/// One measurement of where the reference shot's content currently sits in
+/// the live camera frame.
+struct GlareGuideUpdate: Equatable {
+  /// Content displacement in unit coordinates (top-left origin): a point at
+  /// unit position `u` in the reference frame currently appears at
+  /// `u + offset` in the live frame. Nil when the frame could not be
+  /// registered against the reference — tracking lost.
+  let offset: CGSize?
+  /// Width / height of the analyzed live frame, so the view can map unit
+  /// positions through the preview's aspect-fill.
+  let frameAspect: CGFloat
+}
+
+/// Live tracker behind the glare-free screen's puzzle-anchored guide dot:
+/// `BoxCameraSession` pushes downscaled preview frames in from its video
+/// queue, each is registered against the center reference shot with
+/// Vision's translational aligner, and the measured content offset is
+/// delivered to `onUpdate` on the main actor. The controller turns that
+/// into a dot pinned to a fixed spot on the puzzle — and into the
+/// auto-shutter once the dot reaches the screen center.
+///
+/// Translation-only on purpose: the guide needs ~10 Hz robustness, not
+/// sub-pixel warps. The composer redoes full homographic registration on
+/// the captured photos; a few percent of guide error just moves the dot a
+/// few points on screen. Registration runs on small highlight-capped,
+/// blurred proxies (see `GlareFreeComposer` for why capping matters), and
+/// each measurement must pass a direct image-difference check before it is
+/// trusted — a failed check reports "tracking lost" rather than a dot
+/// jumping to wherever a specular blob dragged the correlation.
+///
+/// Threading matches `BarcodeScanStreamer`: `shouldAcceptFrame`/`submit`
+/// are lock-guarded and safe from any thread, `setReference`/`onUpdate`
+/// are main-actor-confined.
+final class GlareGuideTracker: LiveFrameConsumer, @unchecked Sendable {
+  /// Long-side cap for the tracking proxies. A quarter of the composer's
+  /// registration resolution: the dot only needs ~1% accuracy, and small
+  /// proxies keep each measurement a few milliseconds.
+  static let proxyMaxDimension: CGFloat = 384
+  /// Blur radius as a fraction of the proxy long side — the composer's
+  /// coarse-stage blur, chosen there for a wide, glare-resistant basin.
+  private static let blurFraction: CGFloat = 1.0 / 64.0
+  /// Acceptance cap for the mean absolute difference (linear RGB, central
+  /// half) between the reference proxy and the translated frame proxy.
+  /// Looser than the composer's 0.04: these proxies are far blurrier, but
+  /// a hand-held frame also differs from the reference by the perspective
+  /// a translation cannot model.
+  private static let maxAlignmentError: CGFloat = 0.06
+  /// Offsets beyond this are geometrically implausible for a guided shot
+  /// (the puzzle would be mostly out of frame) — treated as tracking lost.
+  private static let maxPlausibleOffset: CGFloat = 0.6
+
+  private static let context = CIContext()
+  private static let log = Logger(subsystem: "dk.delectosoft.pussel", category: "glare-guide")
+
+  private let lock = NSLock()
+  private var throttle = PiecePreviewThrottle()
+  /// Lock-guarded; whether the previous measurement had a fix, so only
+  /// acquired/lost *transitions* are logged — not every 10 Hz frame.
+  private var wasTracking = false
+  /// Lock-guarded; nil until the center reference shot is taken.
+  private var referenceProxy: CGImage?
+  /// Lock-guarded: the last verified proxy-space translation, reused as a
+  /// registration prior for the next frame. A hand moves continuously, so
+  /// the previous fix is almost always within a few pixels of the truth.
+  private var lastTranslation: CGVector?
+  /// Lock-guarded: where the current step expects the content to end up
+  /// (unit offset, top-left origin) — the step's anchor steered to the
+  /// screen center. Used as a fallback prior, which matters because
+  /// Vision's translational correlation can misfire on large raw
+  /// displacements; registering the small residual after pre-shifting by
+  /// the expectation is far better conditioned.
+  private var expectedOffset: CGSize?
+
+  /// Called on the main actor with every measurement. Set once by the
+  /// owning view before streaming starts.
+  @MainActor var onUpdate: ((GlareGuideUpdate) -> Void)?
+
+  /// Installs the center shot as the registration reference. Synchronous
+  /// but cheap (one ~384 px Core Image render); call it when the first
+  /// step's photo lands.
+  @MainActor func setReference(_ image: UIImage) {
+    let proxy = Self.referenceProxy(of: image)
+    lock.withLock {
+      referenceProxy = proxy
+      lastTranslation = nil
+      wasTracking = false
+      throttle = PiecePreviewThrottle()
+    }
+  }
+
+  /// The reference tracking proxy of a captured photo, with its EXIF
+  /// orientation baked into the pixels first. A device photo's `cgImage`
+  /// is the landscape sensor bitmap plus an orientation tag, while the
+  /// live frames this reference is registered against arrive physically
+  /// rotated upright — using the raw bitmap would compare a 90°-rotated
+  /// pair, and tracking would never lock. Internal so the regression test
+  /// can exercise exactly the path `setReference` uses.
+  static func referenceProxy(of image: UIImage) -> CGImage? {
+    let pixelSize = CGSize(
+      width: image.size.width * image.scale, height: image.size.height * image.scale)
+    guard pixelSize.width > 0, pixelSize.height > 0 else { return nil }
+    let scale = min(1, proxyMaxDimension / max(pixelSize.width, pixelSize.height))
+    let target = CGSize(
+      width: (pixelSize.width * scale).rounded(.down),
+      height: (pixelSize.height * scale).rounded(.down))
+    guard target.width >= 1, target.height >= 1 else { return nil }
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    let upright = UIGraphicsImageRenderer(size: target, format: format).image { _ in
+      image.draw(in: CGRect(origin: .zero, size: target))
+    }
+    return upright.cgImage.flatMap { trackingProxy(of: $0) }
+  }
+
+  /// Stops tracking (frames are ignored until a new reference is set) —
+  /// called when the flow restarts.
+  @MainActor func clearReference() {
+    lock.withLock {
+      referenceProxy = nil
+      lastTranslation = nil
+      expectedOffset = nil
+      wasTracking = false
+      throttle = PiecePreviewThrottle()
+    }
+  }
+
+  /// Tells the tracker where the current step is steering the content —
+  /// the controller's expected shift for the active anchor. Nil when
+  /// there is no expectation (the reference step).
+  @MainActor func setExpectedOffset(_ offset: CGSize?) {
+    lock.withLock { expectedOffset = offset }
+  }
+
+  // MARK: - LiveFrameConsumer
+
+  func shouldAcceptFrame(now: Date) -> Bool {
+    lock.withLock { referenceProxy != nil && throttle.shouldSend(now: now) }
+  }
+
+  func submit(cgImage: CGImage, now: Date) {
+    let state = lock.withLock { () -> (CGImage, [CGVector])? in
+      guard let referenceProxy, throttle.shouldSend(now: now) else { return nil }
+      throttle.markSent(at: now)
+      var priors: [CGVector] = []
+      if let lastTranslation {
+        priors.append(lastTranslation)
+      }
+      if let expectedOffset {
+        priors.append(
+          Self.translationVector(
+            ofUnitOffset: expectedOffset,
+            proxySize: CGSize(width: referenceProxy.width, height: referenceProxy.height)))
+      }
+      priors.append(.zero)
+      return (referenceProxy, priors)
+    }
+    guard let (reference, priors) = state else { return }
+    Task.detached(priority: .userInitiated) { [weak self] in
+      guard let self else { return }
+      defer { self.lock.withLock { self.throttle.markCompleted() } }
+      let (update, translation) = Self.measure(
+        frame: cgImage, referenceProxy: reference, priors: priors)
+      let isTracking = update.offset != nil
+      let transitioned = self.lock.withLock { () -> Bool in
+        if let translation {
+          self.lastTranslation = translation
+        }
+        let changed = self.wasTracking != isTracking
+        self.wasTracking = isTracking
+        return changed
+      }
+      if transitioned {
+        if let offset = update.offset {
+          let x = offset.width
+          let y = offset.height
+          Self.log.info(
+            "tracking acquired, offset (\(x, format: .fixed(precision: 3)), \(y, format: .fixed(precision: 3)))"
+          )
+        } else {
+          Self.log.info("tracking lost")
+        }
+      }
+      await MainActor.run { self.onUpdate?(update) }
+    }
+  }
+
+  // MARK: - Measurement
+
+  /// Registers `frame` against the reference proxy and converts the found
+  /// translation into a unit content offset. Returns the update plus the
+  /// verified proxy-space translation (nil when lost) so the caller can
+  /// carry it forward as the next frame's prior. Static so it is directly
+  /// testable without a camera or throttle.
+  ///
+  /// Each prior is tried in turn, yielding up to two candidate fixes: the
+  /// prior refined by Vision registering the residual of the pre-shifted
+  /// proxy, and the raw prior itself. A `.zero` prior is plain direct
+  /// registration. Every candidate must pass the image-difference
+  /// verification, so an accepted raw prior is not a guess — it is
+  /// template matching at a hypothesized displacement. The shape exists
+  /// because Vision's correlation demonstrably misfires: steering-sized
+  /// shifts came back with a wildly wrong x on the Simulator, and there
+  /// even the residual of a nearly aligned pair can be garbage — the
+  /// verification gate keeps whichever candidate actually matches the
+  /// pixels.
+  static func measure(
+    frame: CGImage, referenceProxy: CGImage, priors: [CGVector] = [.zero]
+  ) -> (GlareGuideUpdate, CGVector?) {
+    let aspect = CGFloat(frame.width) / CGFloat(frame.height)
+    let lost = (GlareGuideUpdate(offset: nil, frameAspect: aspect), CGVector?.none)
+    let proxySize = CGSize(width: referenceProxy.width, height: referenceProxy.height)
+    let extent = CGRect(origin: .zero, size: proxySize)
+    // Render the frame proxy at exactly the reference proxy's pixel size so
+    // the registration translation lives in one well-defined space. Live
+    // frames and the reference photo share the camera's aspect, so this is
+    // a pure downscale in practice, not a distorting stretch.
+    guard let frameProxy = trackingProxy(of: frame, size: proxySize) else { return lost }
+    for prior in priors {
+      var candidates: [CGVector] = []
+      if prior == .zero {
+        if let direct = translation(mapping: frameProxy, ontoReference: referenceProxy) {
+          candidates.append(direct)
+        }
+      } else {
+        if let preShifted = rendered(frameProxy, shiftedBy: prior, extent: extent),
+          let residual = translation(mapping: preShifted, ontoReference: referenceProxy)
+        {
+          candidates.append(CGVector(dx: prior.dx + residual.dx, dy: prior.dy + residual.dy))
+        }
+        candidates.append(prior)
+      }
+      for total in candidates {
+        guard
+          alignmentError(of: total, floating: frameProxy, reference: referenceProxy) ?? 1
+            < maxAlignmentError
+        else { continue }
+        // `total` maps live-frame pixels into reference pixels (lower-left
+        // origin): p_ref = p_live + t. A reference point therefore shows
+        // up in the live frame displaced by −t — flipped to top-left units
+        // for the UI.
+        let offset = CGSize(
+          width: -total.dx / proxySize.width,
+          height: total.dy / proxySize.height)
+        guard abs(offset.width) < maxPlausibleOffset, abs(offset.height) < maxPlausibleOffset
+        else { continue }
+        return (GlareGuideUpdate(offset: offset, frameAspect: aspect), total)
+      }
+    }
+    return lost
+  }
+
+  /// The proxy-space translation at which a unit content offset (top-left
+  /// origin) would place the live frame — the inverse of the conversion in
+  /// `measure`, used to turn the expected offset into a prior.
+  static func translationVector(ofUnitOffset offset: CGSize, proxySize: CGSize) -> CGVector {
+    CGVector(dx: -offset.width * proxySize.width, dy: offset.height * proxySize.height)
+  }
+
+  /// Renders the proxy shifted by `translation` over neutral gray — the
+  /// pre-shifted input whose residual registration a prior hypothesis
+  /// measures. Gray, not black: the fill is registered against, and a hard
+  /// dark border would hand the correlation false structure.
+  private static func rendered(
+    _ image: CGImage, shiftedBy translation: CGVector, extent: CGRect
+  ) -> CGImage? {
+    let gray = CIImage(color: CIColor(red: 0.5, green: 0.5, blue: 0.5)).cropped(to: extent)
+    let shifted = CIImage(cgImage: image)
+      .transformed(by: CGAffineTransform(translationX: translation.dx, y: translation.dy))
+      .composited(over: gray)
+      .cropped(to: extent)
+    return context.createCGImage(shifted, from: extent)
+  }
+
+  private static func translation(
+    mapping floating: CGImage, ontoReference reference: CGImage
+  ) -> CGVector? {
+    let request = VNTranslationalImageRegistrationRequest(targetedCGImage: floating, options: [:])
+    let handler = VNImageRequestHandler(cgImage: reference, options: [:])
+    guard (try? handler.perform([request])) != nil,
+      let transform = request.results?.first?.alignmentTransform
+    else { return nil }
+    return CGVector(dx: transform.tx, dy: transform.ty)
+  }
+
+  /// The tracking proxy of `image`: downscaled (to `size`, or to
+  /// `proxyMaxDimension` on the long side), brightness capped at flat gray
+  /// so glare carries no gradients, then blurred — the same conditioning
+  /// the composer applies before its own registration. Internal so tests
+  /// can build a reference proxy without the main-actor plumbing.
+  static func trackingProxy(of image: CGImage, size: CGSize? = nil) -> CGImage? {
+    let width = CGFloat(image.width)
+    let height = CGFloat(image.height)
+    guard width > 0, height > 0 else { return nil }
+    let target: CGSize
+    if let size {
+      target = size
+    } else {
+      let scale = min(1, proxyMaxDimension / max(width, height))
+      target = CGSize(
+        width: (width * scale).rounded(.down), height: (height * scale).rounded(.down))
+    }
+    guard target.width >= 1, target.height >= 1 else { return nil }
+    let extent = CGRect(origin: .zero, size: target)
+    let downscaled = CIImage(cgImage: image)
+      .transformed(by: CGAffineTransform(scaleX: target.width / width, y: target.height / height))
+    let cap = CIImage(color: CIColor(red: 0.55, green: 0.55, blue: 0.55)).cropped(to: extent)
+    let minimum = CIFilter.minimumCompositing()
+    minimum.inputImage = downscaled.cropped(to: extent)
+    minimum.backgroundImage = cap
+    guard let capped = minimum.outputImage else { return nil }
+    let blur = CIFilter.gaussianBlur()
+    blur.inputImage = capped.clampedToExtent()
+    blur.radius = Float(max(target.width, target.height) * blurFraction)
+    guard let blurred = blur.outputImage else { return nil }
+    return context.createCGImage(blurred.cropped(to: extent), from: extent)
+  }
+
+  /// Mean absolute difference (linear RGB) between the reference proxy and
+  /// the frame proxy shifted by `translation` — the same verification idea
+  /// as `GlareFreeComposer.alignmentError`, including the linear-space
+  /// readout (an sRGB re-encode would inflate small averages several-fold).
+  ///
+  /// Averaged over the central half *clipped to where the shifted frame
+  /// actually has pixels*: at steering-sized offsets the shifted frame no
+  /// longer covers the whole window, and letting the filler band into the
+  /// average would report "lost" precisely when the user reaches the
+  /// target.
+  private static func alignmentError(
+    of translation: CGVector, floating: CGImage, reference: CGImage
+  ) -> CGFloat? {
+    let extent = CGRect(x: 0, y: 0, width: reference.width, height: reference.height)
+    let gray = CIImage(color: CIColor(red: 0.5, green: 0.5, blue: 0.5)).cropped(to: extent)
+    let shifted = CIImage(cgImage: floating)
+      .transformed(by: CGAffineTransform(translationX: translation.dx, y: translation.dy))
+      .composited(over: gray)
+      .cropped(to: extent)
+    let window =
+      extent
+      .insetBy(dx: extent.width * 0.25, dy: extent.height * 0.25)
+      .intersection(extent.offsetBy(dx: translation.dx, dy: translation.dy))
+    guard !window.isEmpty else { return nil }
+    let difference = CIFilter.differenceBlendMode()
+    difference.inputImage = shifted
+    difference.backgroundImage = CIImage(cgImage: reference)
+    guard let diffImage = difference.outputImage else { return nil }
+    let average = CIFilter.areaAverage()
+    average.inputImage = diffImage
+    average.extent = window
+    guard let output = average.outputImage,
+      let linear = CGColorSpace(name: CGColorSpace.linearSRGB)
+    else { return nil }
+    var pixel = [UInt8](repeating: 0, count: 4)
+    context.render(
+      output, toBitmap: &pixel, rowBytes: 4, bounds: CGRect(x: 0, y: 0, width: 1, height: 1),
+      format: .RGBA8, colorSpace: linear)
+    return (CGFloat(pixel[0]) + CGFloat(pixel[1]) + CGFloat(pixel[2])) / 3 / 255
+  }
+}

--- a/ios/Pussel/Features/Capture/LiveFrameConsumer.swift
+++ b/ios/Pussel/Features/Capture/LiveFrameConsumer.swift
@@ -1,0 +1,21 @@
+import CoreGraphics
+import Foundation
+
+/// A consumer of a camera session's live low-res frame stream — the barcode
+/// streamer on the box screen, the glare-guide tracker on the glare-free
+/// screen. Both methods must be safe to call from the session's video queue.
+///
+/// The two-call shape exists so the session can check `shouldAcceptFrame`
+/// *before* paying to downscale and detach a frame that would only be
+/// dropped by the consumer's throttle.
+protocol LiveFrameConsumer: AnyObject {
+  /// Whether a frame arriving at `now` is worth preparing and submitting.
+  func shouldAcceptFrame(now: Date) -> Bool
+  /// Analyzes an already-downscaled upright frame. Must return quickly
+  /// (dispatch real work to a background task).
+  func submit(cgImage: CGImage, now: Date)
+}
+
+/// `BarcodeScanStreamer` already speaks this shape — the protocol was
+/// extracted from it when the glare-free screen became the second consumer.
+extension BarcodeScanStreamer: LiveFrameConsumer {}

--- a/ios/Pussel/Support/DebugNavigation.swift
+++ b/ios/Pussel/Support/DebugNavigation.swift
@@ -16,7 +16,12 @@
   ///   scan[?open=0] (M10 scan-and-lock demo — mirrors camera),
   ///   scanconfirm (taps the M10 uncertain-confirm chip on the open scan view),
   ///   boxcamera[?open=0] (forces the capture screen's live box-camera cover
-  ///   open, for the barcode auto-lookup flow — mirrors camera).
+  ///   open, for the barcode auto-lookup flow — mirrors camera),
+  ///   glarecamera[?open=0] (forces the glare-free five-shot capture cover
+  ///   open — mirrors boxcamera),
+  ///   glareshot (takes the open glare-free screen's next shot; feed the
+  ///   frame first with previewloop, swapping the path between shots to
+  ///   simulate moving glare).
   /// Simulator apps can read host file paths directly. Compiled out of
   /// Release builds; the handler runs the same actions as the real UI.
   @MainActor
@@ -94,6 +99,10 @@
         debugCamera(open: value("open"))
       case "boxcamera":
         debugBoxCamera(open: value("open"))
+      case "glarecamera":
+        debugGlareCamera(open: value("open"))
+      case "glareshot":
+        await GlareFreeCaptureController.debugActive?.captureShot()
       case "scan":
         debugScan(open: value("open"))
       case "scanconfirm":
@@ -169,6 +178,13 @@
     /// capture-puzzle phase (`reset` gets there).
     private func debugBoxCamera(open: String?) {
       flow.debugBoxCameraOpen = (open.flatMap(Int.init) ?? 1) != 0
+    }
+
+    /// Forces the glare-free capture cover open (or closed with `?open=0`),
+    /// even on the Simulator — mirrors `debugBoxCamera`. Must be in the
+    /// capture-puzzle phase (`reset` gets there).
+    private func debugGlareCamera(open: String?) {
+      flow.debugGlareCameraOpen = (open.flatMap(Int.init) ?? 1) != 0
     }
 
     /// Starts (or, with `?stop=1`, stops) a repeating fake-frame loop on the

--- a/ios/PusselTests/ARGuideGeometryTests.swift
+++ b/ios/PusselTests/ARGuideGeometryTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+import simd
+
+@testable import Pussel
+
+/// Tests for the AR guide source's pure geometry — the quad interpolation
+/// that places the corner targets on the puzzle's plane, and the
+/// front-of-camera test that keeps behind-the-camera projections (which
+/// come out mirrored) off the screen. No `ARSession` involved.
+final class ARGuideGeometryTests: XCTestCase {
+  /// A 2×2 m quad on the floor plane, in raycast screen-corner order:
+  /// top left, top right, bottom right, bottom left.
+  private let quad: [SIMD3<Float>] = [
+    SIMD3(-1, 0, -1),
+    SIMD3(1, 0, -1),
+    SIMD3(1, 0, 1),
+    SIMD3(-1, 0, 1),
+  ]
+
+  private func assertEqual(
+    _ point: SIMD3<Float>, _ expected: SIMD3<Float>, file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    XCTAssertEqual(point.x, expected.x, accuracy: 1e-5, file: file, line: line)
+    XCTAssertEqual(point.y, expected.y, accuracy: 1e-5, file: file, line: line)
+    XCTAssertEqual(point.z, expected.z, accuracy: 1e-5, file: file, line: line)
+  }
+
+  func testInterpolationHitsTheQuadCorners() {
+    assertEqual(ARGuideGeometry.interpolated(quad: quad, at: CGPoint(x: 0, y: 0)), quad[0])
+    assertEqual(ARGuideGeometry.interpolated(quad: quad, at: CGPoint(x: 1, y: 0)), quad[1])
+    assertEqual(ARGuideGeometry.interpolated(quad: quad, at: CGPoint(x: 1, y: 1)), quad[2])
+    assertEqual(ARGuideGeometry.interpolated(quad: quad, at: CGPoint(x: 0, y: 1)), quad[3])
+  }
+
+  func testInterpolationOfCenterAndAnchor() {
+    assertEqual(
+      ARGuideGeometry.interpolated(quad: quad, at: CGPoint(x: 0.5, y: 0.5)), SIMD3(0, 0, 0))
+    // The top-left step anchor: a quarter across, a third down.
+    assertEqual(
+      ARGuideGeometry.interpolated(quad: quad, at: CGPoint(x: 0.25, y: 0.32)),
+      SIMD3(-0.5, 0, -0.36))
+  }
+
+  func testInterpolationOfANonPlanarQuadStaysBilinear() {
+    // Lift one corner: interpolation along the top edge must follow it.
+    var lifted = quad
+    lifted[1].y = 2
+    let point = ARGuideGeometry.interpolated(quad: lifted, at: CGPoint(x: 0.75, y: 0))
+    XCTAssertEqual(point.y, 1.5, accuracy: 1e-5)
+  }
+
+  func testIsInFrontUsesTheCameraLookDirection() {
+    // The identity camera sits at the origin looking down −z.
+    let identity = matrix_identity_float4x4
+    XCTAssertTrue(ARGuideGeometry.isInFront(ofCameraAt: identity, point: SIMD3(0, 0, -1)))
+    XCTAssertFalse(ARGuideGeometry.isInFront(ofCameraAt: identity, point: SIMD3(0, 0, 1)))
+  }
+
+  func testIsInFrontFollowsTheCameraTransform() {
+    // Turn the camera 180° about y: it now looks toward +z, so the same
+    // world points swap sides.
+    let about = simd_quatf(angle: .pi, axis: SIMD3(0, 1, 0))
+    var transform = simd_float4x4(about)
+    transform.columns.3 = SIMD4(0, 0, -3, 1)
+    XCTAssertTrue(ARGuideGeometry.isInFront(ofCameraAt: transform, point: SIMD3(0, 0, 1)))
+    XCTAssertFalse(ARGuideGeometry.isInFront(ofCameraAt: transform, point: SIMD3(0, 0, -5)))
+  }
+}

--- a/ios/PusselTests/GlareAimStabilityTrackerTests.swift
+++ b/ios/PusselTests/GlareAimStabilityTrackerTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import XCTest
+
+@testable import Pussel
+
+final class GlareAimStabilityTrackerTests: XCTestCase {
+  private let start = Date(timeIntervalSinceReferenceDate: 1000)
+
+  private func at(_ seconds: TimeInterval) -> Date {
+    start.addingTimeInterval(seconds)
+  }
+
+  func testFiresAfterSustainedOnTargetDwell() {
+    var tracker = GlareAimStabilityTracker()
+    XCTAssertFalse(tracker.ingest(onTarget: true, at: at(0)))
+    XCTAssertFalse(tracker.ingest(onTarget: true, at: at(0.2)))
+    XCTAssertTrue(tracker.ingest(onTarget: true, at: at(0.45)))
+  }
+
+  func testDwellNeedsElapsedTimeNotJustSamples() {
+    var tracker = GlareAimStabilityTracker()
+    // A burst of samples with no time passing is not a steady hand.
+    XCTAssertFalse(tracker.ingest(onTarget: true, at: at(0)))
+    XCTAssertFalse(tracker.ingest(onTarget: true, at: at(0)))
+    XCTAssertFalse(tracker.ingest(onTarget: true, at: at(0.1)))
+  }
+
+  func testOffTargetBreaksTheStreak() {
+    var tracker = GlareAimStabilityTracker()
+    XCTAssertFalse(tracker.ingest(onTarget: true, at: at(0)))
+    XCTAssertFalse(tracker.ingest(onTarget: false, at: at(0.2)))
+    // The streak restarts here; 0.3 s later is not yet a full dwell.
+    XCTAssertFalse(tracker.ingest(onTarget: true, at: at(0.4)))
+    XCTAssertFalse(tracker.ingest(onTarget: true, at: at(0.7)))
+    XCTAssertTrue(tracker.ingest(onTarget: true, at: at(0.9)))
+  }
+
+  func testLatchesUntilReset() {
+    var tracker = GlareAimStabilityTracker()
+    _ = tracker.ingest(onTarget: true, at: at(0))
+    XCTAssertTrue(tracker.ingest(onTarget: true, at: at(0.5)))
+    // Still on target — must not fire again for the same step.
+    XCTAssertFalse(tracker.ingest(onTarget: true, at: at(1.0)))
+    XCTAssertFalse(tracker.ingest(onTarget: true, at: at(2.0)))
+    tracker.reset()
+    XCTAssertFalse(tracker.ingest(onTarget: true, at: at(3.0)))
+    XCTAssertTrue(tracker.ingest(onTarget: true, at: at(3.5)))
+  }
+}

--- a/ios/PusselTests/GlareFreeCaptureControllerTests.swift
+++ b/ios/PusselTests/GlareFreeCaptureControllerTests.swift
@@ -1,0 +1,184 @@
+import UIKit
+import XCTest
+
+@testable import Pussel
+
+/// Tests for the five-shot glare-free capture state machine, with capture
+/// and compose injected — no camera or Vision involved.
+@MainActor
+final class GlareFreeCaptureControllerTests: XCTestCase {
+  private func solidImage() -> UIImage {
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    return UIGraphicsImageRenderer(size: CGSize(width: 4, height: 4), format: format)
+      .image { context in
+        UIColor.red.setFill()
+        context.fill(CGRect(x: 0, y: 0, width: 4, height: 4))
+      }
+  }
+
+  /// A tracker update whose offset steers the given step's anchor exactly
+  /// onto the screen center.
+  private func onTargetUpdate(step: Int) -> GlareGuideUpdate {
+    let anchor = GlareFreeCaptureController.steps[step].anchor
+    return GlareGuideUpdate(
+      offset: CGSize(width: 0.5 - anchor.x, height: 0.5 - anchor.y), frameAspect: 0.75)
+  }
+
+  /// Waits for the controller's async auto-capture task to move the phase
+  /// past the given step.
+  private func waitForAdvance(
+    of controller: GlareFreeCaptureController, past step: Int
+  ) async {
+    for _ in 0..<200 {
+      if controller.phase != .capturing(step: step) { return }
+      await Task.yield()
+    }
+  }
+
+  func testAdvancesThroughAllStepsThenComposes() async {
+    let controller = GlareFreeCaptureController(
+      capture: { self.solidImage() },
+      compose: { reference, others, _ in
+        GlareFreeComposer.Composite(image: reference, alignedFrameCount: others.count)
+      })
+    for step in 0..<GlareFreeCaptureController.steps.count {
+      XCTAssertEqual(controller.phase, .capturing(step: step))
+      XCTAssertEqual(controller.capturedCount, step)
+      await controller.captureShot()
+    }
+    XCTAssertEqual(controller.phase, .done)
+    // The fake compose reports one aligned frame per non-reference shot,
+    // proving the reference/others split reached it intact.
+    XCTAssertEqual(
+      controller.composite?.alignedFrameCount, GlareFreeCaptureController.steps.count - 1)
+  }
+
+  func testCenterShotBecomesTrackingReference() async {
+    let reference = solidImage()
+    let controller = GlareFreeCaptureController(
+      capture: { reference }, compose: { _, _, _ in nil })
+    XCTAssertNil(controller.referenceShot)
+    await controller.captureShot()
+    XCTAssertIdentical(controller.referenceShot, reference)
+  }
+
+  func testAimDwellAutoCapturesCornerStep() async {
+    let controller = GlareFreeCaptureController(
+      capture: { self.solidImage() }, compose: { _, _, _ in nil })
+    await controller.captureShot()
+    XCTAssertEqual(controller.phase, .capturing(step: 1))
+
+    let start = Date()
+    // One on-target measurement is not enough — the dwell needs time.
+    controller.ingestGuide(onTargetUpdate(step: 1), at: start)
+    XCTAssertEqual(controller.phase, .capturing(step: 1))
+    // Comfortably past minDuration — Date arithmetic can land a rounding
+    // error short of an exact threshold.
+    controller.ingestGuide(
+      onTargetUpdate(step: 1),
+      at: start.addingTimeInterval(GlareAimStabilityTracker.minDuration + 0.1))
+    await waitForAdvance(of: controller, past: 1)
+    XCTAssertEqual(controller.phase, .capturing(step: 2))
+    XCTAssertEqual(controller.capturedCount, 2)
+    // The advance re-armed the aim: the new step starts without a guide
+    // fix, so no stale dot can instantly re-fire.
+    XCTAssertNil(controller.guide)
+  }
+
+  func testOffTargetDwellDoesNotCapture() async {
+    let controller = GlareFreeCaptureController(
+      capture: { self.solidImage() }, compose: { _, _, _ in nil })
+    await controller.captureShot()
+
+    // The dot sits at its resting anchor position (offset zero) — well
+    // outside the center ring.
+    let resting = GlareGuideUpdate(offset: .zero, frameAspect: 0.75)
+    let start = Date()
+    for tick in 0..<10 {
+      controller.ingestGuide(resting, at: start.addingTimeInterval(Double(tick) * 0.2))
+    }
+    XCTAssertEqual(controller.phase, .capturing(step: 1))
+    XCTAssertEqual(controller.capturedCount, 1)
+  }
+
+  func testGuideIsIgnoredWhileAimingTheReferenceShot() {
+    let controller = GlareFreeCaptureController(
+      capture: { self.solidImage() }, compose: { _, _, _ in nil })
+    controller.ingestGuide(onTargetUpdate(step: 1))
+    XCTAssertNil(controller.guide)
+    XCTAssertEqual(controller.phase, .capturing(step: 0))
+  }
+
+  func testDotPositionTracksAnchorPlusOffset() async throws {
+    let controller = GlareFreeCaptureController(
+      capture: { self.solidImage() }, compose: { _, _, _ in nil })
+    // While aiming the reference shot the dot marks the screen center.
+    XCTAssertEqual(controller.dotUnitPosition, CGPoint(x: 0.5, y: 0.5))
+    await controller.captureShot()
+    // No fix yet — no dot.
+    XCTAssertNil(controller.dotUnitPosition)
+    controller.ingestGuide(
+      GlareGuideUpdate(offset: CGSize(width: 0.1, height: -0.05), frameAspect: 0.75))
+    let anchor = GlareFreeCaptureController.steps[1].anchor
+    let dot = try XCTUnwrap(controller.dotUnitPosition)
+    XCTAssertEqual(dot.x, anchor.x + 0.1, accuracy: 1e-9)
+    XCTAssertEqual(dot.y, anchor.y - 0.05, accuracy: 1e-9)
+  }
+
+  func testComposeReceivesTheExpectedShifts() async throws {
+    var receivedShifts: [CGSize?] = []
+    let controller = GlareFreeCaptureController(
+      capture: { self.solidImage() },
+      compose: { reference, _, shifts in
+        receivedShifts = shifts
+        return GlareFreeComposer.Composite(image: reference, alignedFrameCount: 4)
+      })
+    for _ in GlareFreeCaptureController.steps.indices {
+      await controller.captureShot()
+    }
+    XCTAssertEqual(receivedShifts.count, GlareFreeCaptureController.steps.count - 1)
+    // Each corner shot is expected to have moved the content by its
+    // anchor's offset from the center — e.g. the top-left anchor at
+    // (0.25, 0.32) means the content moved (+0.25, +0.18).
+    let first = try XCTUnwrap(receivedShifts.first ?? nil)
+    XCTAssertEqual(first.width, 0.25, accuracy: 1e-9)
+    XCTAssertEqual(first.height, 0.18, accuracy: 1e-9)
+  }
+
+  func testNilCaptureFailsTheStep() async {
+    let controller = GlareFreeCaptureController(
+      capture: { nil },
+      compose: { _, _, _ in
+        XCTFail("compose should not run after a failed capture")
+        return nil
+      })
+    await controller.captureShot()
+    guard case .failed = controller.phase else {
+      return XCTFail("expected .failed, got \(controller.phase)")
+    }
+  }
+
+  func testRestartAfterFailureBeginsANewSequence() async {
+    let controller = GlareFreeCaptureController(capture: { nil }, compose: { _, _, _ in nil })
+    await controller.captureShot()
+    controller.restart()
+    XCTAssertEqual(controller.phase, .capturing(step: 0))
+    XCTAssertEqual(controller.capturedCount, 0)
+    XCTAssertNil(controller.composite)
+    XCTAssertNil(controller.referenceShot)
+  }
+
+  func testNilComposeFallsBackToReferenceShot() async {
+    let controller = GlareFreeCaptureController(
+      capture: { self.solidImage() }, compose: { _, _, _ in nil })
+    for _ in GlareFreeCaptureController.steps.indices {
+      await controller.captureShot()
+    }
+    XCTAssertEqual(controller.phase, .done)
+    // The degraded composite is the reference shot, flagged by a zero
+    // aligned-frame count so the view can tell the user.
+    XCTAssertEqual(controller.composite?.alignedFrameCount, 0)
+    XCTAssertNotNil(controller.composite?.image)
+  }
+}

--- a/ios/PusselTests/GlareFreeComposerTests.swift
+++ b/ios/PusselTests/GlareFreeComposerTests.swift
@@ -1,0 +1,191 @@
+import UIKit
+import XCTest
+import simd
+
+@testable import Pussel
+
+/// Tests for the glare-free burst composer, running the real Vision
+/// registration + Core Image min-composite pipeline on synthetic frames
+/// with known glare. The frames shift by ~40 px, so a warp applied in the
+/// wrong direction (an 80 px error) samples entirely different texture and
+/// fails loudly — the test pins the registration convention, not just
+/// "something blended".
+final class GlareFreeComposerTests: XCTestCase {
+  private let cardSize = 512
+
+  /// Deterministic test card: seeded random mid-brightness rectangles.
+  /// Deliberately non-periodic — a regular grid nearly matches itself at
+  /// cell offsets, which can pull intensity-based registration into a
+  /// false identity alignment. All colors sit well below white so glare is
+  /// always the brightest thing in a frame.
+  private func testCard() -> UIImage {
+    var state: UInt64 = 0x9E37_79B9_7F4A_7C15
+    func next() -> CGFloat {
+      state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+      return CGFloat(state >> 33) / CGFloat(UInt32.max >> 1)
+    }
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    return UIGraphicsImageRenderer(
+      size: CGSize(width: cardSize, height: cardSize), format: format
+    ).image { context in
+      UIColor(white: 0.4, alpha: 1).setFill()
+      context.fill(CGRect(x: 0, y: 0, width: cardSize, height: cardSize))
+      for _ in 0..<300 {
+        let width = 10 + next() * 70
+        let height = 10 + next() * 70
+        let x = next() * (CGFloat(cardSize) - width)
+        let y = next() * (CGFloat(cardSize) - height)
+        UIColor(
+          red: 0.15 + 0.55 * next(),
+          green: 0.15 + 0.55 * next(),
+          blue: 0.15 + 0.55 * next(),
+          alpha: 1
+        ).setFill()
+        context.fill(CGRect(x: x, y: y, width: width, height: height))
+      }
+      // Uniform patches over the two sampled points, so the assertions
+      // compare solid color against solid color rather than landing on a
+      // random rectangle edge blurred by warp resampling.
+      UIColor(red: 0.30, green: 0.55, blue: 0.25, alpha: 1).setFill()
+      context.fill(CGRect(x: 140, y: 140, width: 40, height: 40))
+      UIColor(red: 0.25, green: 0.40, blue: 0.55, alpha: 1).setFill()
+      context.fill(CGRect(x: 76, y: 268, width: 40, height: 40))
+    }
+  }
+
+  /// One simulated shot: the card drawn shifted by `translation` over a
+  /// gray backdrop, with an optional white "glare" disc burned in at
+  /// `glareCenter` (canvas coordinates, top-left origin).
+  private func frame(
+    base: UIImage, translation: CGSize, glareCenter: CGPoint?
+  ) -> UIImage {
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    return UIGraphicsImageRenderer(
+      size: CGSize(width: cardSize, height: cardSize), format: format
+    ).image { context in
+      UIColor(white: 0.5, alpha: 1).setFill()
+      context.fill(CGRect(x: 0, y: 0, width: cardSize, height: cardSize))
+      base.draw(at: CGPoint(x: translation.width, y: translation.height))
+      if let glareCenter {
+        UIColor.white.setFill()
+        context.cgContext.fillEllipse(
+          in: CGRect(x: glareCenter.x - 48, y: glareCenter.y - 48, width: 96, height: 96))
+      }
+    }
+  }
+
+  /// The RGB of the pixel at `point` (top-left-origin pixel coordinates).
+  private func pixel(of image: UIImage, at point: CGPoint) -> [UInt8] {
+    guard let cgImage = image.cgImage else {
+      XCTFail("image has no CGImage")
+      return [0, 0, 0]
+    }
+    var rgba = [UInt8](repeating: 0, count: 4)
+    guard
+      let context = CGContext(
+        data: &rgba,
+        width: 1,
+        height: 1,
+        bitsPerComponent: 8,
+        bytesPerRow: 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+          | CGBitmapInfo.byteOrder32Big.rawValue)
+    else {
+      XCTFail("could not create pixel context")
+      return [0, 0, 0]
+    }
+    // Draw so the wanted pixel lands at (0,0): offset by -point, flipped to
+    // CG's lower-left origin via the height term.
+    context.draw(
+      cgImage,
+      in: CGRect(
+        x: -point.x, y: point.y - CGFloat(cgImage.height) + 1,
+        width: CGFloat(cgImage.width), height: CGFloat(cgImage.height)))
+    return Array(rgba[0..<3])
+  }
+
+  private func assertClose(
+    _ actual: [UInt8], _ expected: [UInt8], tolerance: Int, _ message: String,
+    file: StaticString = #filePath, line: UInt = #line
+  ) {
+    for (got, want) in zip(actual, expected) {
+      XCTAssertEqual(
+        Int(got), Int(want), accuracy: tolerance, "\(message) — got \(actual), want \(expected)",
+        file: file, line: line)
+    }
+  }
+
+  func testComposeRemovesReferenceGlare() throws {
+    let base = testCard()
+    let referenceGlare = CGPoint(x: 160, y: 160)
+    let reference = frame(base: base, translation: .zero, glareCenter: referenceGlare)
+    let others = [
+      frame(
+        base: base, translation: CGSize(width: 42, height: -38),
+        glareCenter: CGPoint(x: 352, y: 160)),
+      frame(
+        base: base, translation: CGSize(width: -40, height: 36),
+        glareCenter: CGPoint(x: 160, y: 352)),
+      frame(
+        base: base, translation: CGSize(width: 38, height: 40),
+        glareCenter: CGPoint(x: 352, y: 352)),
+      frame(
+        base: base, translation: CGSize(width: -36, height: -42),
+        glareCenter: CGPoint(x: 256, y: 96)),
+    ]
+
+    guard let result = GlareFreeComposer.compose(reference: reference, others: others) else {
+      return XCTFail("compose returned nil")
+    }
+    XCTAssertEqual(
+      result.alignedFrameCount, others.count,
+      "all synthetic frames should register onto the reference")
+    XCTAssertEqual(result.image.size, reference.size)
+
+    // The reference's glare disc was pure white; after compositing it must
+    // show the card's own cell color again.
+    let healed = pixel(of: result.image, at: referenceGlare)
+    let want = pixel(of: base, at: referenceGlare)
+    assertClose(healed, want, tolerance: 40, "glare spot should heal to the card color")
+    XCTAssertLessThan(
+      Int(healed[0]) + Int(healed[1]) + Int(healed[2]), 3 * 220,
+      "glare spot should no longer be near-white")
+
+    // A spot that was never glared keeps its color — compositing must not
+    // disturb clean areas.
+    let clean = CGPoint(x: 96, y: 288)
+    assertClose(
+      pixel(of: result.image, at: clean), pixel(of: base, at: clean), tolerance: 40,
+      "clean area should keep the card color")
+  }
+
+  func testSeedMatrixUndoesTheExpectedContentShift() {
+    let extent = CGRect(x: 0, y: 0, width: 512, height: 512)
+    let seed = GlareFreeComposer.seedMatrix(
+      expectedShift: CGSize(width: 0.1, height: 0.05), proxyExtent: extent)
+    // Content shifted 10% right / 5% down (top-left units) puts the
+    // feature that sat at lower-left-origin (256, 256) in the reference at
+    // (307.2, 230.4) in the floating frame; the seed warp (floating →
+    // reference) must map it back. Pinned here because a wrong-signed seed
+    // fails silently — the other seed hypotheses would rescue it.
+    let mapped = seed * SIMD3<Float>(307.2, 230.4, 1)
+    XCTAssertEqual(CGFloat(mapped.x / mapped.z), 256, accuracy: 0.01)
+    XCTAssertEqual(CGFloat(mapped.y / mapped.z), 256, accuracy: 0.01)
+  }
+
+  func testComposeWithNoOthersReturnsReference() throws {
+    let base = testCard()
+    guard let result = GlareFreeComposer.compose(reference: base, others: []) else {
+      return XCTFail("compose returned nil")
+    }
+    XCTAssertEqual(result.alignedFrameCount, 0)
+    XCTAssertEqual(result.image.size, base.size)
+    let center = CGPoint(x: 256, y: 256)
+    assertClose(
+      pixel(of: result.image, at: center), pixel(of: base, at: center), tolerance: 8,
+      "a no-op composite should reproduce the reference")
+  }
+}

--- a/ios/PusselTests/GlareFreeComposerTests.swift
+++ b/ios/PusselTests/GlareFreeComposerTests.swift
@@ -122,22 +122,27 @@ final class GlareFreeComposerTests: XCTestCase {
     let base = testCard()
     let referenceGlare = CGPoint(x: 160, y: 160)
     let reference = frame(base: base, translation: .zero, glareCenter: referenceGlare)
-    let others = [
-      frame(
-        base: base, translation: CGSize(width: 42, height: -38),
-        glareCenter: CGPoint(x: 352, y: 160)),
-      frame(
-        base: base, translation: CGSize(width: -40, height: 36),
-        glareCenter: CGPoint(x: 160, y: 352)),
-      frame(
-        base: base, translation: CGSize(width: 38, height: 40),
-        glareCenter: CGPoint(x: 352, y: 352)),
-      frame(
-        base: base, translation: CGSize(width: -36, height: -42),
-        glareCenter: CGPoint(x: 256, y: 96)),
+    let shots: [(translation: CGSize, glare: CGPoint)] = [
+      (CGSize(width: 42, height: -38), CGPoint(x: 352, y: 160)),
+      (CGSize(width: -40, height: 36), CGPoint(x: 160, y: 352)),
+      (CGSize(width: 38, height: 40), CGPoint(x: 352, y: 352)),
+      (CGSize(width: -36, height: -42), CGPoint(x: 256, y: 96)),
     ]
+    let others = shots.map { frame(base: base, translation: $0.translation, glareCenter: $0.glare) }
+    // Seed with each frame's true content shift, as the capture controller
+    // does in production (the guided flow always knows where each shot was
+    // steered). Unseeded registration is measurably machine-dependent —
+    // Vision's basin differs across runners — and is not the shipped path.
+    let expectedShifts = shots.map { shot -> CGSize? in
+      CGSize(
+        width: shot.translation.width / CGFloat(cardSize),
+        height: shot.translation.height / CGFloat(cardSize))
+    }
 
-    guard let result = GlareFreeComposer.compose(reference: reference, others: others) else {
+    guard
+      let result = GlareFreeComposer.compose(
+        reference: reference, others: others, expectedShifts: expectedShifts)
+    else {
       return XCTFail("compose returned nil")
     }
     XCTAssertEqual(

--- a/ios/PusselTests/GlareGuideTrackerTests.swift
+++ b/ios/PusselTests/GlareGuideTrackerTests.swift
@@ -1,0 +1,194 @@
+import UIKit
+import XCTest
+
+@testable import Pussel
+
+/// Tests for the guide tracker's measurement core, running the real Vision
+/// translational registration on synthetic frames — the same seeded random
+/// test card the composer tests use (a periodic pattern would false-lock
+/// registration at identity). The measured offsets pin the tracker's sign
+/// convention: content shifted right/down must report a positive offset in
+/// top-left unit coordinates.
+final class GlareGuideTrackerTests: XCTestCase {
+  private let cardSize = 512
+
+  private func testCard() -> UIImage {
+    var state: UInt64 = 0x9E37_79B9_7F4A_7C15
+    func next() -> CGFloat {
+      state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+      return CGFloat(state >> 33) / CGFloat(UInt32.max >> 1)
+    }
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    return UIGraphicsImageRenderer(
+      size: CGSize(width: cardSize, height: cardSize), format: format
+    ).image { context in
+      UIColor(white: 0.4, alpha: 1).setFill()
+      context.fill(CGRect(x: 0, y: 0, width: cardSize, height: cardSize))
+      for _ in 0..<300 {
+        let width = 10 + next() * 70
+        let height = 10 + next() * 70
+        let x = next() * (CGFloat(cardSize) - width)
+        let y = next() * (CGFloat(cardSize) - height)
+        UIColor(
+          red: 0.15 + 0.55 * next(),
+          green: 0.15 + 0.55 * next(),
+          blue: 0.15 + 0.55 * next(),
+          alpha: 1
+        ).setFill()
+        context.fill(CGRect(x: x, y: y, width: width, height: height))
+      }
+    }
+  }
+
+  /// The card drawn shifted by `translation` (top-left UIKit coordinates)
+  /// over a gray backdrop — one simulated live frame.
+  private func frame(base: UIImage, translation: CGSize) throws -> CGImage {
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    let image = UIGraphicsImageRenderer(
+      size: CGSize(width: cardSize, height: cardSize), format: format
+    ).image { context in
+      UIColor(white: 0.45, alpha: 1).setFill()
+      context.fill(CGRect(x: 0, y: 0, width: cardSize, height: cardSize))
+      base.draw(at: CGPoint(x: translation.width, y: translation.height))
+    }
+    return try XCTUnwrap(image.cgImage)
+  }
+
+  private func referenceProxy(of reference: CGImage) throws -> CGImage {
+    try XCTUnwrap(GlareGuideTracker.trackingProxy(of: reference))
+  }
+
+  func testMeasuresContentShiftInTopLeftUnits() throws {
+    let base = testCard()
+    let reference = try frame(base: base, translation: .zero)
+    let live = try frame(base: base, translation: CGSize(width: 51, height: -38))
+
+    let (update, translation) = GlareGuideTracker.measure(
+      frame: live, referenceProxy: try referenceProxy(of: reference))
+    let offset = try XCTUnwrap(update.offset, "shifted frame should still track")
+    // Content moved 51 px right and 38 px up on a 512 px frame.
+    XCTAssertEqual(offset.width, 51.0 / 512.0, accuracy: 0.02)
+    XCTAssertEqual(offset.height, -38.0 / 512.0, accuracy: 0.02)
+    XCTAssertEqual(update.frameAspect, 1)
+    XCTAssertNotNil(translation, "a verified fix should be reusable as the next prior")
+  }
+
+  func testPriorSeededMeasurementFindsTheSameShift() throws {
+    let base = testCard()
+    let reference = try frame(base: base, translation: .zero)
+    let live = try frame(base: base, translation: CGSize(width: 51, height: -38))
+    let proxy = try referenceProxy(of: reference)
+
+    // Seed with the roughly correct prior (as the previous frame's fix or
+    // the step's expectation would): the residual path must converge to
+    // the same answer as direct registration.
+    let roughPrior = GlareGuideTracker.translationVector(
+      ofUnitOffset: CGSize(width: 48.0 / 512.0, height: -34.0 / 512.0),
+      proxySize: CGSize(width: proxy.width, height: proxy.height))
+    let (update, _) = GlareGuideTracker.measure(
+      frame: live, referenceProxy: proxy, priors: [roughPrior])
+    let offset = try XCTUnwrap(update.offset)
+    XCTAssertEqual(offset.width, 51.0 / 512.0, accuracy: 0.02)
+    XCTAssertEqual(offset.height, -38.0 / 512.0, accuracy: 0.02)
+  }
+
+  func testBadPriorFallsThroughToDirectRegistration() throws {
+    let base = testCard()
+    let reference = try frame(base: base, translation: .zero)
+    let live = try frame(base: base, translation: CGSize(width: 51, height: -38))
+    let proxy = try referenceProxy(of: reference)
+
+    // A wildly wrong prior fails verification; the trailing .zero
+    // hypothesis (direct registration) must still find the shift.
+    let badPrior = CGVector(dx: 150, dy: -120)
+    let (update, _) = GlareGuideTracker.measure(
+      frame: live, referenceProxy: proxy, priors: [badPrior, .zero])
+    let offset = try XCTUnwrap(update.offset)
+    XCTAssertEqual(offset.width, 51.0 / 512.0, accuracy: 0.02)
+    XCTAssertEqual(offset.height, -38.0 / 512.0, accuracy: 0.02)
+  }
+
+  func testIdenticalFrameMeasuresZeroOffset() throws {
+    let base = testCard()
+    let reference = try frame(base: base, translation: .zero)
+    let (update, _) = GlareGuideTracker.measure(
+      frame: reference, referenceProxy: try referenceProxy(of: reference))
+    let offset = try XCTUnwrap(update.offset)
+    XCTAssertEqual(offset.width, 0, accuracy: 0.01)
+    XCTAssertEqual(offset.height, 0, accuracy: 0.01)
+  }
+
+  func testUnrelatedSceneReportsTrackingLost() throws {
+    let base = testCard()
+    let reference = try frame(base: base, translation: .zero)
+    // A featureless frame: whatever translation Vision returns, the
+    // verification difference stays huge and the tracker must say "lost"
+    // rather than hand the UI a confident wrong offset.
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    let blank = UIGraphicsImageRenderer(
+      size: CGSize(width: cardSize, height: cardSize), format: format
+    ).image { context in
+      UIColor(white: 0.2, alpha: 1).setFill()
+      context.fill(CGRect(x: 0, y: 0, width: cardSize, height: cardSize))
+    }
+    let (update, translation) = GlareGuideTracker.measure(
+      frame: try XCTUnwrap(blank.cgImage), referenceProxy: try referenceProxy(of: reference))
+    XCTAssertNil(update.offset)
+    XCTAssertNil(translation)
+  }
+
+  func testRotatedReferencePhotoStillTracks() throws {
+    let base = testCard()
+    let upright = try frame(base: base, translation: .zero)
+    // A device photo: the pixel bitmap is stored rotated, with the EXIF
+    // orientation tag saying how to display it upright. The reference path
+    // must bake that orientation before registering against live frames,
+    // which arrive physically upright.
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    let rotatedBitmap = UIGraphicsImageRenderer(
+      size: CGSize(width: cardSize, height: cardSize), format: format
+    ).image { context in
+      let half = CGFloat(cardSize) / 2
+      context.cgContext.translateBy(x: half, y: half)
+      context.cgContext.rotate(by: .pi / 2)
+      context.cgContext.translateBy(x: -half, y: -half)
+      UIImage(cgImage: upright).draw(at: .zero)
+    }
+    let photo = UIImage(
+      cgImage: try XCTUnwrap(rotatedBitmap.cgImage), scale: 1, orientation: .left)
+    // Sanity: the tagged photo displays as the upright card again. If this
+    // fails the fixture is wrong, not the tracker.
+    let displayed = UIGraphicsImageRenderer(size: photo.size, format: format).image { _ in
+      photo.draw(at: .zero)
+    }
+    XCTAssertEqual(
+      GlareGuideTracker.measure(
+        frame: try XCTUnwrap(displayed.cgImage),
+        referenceProxy: try referenceProxy(of: upright)
+      ).0.offset.map { hypot($0.width, $0.height) } ?? 1, 0, accuracy: 0.01,
+      "fixture: tagged photo should display as the original card")
+
+    let proxy = try XCTUnwrap(
+      GlareGuideTracker.referenceProxy(of: photo),
+      "reference proxy should build from a tagged photo")
+    let (update, _) = GlareGuideTracker.measure(frame: upright, referenceProxy: proxy)
+    let offset = try XCTUnwrap(
+      update.offset, "an upright live frame must track against a rotated reference photo")
+    XCTAssertEqual(offset.width, 0, accuracy: 0.01)
+    XCTAssertEqual(offset.height, 0, accuracy: 0.01)
+  }
+
+  @MainActor
+  func testSetReferenceEnablesFrameAcceptance() throws {
+    let tracker = GlareGuideTracker()
+    XCTAssertFalse(tracker.shouldAcceptFrame(now: Date()))
+    tracker.setReference(testCard())
+    XCTAssertTrue(tracker.shouldAcceptFrame(now: Date()))
+    tracker.clearReference()
+    XCTAssertFalse(tracker.shouldAcceptFrame(now: Date()))
+  }
+}

--- a/ios/PusselTests/GlareGuideTrackerTests.swift
+++ b/ios/PusselTests/GlareGuideTrackerTests.swift
@@ -191,4 +191,18 @@ final class GlareGuideTrackerTests: XCTestCase {
     tracker.clearReference()
     XCTAssertFalse(tracker.shouldAcceptFrame(now: Date()))
   }
+
+  /// The tracker doubles as the Simulator/E2E `GlareGuideSource` — the
+  /// protocol lifecycle must drive the same reference plumbing.
+  @MainActor
+  func testGuideSourceConformanceDrivesTheReferenceLifecycle() throws {
+    let tracker = GlareGuideTracker()
+    let source: any GlareGuideSource = tracker
+    source.beginGuiding(reference: testCard())
+    XCTAssertTrue(tracker.shouldAcceptFrame(now: Date()))
+    source.setActiveStep(1)
+    source.setActiveStep(nil)
+    source.stopGuiding()
+    XCTAssertFalse(tracker.shouldAcceptFrame(now: Date()))
+  }
 }


### PR DESCRIPTION
## Summary

Adds a guided five-shot glare-free capture flow to the iOS app (PhotoScan-style): a manual center reference shot, then four corner shots that auto-fire when the guided target dwells in the screen-center ring. The burst is fused on-device into one glare-free composite (register + per-pixel minimum) that continues down the normal detect-frame path.

Two commits:

1. **Guided capture + composition** (`3efa2b5`): `GlareFreeComposer` (highlight-capped proxy registration, translational bootstrap → iterative homography, image-difference verification gate), `GlareFreeCaptureController` five-step state machine with dwell auto-shutter, and `GlareGuideTracker` — live Vision translational registration with prior hypotheses and a verification gate.
2. **ARKit rebuild of the guidance** (`c10ffb4`): device testing showed registration tracking flaky under hand tilt (translation-only model). Guidance now sits behind a `GlareGuideSource` protocol:
   - **Devices**: `ARGlareGuideSource` — world tracking; the screen center is raycast onto the puzzle's surface, the surface's world height is remembered (plane detection never converges over a glossy puzzle on non-LiDAR devices; the corner raycasts fail at FOV edges), and the corner quad is derived analytically by intersecting corner rays with the gravity-horizontal plane. The quad freezes at the center shot as an always-visible puzzle outline; all four world-anchored targets show at once (clockwise: TL, TR, BR, BL), the current one steered into the ring. Stills via `captureHighResolutionFrame()`.
   - **Simulator/E2E**: `GlareGuideTracker` remains the fallback, keeping the `pusseldebug://` debug-driver flow intact.

## Testing

- 210 unit tests pass (new: composer seed matrix, tracker sign conventions/priors/EXIF regression, controller dwell auto-capture, AR quad interpolation + behind-camera filtering, source lifecycle)
- `make check-ios` clean
- Simulator E2E: full debug-driver run (center shot + 4 auto-captured corners → glare-free composite → confirm screen)
- Hand-tested on an iPhone 15: surface lock ~2 s, stable outline + targets, full clockwise auto-capture run

🤖 Generated with [Claude Code](https://claude.com/claude-code)