### PR TITLE
feat: estimate piece count by OCR-ing the box shot on barcode lookup

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -51,6 +51,11 @@ jobs:
           make check-backend
           make check-shared
 
+      - name: Install tesseract
+        # Powers the piece-count OCR (app/services/piece_count_estimator.py);
+        # without it those tests skip and the estimator degrades to None.
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends tesseract-ocr
+
       - name: Run tests
         working-directory: backend
         env:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,12 @@
 FROM python:3.12-slim
 
+# tesseract powers the barcode lookup's piece-count OCR
+# (app/services/piece_count_estimator.py); without it the estimator
+# gracefully returns no estimate.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tesseract-ocr \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY requirements.txt .

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,6 +48,7 @@ from app.services.barcode_lookup_cache import BarcodeLookupRecord, get_barcode_l
 from app.services.classical_matcher import get_classical_matcher
 from app.services.grid_snap import snap_to_grid
 from app.services.image_processor import get_image_processor
+from app.services.piece_count_estimator import estimate_piece_count
 from app.services.piece_detector import get_piece_detector
 from app.services.piece_geometry.service import (
     PieceGeometryRecord,
@@ -363,9 +364,11 @@ async def lookup_barcode(ean: str) -> BarcodeLookupResponse:
     numbers from the EAN (see `app.services.ravensburger_lookup`), probes
     ravensburger.org concurrently, and returns the first real image as a
     JPEG data URL — the clean puzzle motif when the product has one, else
-    the box shot (see `image_kind`). Results — hits and misses — are
-    cached in-process so a barcode held in front of the camera doesn't
-    re-probe the site.
+    the box shot (see `image_kind`). The box shot is additionally OCR'd for
+    the printed piece count (see `app.services.piece_count_estimator`),
+    returned as `piece_count_estimate` for prefilling the piece-count input.
+    Results — hits and misses — are cached in-process so a barcode held in
+    front of the camera doesn't re-probe the site.
 
     Requires authentication and is rate-limited per-user (see the route's
     ``dependencies``); doesn't need the caller's identity beyond that.
@@ -399,6 +402,7 @@ async def lookup_barcode(ean: str) -> BarcodeLookupResponse:
         box_image=f"data:image/jpeg;base64,{image_base64}",
         image_kind=cached.image_kind,
         article_number=cached.article_number,
+        piece_count_estimate=cached.piece_count,
     )
 
 
@@ -430,8 +434,18 @@ async def _resolve_barcode(ean: str) -> BarcodeLookupRecord:
             continue
         buffer = io.BytesIO()
         image.save(buffer, format="JPEG", quality=90)
+        # The piece count is printed on the box shot only, so when the motif
+        # won the display slot the box is fetched separately just for OCR.
+        box_jpeg = fetched.content if fetched.kind == "box" else await client.fetch_box_image(candidate)
+        piece_count = None
+        if box_jpeg is not None:
+            piece_count = await asyncio.to_thread(estimate_piece_count, box_jpeg)
         return BarcodeLookupRecord(
-            found=True, image_jpeg=buffer.getvalue(), image_kind=fetched.kind, article_number=candidate
+            found=True,
+            image_jpeg=buffer.getvalue(),
+            image_kind=fetched.kind,
+            article_number=candidate,
+            piece_count=piece_count,
         )
 
     if ean.startswith(RAVENSBURGER_ADULT_PREFIX):

--- a/backend/app/models/puzzle_model.py
+++ b/backend/app/models/puzzle_model.py
@@ -183,6 +183,13 @@ class BarcodeLookupResponse(BaseModel):
     article_number: Optional[str] = Field(
         default=None, description="Resolved Ravensburger article number; present when found"
     )
+    piece_count_estimate: Optional[int] = Field(
+        default=None,
+        description=(
+            "Piece count read off the box shot by OCR, for prefilling the piece-count input; "
+            "None when the box couldn't be read confidently (never a low-confidence guess)"
+        ),
+    )
 
 
 class GeneratePieceRequest(BaseModel):

--- a/backend/app/services/barcode_lookup_cache.py
+++ b/backend/app/services/barcode_lookup_cache.py
@@ -28,12 +28,15 @@ class BarcodeLookupRecord:
         image_kind: "motif" (clean puzzle artwork) or "box" when found,
             else None.
         article_number: The resolved article number when found, else None.
+        piece_count: The piece count OCR'd from the box shot (see
+            `app.services.piece_count_estimator`), or None when unreadable.
     """
 
     found: bool
     image_jpeg: Optional[bytes]
     image_kind: Optional[ImageKind]
     article_number: Optional[str]
+    piece_count: Optional[int] = None
 
 
 class BarcodeLookupCache:

--- a/backend/app/services/piece_count_estimator.py
+++ b/backend/app/services/piece_count_estimator.py
@@ -1,0 +1,240 @@
+"""OCR-based piece-count estimation from Ravensburger box shots.
+
+Every Ravensburger box prints its piece count prominently near the top-left
+corner of the front (8-digit "12xxxxxx" boxes and square gift boxes) or
+rotated 90° along the left edge (classic 5-digit softclick boxes, Nathan
+boxes). The clean puzzle motif (`_1` shot) deliberately has no text, so the
+estimate always reads the box shot.
+
+The pipeline OCRs a few targeted crops of the box shot with tesseract and
+keeps tokens that exactly match a piece count Ravensburger actually sells
+(plus "N x M" kids multipacks, where the per-puzzle M is the estimate).
+The tallest such token wins — the count is always the biggest number on the
+box, which is what beats look-alike numerals like the "Since 1891" tagline,
+age badges, and centimetre dimensions. Validated against 21 live box shots
+(20 correct, 1 conservative None, 0 wrong guesses): misses return None
+rather than a wrong guess, so the app's piece-count field just stays empty.
+
+Tesseract is invoked via subprocess (no extra Python dependency); when the
+binary is not installed the estimator degrades to always returning None.
+"""
+
+import logging
+import re
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Optional, Sequence
+
+import cv2
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# Piece counts Ravensburger sells as single-puzzle boxes. Deliberately a
+# closed set: exact-match filtering is what keeps OCR noise (years, article
+# numbers, box dimensions) from ever becoming an estimate.
+PLAIN_COUNTS = frozenset({24, 35, 49, 54, 60, 80, 100, 125, 150, 200, 300, 500, 750, 1000, 1500, 2000, 3000, 5000})
+# Kids multipacks are printed "N x M" (e.g. "2x12", "3x49"); N is the number
+# of puzzles in the box and M — the estimate — the pieces per puzzle. The
+# small-N requirement rejects box dimensions like "70x50".
+MULTIPACK_PUZZLES = frozenset({2, 3, 4})
+MULTIPACK_PIECES = frozenset({12, 20, 24, 49, 100})
+
+_PACK_RE = re.compile(r"^([234])\s*[xX]\s*(\d{1,3})$")
+_NUM_RE = re.compile(r"^\d{2,4}$")
+# A thousands separator inside a count ("1.000" / "1,000").
+_SEP_RE = re.compile(r"^(\d)[.,](\d{3})$")
+_STRIP_CHARS = "\"'.,;:()|«»“”*"
+
+# Tokens shorter than this (pixels, in the upscaled OCR input) are fine print
+# — the "1000 Teile" contents line, not the front-of-box count.
+_MIN_TOKEN_HEIGHT = 40
+# Tokens below this tesseract confidence are dropped outright. On the live
+# validation set every correct badge read scored ≥ 63 while every misread
+# (e.g. a stylized "500" read as "200") scored below 58 — a threshold between
+# the two turns would-be wrong guesses into safe Nones.
+_MIN_TOKEN_CONFIDENCE = 60.0
+# A candidate this tall and confident ends the variant sweep early.
+_EARLY_EXIT_HEIGHT = 100
+_EARLY_EXIT_CONFIDENCE = 80.0
+# Box shots smaller than this can't carry a readable count badge.
+_MIN_IMAGE_DIMENSION = 200
+
+_TESSERACT_TIMEOUT_SECONDS = 20.0
+_warned_missing_tesseract = False
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    """A piece-count reading from one OCR token."""
+
+    value: int
+    height: int
+    confidence: float
+
+
+@dataclass(frozen=True)
+class _OcrWord:
+    """One word row from tesseract's TSV output."""
+
+    text: str
+    height: int
+    confidence: float
+
+
+def _tesseract_available() -> bool:
+    """Report whether the tesseract binary is on PATH, warning once when not.
+
+    Returns:
+        True when tesseract can be invoked.
+    """
+    global _warned_missing_tesseract
+    if shutil.which("tesseract") is not None:
+        return True
+    if not _warned_missing_tesseract:
+        logger.warning("tesseract binary not found; piece-count estimation is disabled")
+        _warned_missing_tesseract = True
+    return False
+
+
+def _ocr_words(image: np.ndarray, psm: int) -> list[_OcrWord]:
+    """Run tesseract on a grayscale/binary image and parse its TSV words.
+
+    Args:
+        image: Single-channel image to OCR.
+        psm: Tesseract page-segmentation mode (11 = sparse text, 7 = single
+            line).
+
+    Returns:
+        The recognized words with glyph heights and confidences; empty on any
+        tesseract failure (never raises).
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "ocr.png"
+        cv2.imwrite(str(path), image)
+        try:
+            result = subprocess.run(
+                ["tesseract", str(path), "-", "--psm", str(psm), "tsv"],
+                capture_output=True,
+                text=True,
+                timeout=_TESSERACT_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (subprocess.SubprocessError, OSError) as exc:
+            logger.warning("tesseract invocation failed: %s", exc)
+            return []
+    words = []
+    for line in result.stdout.splitlines()[1:]:
+        columns = line.split("\t")
+        if len(columns) < 12 or not columns[11].strip():
+            continue
+        try:
+            height, confidence = int(columns[9]), float(columns[10])
+        except ValueError:
+            continue
+        words.append(_OcrWord(text=columns[11].strip(), height=height, confidence=confidence))
+    return words
+
+
+def _extract_candidates(words: Sequence[_OcrWord]) -> list[_Candidate]:
+    """Filter OCR words down to plausible piece counts.
+
+    Args:
+        words: Recognized words from one OCR pass.
+
+    Returns:
+        A candidate per word that exactly matches a known plain count or an
+        "N x M" multipack (whose per-puzzle M becomes the value).
+    """
+    candidates = []
+    for word in words:
+        token = word.text.strip(_STRIP_CHARS).replace("×", "x")
+        token = _SEP_RE.sub(r"\1\2", token)
+        pack = _PACK_RE.match(token)
+        if pack and int(pack.group(1)) in MULTIPACK_PUZZLES and int(pack.group(2)) in MULTIPACK_PIECES:
+            candidates.append(_Candidate(value=int(pack.group(2)), height=word.height, confidence=word.confidence))
+        elif _NUM_RE.match(token) and int(token) in PLAIN_COUNTS:
+            candidates.append(_Candidate(value=int(token), height=word.height, confidence=word.confidence))
+    return candidates
+
+
+def _channel_variants(crop: np.ndarray, scale: int) -> Iterator[np.ndarray]:
+    """Yield single-channel OCR inputs for a BGR crop.
+
+    Plain grayscale reads most badges; an Otsu threshold of the darkest
+    channel isolates colored text on light box borders (tesseract's own
+    binarization loses e.g. pink-on-white), and an inverted threshold of the
+    brightest channel isolates light text on dark artwork.
+
+    Args:
+        crop: BGR crop of the box shot.
+        scale: Upscale factor applied before OCR.
+
+    Yields:
+        Grayscale, dark-text-binarized, and light-text-binarized images.
+    """
+    resized = cv2.resize(crop, None, fx=scale, fy=scale, interpolation=cv2.INTER_LANCZOS4)
+    yield cv2.cvtColor(resized, cv2.COLOR_BGR2GRAY)
+    _, dark = cv2.threshold(resized.min(axis=2), 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+    yield dark
+    _, light = cv2.threshold(resized.max(axis=2), 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+    yield light
+
+
+def _attempts(image: np.ndarray) -> Iterator[tuple[np.ndarray, int]]:
+    """Yield (OCR input, psm) attempts in decreasing hit-rate order.
+
+    The top band catches upright counts (8-digit-era boxes); the left band,
+    rotated to upright both ways, catches the 90°-rotated counts of classic
+    5-digit boxes; a single-line pass over the top-left quadrant rescues
+    stylized digits that sparse-text segmentation splits apart (square gift
+    boxes).
+
+    Args:
+        image: The full BGR box shot.
+
+    Yields:
+        (single-channel image, tesseract psm) pairs.
+    """
+    height, width = image.shape[:2]
+    top_band = image[: int(height * 0.32), :]
+    left_band = image[:, : int(width * 0.30)]
+    top_left = image[: int(height * 0.32), : width // 2]
+    for variant in _channel_variants(top_band, scale=3):
+        yield variant, 11
+    for rotation in (cv2.ROTATE_90_CLOCKWISE, cv2.ROTATE_90_COUNTERCLOCKWISE):
+        for variant in _channel_variants(cv2.rotate(left_band, rotation), scale=3):
+            yield variant, 11
+    for variant in _channel_variants(top_left, scale=2):
+        yield variant, 7
+
+
+def estimate_piece_count(box_jpeg: bytes) -> Optional[int]:
+    """Estimate a puzzle's piece count from its Ravensburger box shot.
+
+    Args:
+        box_jpeg: The box-shot image bytes as fetched from ravensburger.org.
+
+    Returns:
+        The most likely piece count, or None when no confident reading exists
+        (undecodable/tiny image, tesseract unavailable, or no token matching
+        a known count) — never a low-confidence guess.
+    """
+    if not _tesseract_available():
+        return None
+    image = cv2.imdecode(np.frombuffer(box_jpeg, dtype=np.uint8), cv2.IMREAD_COLOR)
+    if image is None or min(image.shape[:2]) < _MIN_IMAGE_DIMENSION:
+        return None
+    best: Optional[_Candidate] = None
+    for variant, psm in _attempts(image):
+        for candidate in _extract_candidates(_ocr_words(variant, psm)):
+            if candidate.height < _MIN_TOKEN_HEIGHT or candidate.confidence < _MIN_TOKEN_CONFIDENCE:
+                continue
+            if best is None or (candidate.height, candidate.confidence) > (best.height, best.confidence):
+                best = candidate
+        if best is not None and best.height >= _EARLY_EXIT_HEIGHT and best.confidence >= _EARLY_EXIT_CONFIDENCE:
+            break
+    return best.value if best else None

--- a/backend/app/services/piece_count_estimator.py
+++ b/backend/app/services/piece_count_estimator.py
@@ -12,8 +12,9 @@ keeps tokens that exactly match a piece count Ravensburger actually sells
 The tallest such token wins — the count is always the biggest number on the
 box, which is what beats look-alike numerals like the "Since 1891" tagline,
 age badges, and centimetre dimensions. Validated against 21 live box shots
-(20 correct, 1 conservative None, 0 wrong guesses): misses return None
-rather than a wrong guess, so the app's piece-count field just stays empty.
+(19 matching the expected label, 2 conservative Nones, 0 wrong guesses):
+an unreadable box returns None rather than a wrong guess, so the app's
+piece-count field just stays empty.
 
 Tesseract is invoked via subprocess (no extra Python dependency); when the
 binary is not installed the estimator degrades to always returning None.

--- a/backend/app/services/ravensburger_client.py
+++ b/backend/app/services/ravensburger_client.py
@@ -89,6 +89,30 @@ class RavensburgerClient:
             logger.warning("Ravensburger image fetch failed for article %s: %s", article_number, exc)
         return None
 
+    async def fetch_box_image(self, article_number: str) -> Optional[bytes]:
+        """Fetch the box shot for an article number.
+
+        Used when `fetch_puzzle_image` returned the motif: the piece-count
+        estimator needs the box shot, which is where the count is printed
+        (the motif deliberately carries no text).
+
+        Args:
+            article_number: A Ravensburger article number known to exist.
+
+        Returns:
+            The box-shot JPEG bytes, or None when the article has no box
+            shot or on any transport error/timeout — a miss is never an
+            exception.
+        """
+        try:
+            async with httpx.AsyncClient(timeout=settings.RAVENSBURGER_CDN_TIMEOUT_SECONDS) as client:
+                response = await client.get(self.image_url(article_number, BOX_SUFFIX))
+                if response.status_code == 200 and response.content:
+                    return response.content
+        except httpx.HTTPError as exc:
+            logger.warning("Ravensburger box-shot fetch failed for article %s: %s", article_number, exc)
+        return None
+
 
 @lru_cache()
 def get_ravensburger_client() -> RavensburgerClient:

--- a/backend/tests/test_barcode_endpoint.py
+++ b/backend/tests/test_barcode_endpoint.py
@@ -1,9 +1,11 @@
 """Tests for GET /api/v1/puzzle/barcode/{ean} (Ravensburger product-image lookup).
 
 ravensburger.org is never contacted: `app.main.get_ravensburger_client` is
-patched with a fake whose `fetch_puzzle_image` is an AsyncMock. The
-process-global lookup cache singleton is cleared around every test so cached
-hits/misses can't leak between tests.
+patched with a fake whose `fetch_puzzle_image`/`fetch_box_image` are
+AsyncMocks; tests around the piece-count estimate also patch
+`app.main.estimate_piece_count` so no OCR runs. The process-global lookup
+cache singleton is cleared around every test so cached hits/misses can't
+leak between tests.
 
 Mirrors the token helper in tests/test_rate_limit.py.
 """
@@ -56,16 +58,20 @@ def auth_headers(user_id: str = "test-user-id") -> dict[str, str]:
     return {"Authorization": f"Bearer {create_test_token(user_id)}"}
 
 
-def make_fake_ravensburger_client(hit_articles: dict[str, bytes], kind: ImageKind = "motif") -> MagicMock:
+def make_fake_ravensburger_client(
+    hit_articles: dict[str, bytes], kind: ImageKind = "motif", box_bytes: Optional[bytes] = None
+) -> MagicMock:
     """Build a fake RavensburgerClient hitting only the given article numbers.
 
     Args:
         hit_articles: Article number -> image bytes for articles that exist.
         kind: The image kind ("motif" or "box") every hit reports.
+        box_bytes: What `fetch_box_image` resolves to (the OCR source when
+            the display image is the motif); None models a missing box shot.
 
     Returns:
-        A MagicMock whose async `fetch_puzzle_image` resolves per
-        `hit_articles`.
+        A MagicMock whose async `fetch_puzzle_image` and `fetch_box_image`
+        resolve per `hit_articles` / `box_bytes`.
     """
 
     async def fetch_puzzle_image(article_number: str) -> Optional[RavensburgerImage]:
@@ -76,6 +82,7 @@ def make_fake_ravensburger_client(hit_articles: dict[str, bytes], kind: ImageKin
 
     fake = MagicMock()
     fake.fetch_puzzle_image = AsyncMock(side_effect=fetch_puzzle_image)
+    fake.fetch_box_image = AsyncMock(return_value=box_bytes)
     return fake
 
 
@@ -130,7 +137,13 @@ class TestBarcodeLookupEndpoint:
         with patch("app.main.get_ravensburger_client", return_value=fake):
             response = client.get(f"/api/v1/puzzle/barcode/{FROZEN_EAN}", headers=auth_headers())
         assert response.status_code == 200
-        assert response.json() == {"found": False, "box_image": None, "image_kind": None, "article_number": None}
+        assert response.json() == {
+            "found": False,
+            "box_image": None,
+            "image_kind": None,
+            "article_number": None,
+            "piece_count_estimate": None,
+        }
 
     def test_adult_line_probes_series_prefixes(self) -> None:
         """An adult-line EAN probes series candidates and resolves the hit's article."""
@@ -170,6 +183,59 @@ class TestBarcodeLookupEndpoint:
             response = client.get(f"/api/v1/puzzle/barcode/{FROZEN_EAN}", headers=auth_headers())
         assert response.status_code == 200
         assert response.json()["found"] is False
+
+    def test_motif_hit_ocr_reads_separately_fetched_box_shot(self) -> None:
+        """When the motif wins the display slot, the box shot is fetched just for OCR."""
+        box = b"box-shot-bytes"
+        fake = make_fake_ravensburger_client({"05009": make_jpeg_bytes()}, kind="motif", box_bytes=box)
+        with (
+            patch("app.main.get_ravensburger_client", return_value=fake),
+            patch("app.main.estimate_piece_count", return_value=1000) as estimator,
+        ):
+            response = client.get(f"/api/v1/puzzle/barcode/{FROZEN_EAN}", headers=auth_headers())
+        assert response.status_code == 200
+        assert response.json()["piece_count_estimate"] == 1000
+        fake.fetch_box_image.assert_awaited_once_with("05009")
+        estimator.assert_called_once_with(box)
+
+    def test_box_hit_ocr_reuses_fetched_image(self) -> None:
+        """When the display image already is the box shot, OCR runs on it directly."""
+        box = make_jpeg_bytes()
+        fake = make_fake_ravensburger_client({"05009": box}, kind="box")
+        with (
+            patch("app.main.get_ravensburger_client", return_value=fake),
+            patch("app.main.estimate_piece_count", return_value=500) as estimator,
+        ):
+            response = client.get(f"/api/v1/puzzle/barcode/{FROZEN_EAN}", headers=auth_headers())
+        assert response.status_code == 200
+        assert response.json()["piece_count_estimate"] == 500
+        fake.fetch_box_image.assert_not_awaited()
+        estimator.assert_called_once_with(box)
+
+    def test_missing_box_shot_skips_ocr(self) -> None:
+        """A motif-only product (no box shot) reports no estimate without running OCR."""
+        fake = make_fake_ravensburger_client({"05009": make_jpeg_bytes()}, kind="motif", box_bytes=None)
+        with (
+            patch("app.main.get_ravensburger_client", return_value=fake),
+            patch("app.main.estimate_piece_count", return_value=1000) as estimator,
+        ):
+            response = client.get(f"/api/v1/puzzle/barcode/{FROZEN_EAN}", headers=auth_headers())
+        assert response.status_code == 200
+        assert response.json()["found"] is True
+        assert response.json()["piece_count_estimate"] is None
+        estimator.assert_not_called()
+
+    def test_unreadable_box_yields_null_estimate(self) -> None:
+        """An OCR miss (estimator returns None) is a null estimate, still found."""
+        fake = make_fake_ravensburger_client({"05009": make_jpeg_bytes()}, kind="box")
+        with (
+            patch("app.main.get_ravensburger_client", return_value=fake),
+            patch("app.main.estimate_piece_count", return_value=None),
+        ):
+            response = client.get(f"/api/v1/puzzle/barcode/{FROZEN_EAN}", headers=auth_headers())
+        assert response.status_code == 200
+        assert response.json()["found"] is True
+        assert response.json()["piece_count_estimate"] is None
 
     def test_rate_limited_per_user(self) -> None:
         """Requests beyond the per-user limit are rejected with 429."""

--- a/backend/tests/test_piece_count_estimator.py
+++ b/backend/tests/test_piece_count_estimator.py
@@ -1,0 +1,109 @@
+"""Tests for the box-shot piece-count estimator.
+
+The candidate filter is tested purely; `estimate_piece_count` end-to-end
+tests render synthetic box shots with cv2's Hershey font and are skipped
+when the tesseract binary isn't installed (the estimator's documented
+degraded mode, itself covered by `test_missing_tesseract_disables_estimation`).
+"""
+
+import shutil
+from unittest.mock import patch
+
+import cv2
+import numpy as np
+import pytest
+
+from app.services.piece_count_estimator import _extract_candidates, _OcrWord, estimate_piece_count
+
+requires_tesseract = pytest.mark.skipif(shutil.which("tesseract") is None, reason="tesseract binary not installed")
+
+
+def word(text: str, height: int = 150, confidence: float = 95.0) -> _OcrWord:
+    """Build an OCR word with plausible badge-sized defaults."""
+    return _OcrWord(text=text, height=height, confidence=confidence)
+
+
+def synthetic_box_jpeg(text: str, color: tuple[int, int, int] = (0, 0, 0)) -> bytes:
+    """Render a box-shot stand-in: `text` large in the top-left, like the real badge.
+
+    Args:
+        text: The badge text to print (empty for a blank box).
+        color: BGR text color.
+
+    Returns:
+        JPEG bytes of the rendered image.
+    """
+    image = np.full((750, 1000, 3), 255, dtype=np.uint8)
+    if text:
+        cv2.putText(image, text, (60, 190), cv2.FONT_HERSHEY_DUPLEX, 5.5, color, 14, cv2.LINE_AA)
+    _, encoded = cv2.imencode(".jpg", image)
+    return encoded.tobytes()
+
+
+class TestExtractCandidates:
+    """The token filter that turns OCR words into piece-count candidates."""
+
+    def test_plain_counts_accepted(self) -> None:
+        """Numbers in the known catalog set become candidates."""
+        candidates = _extract_candidates([word("1000"), word("500"), word("100")])
+        assert [c.value for c in candidates] == [1000, 500, 100]
+
+    def test_unknown_numbers_rejected(self) -> None:
+        """Years, article fragments, and off-catalog numbers never match."""
+        assert _extract_candidates([word("1891"), word("900"), word("12"), word("12345")]) == []
+
+    def test_decorations_stripped(self) -> None:
+        """Quotes, punctuation, and thousands separators are cleaned before matching."""
+        candidates = _extract_candidates([word('"500'), word("1.000"), word("1,000")])
+        assert [c.value for c in candidates] == [500, 1000, 1000]
+
+    def test_multipack_yields_per_puzzle_count(self) -> None:
+        """An 'N x M' kids multipack estimates M — the pieces of one puzzle."""
+        candidates = _extract_candidates([word("2x12"), word("3 x 49"), word("2×24")])
+        assert [c.value for c in candidates] == [12, 49, 24]
+
+    def test_box_dimensions_rejected(self) -> None:
+        """Centimetre dimensions like 70x50 don't parse as multipacks."""
+        assert _extract_candidates([word("70x50"), word("2x37")]) == []
+
+    def test_non_numeric_ignored(self) -> None:
+        """Plain words produce no candidates."""
+        assert _extract_candidates([word("Ravensburger"), word("Puzzle")]) == []
+
+
+class TestEstimatePieceCount:
+    """End-to-end behavior of `estimate_piece_count`."""
+
+    def test_undecodable_bytes_yield_none(self) -> None:
+        """Garbage bytes are a graceful None, not an exception."""
+        assert estimate_piece_count(b"not-a-jpeg" * 100) is None
+
+    def test_tiny_image_yields_none(self) -> None:
+        """Images too small to carry a readable badge are skipped without OCR."""
+        _, encoded = cv2.imencode(".jpg", np.full((64, 64, 3), 255, dtype=np.uint8))
+        assert estimate_piece_count(encoded.tobytes()) is None
+
+    def test_missing_tesseract_disables_estimation(self) -> None:
+        """Without the tesseract binary the estimator degrades to None."""
+        with patch("app.services.piece_count_estimator.shutil.which", return_value=None):
+            assert estimate_piece_count(synthetic_box_jpeg("1000")) is None
+
+    @requires_tesseract
+    def test_reads_badge_count(self) -> None:
+        """A big top-left '1000' — the standard badge — is read."""
+        assert estimate_piece_count(synthetic_box_jpeg("1000")) == 1000
+
+    @requires_tesseract
+    def test_reads_colored_badge(self) -> None:
+        """A pink-on-white badge (which plain binarization washes out) is read."""
+        assert estimate_piece_count(synthetic_box_jpeg("1000", color=(140, 30, 233))) == 1000
+
+    @requires_tesseract
+    def test_blank_box_yields_none(self) -> None:
+        """A box with no printed count yields None."""
+        assert estimate_piece_count(synthetic_box_jpeg("")) is None
+
+    @requires_tesseract
+    def test_off_catalog_number_yields_none(self) -> None:
+        """A prominent number outside the catalog set (the 1891 tagline) is not a count."""
+        assert estimate_piece_count(synthetic_box_jpeg("1891")) is None

--- a/ios/Pussel/App/AppActions.swift
+++ b/ios/Pussel/App/AppActions.swift
@@ -55,10 +55,13 @@ extension AppModel {
   /// No detect-frame round trip: the backend's box image is already a clean
   /// straight-on product shot, so the whole image is the trim (see
   /// `TrimCandidate.wholeImage`); the user still rotates/crops and sets the
-  /// piece count on the confirm screen as usual.
-  func startTrimFromBarcodeLookup(jpeg: Data) {
+  /// piece count on the confirm screen as usual — `pieceCountEstimate` (the
+  /// count the backend OCR'd off the box shot, when readable) only prefills
+  /// that field.
+  func startTrimFromBarcodeLookup(jpeg: Data, pieceCountEstimate: Int? = nil) {
     flow.errorMessage = nil
-    flow.phase = .confirmTrim(.wholeImage(jpeg: jpeg, source: .barcodeLookup))
+    flow.phase = .confirmTrim(
+      .wholeImage(jpeg: jpeg, source: .barcodeLookup, pieceCountEstimate: pieceCountEstimate))
   }
 
   /// Uploads the accepted trimmed image and starts a solve session. Any

--- a/ios/Pussel/App/AppFlow.swift
+++ b/ios/Pussel/App/AppFlow.swift
@@ -37,6 +37,10 @@ struct TrimCandidate {
   let zoomSourceJPEG: Data?
   let detection: DetectFrameResponse
   let source: CaptureSource
+  /// Piece count OCR'd from the box shot by the barcode lookup, used to
+  /// prefill the confirm screen's piece-count field; nil for the photo
+  /// paths and for boxes the backend couldn't read.
+  var pieceCountEstimate: Int?
 
   var trimmedJPEG: Data? {
     ImageUtilities.decodeDataURL(detection.trimmedImage)
@@ -47,7 +51,9 @@ struct TrimCandidate {
   /// so the whole image *is* the trim: identity corners, confidence 1.0
   /// (suppressing the low-confidence banner), and the same JPEG as its own
   /// zoom source (the identity re-warp is a no-op crop).
-  static func wholeImage(jpeg: Data, source: CaptureSource) -> TrimCandidate {
+  static func wholeImage(jpeg: Data, source: CaptureSource, pieceCountEstimate: Int? = nil)
+    -> TrimCandidate
+  {
     TrimCandidate(
       rawJPEG: jpeg,
       zoomSourceJPEG: jpeg,
@@ -61,7 +67,8 @@ struct TrimCandidate {
         ),
         confidence: 1.0
       ),
-      source: source
+      source: source,
+      pieceCountEstimate: pieceCountEstimate
     )
   }
 }

--- a/ios/Pussel/Features/Capture/BarcodeCaptureController.swift
+++ b/ios/Pussel/Features/Capture/BarcodeCaptureController.swift
@@ -36,9 +36,10 @@ final class BarcodeCaptureController {
   }
 
   private(set) var phase: Phase = .scanning
-  /// Called with the decoded box JPEG when a lookup succeeds. Set once by
-  /// the owning view.
-  var onFound: ((Data) -> Void)?
+  /// Called with the decoded box JPEG and the backend's OCR'd piece-count
+  /// estimate (nil when the box couldn't be read) when a lookup succeeds.
+  /// Set once by the owning view.
+  var onFound: ((Data, Int?) -> Void)?
 
   private let client: any BarcodeLookupClient
   private var tracker: BarcodeStabilityTracker
@@ -85,7 +86,7 @@ final class BarcodeCaptureController {
         missedEANs.insert(ean)
         return
       }
-      onFound?(jpeg)
+      onFound?(jpeg, response.pieceCountEstimate)
     } catch {
       // Transport/server error: leave the EAN retryable and stay silently
       // in photo mode, per the no-error-UI design for this flow.

--- a/ios/Pussel/Features/Capture/BoxCameraView.swift
+++ b/ios/Pussel/Features/Capture/BoxCameraView.swift
@@ -11,8 +11,9 @@ import UIKit
 struct BoxCameraView: View {
   /// Manual shutter result — routed to the existing detect-frame path.
   let onImage: (UIImage) -> Void
-  /// Resolved barcode-lookup box JPEG — routed straight to confirm-trim.
-  let onBarcodeJPEG: (Data) -> Void
+  /// Resolved barcode-lookup box JPEG and the backend's OCR'd piece-count
+  /// estimate (nil when unreadable) — routed straight to confirm-trim.
+  let onBarcodeJPEG: (Data, Int?) -> Void
 
   @Environment(AppModel.self) private var model
   @Environment(\.dismiss) private var dismiss
@@ -49,9 +50,9 @@ struct BoxCameraView: View {
     .task {
       let controller = self.controller ?? BarcodeCaptureController(client: model.api)
       self.controller = controller
-      controller.onFound = { jpeg in
+      controller.onFound = { jpeg, pieceCountEstimate in
         dismiss()
-        onBarcodeJPEG(jpeg)
+        onBarcodeJPEG(jpeg, pieceCountEstimate)
       }
       streamer.onDetection = { [weak controller] detection in
         controller?.ingest(detection)

--- a/ios/Pussel/Features/Capture/CapturePuzzleView.swift
+++ b/ios/Pussel/Features/Capture/CapturePuzzleView.swift
@@ -29,8 +29,8 @@ struct CapturePuzzleView: View {
         onImage: { image in
           Task { await handle(image: image, source: .camera) }
         },
-        onBarcodeJPEG: { jpeg in
-          model.startTrimFromBarcodeLookup(jpeg: jpeg)
+        onBarcodeJPEG: { jpeg, pieceCountEstimate in
+          model.startTrimFromBarcodeLookup(jpeg: jpeg, pieceCountEstimate: pieceCountEstimate)
         }
       )
     }

--- a/ios/Pussel/Features/Capture/ConfirmTrimView.swift
+++ b/ios/Pussel/Features/Capture/ConfirmTrimView.swift
@@ -24,6 +24,11 @@ struct ConfirmTrimView: View {
   init(candidate: TrimCandidate) {
     self.candidate = candidate
     self.previewImage = candidate.trimmedJPEG.flatMap(UIImage.init(data:))
+    // Prefill from the barcode lookup's OCR'd box count so a correct read
+    // means zero typing — the user can still edit or tap a preset chip.
+    if let estimate = candidate.pieceCountEstimate, Self.pieceCountRange.contains(estimate) {
+      _pieceCountText = State(initialValue: String(estimate))
+    }
   }
 
   /// The entered piece count, or nil while the field is empty/out of range.

--- a/ios/Pussel/Models/PuzzleModels.swift
+++ b/ios/Pussel/Models/PuzzleModels.swift
@@ -30,6 +30,9 @@ struct BarcodeLookupResponse: Codable, Equatable {
   let boxImage: String?
   /// The resolved Ravensburger article number; present when found.
   let articleNumber: String?
+  /// Piece count the backend OCR'd off the box shot, for prefilling the
+  /// piece-count input; nil when the box couldn't be read confidently.
+  let pieceCountEstimate: Int?
 }
 
 /// Response of POST /api/v1/puzzle/upload.

--- a/ios/PusselTests/APIClientTests.swift
+++ b/ios/PusselTests/APIClientTests.swift
@@ -259,8 +259,10 @@ final class APIClientTests: XCTestCase {
 
   func testLookupBarcodeHitsCorrectPathWithAuthenticatedGet() async throws {
     authStore.backendToken = "barcodetoken"
-    let json =
-      #"{"found": true, "box_image": "data:image/jpeg;base64,Qk9Y", "article_number": "05009"}"#
+    let json = #"""
+      {"found": true, "box_image": "data:image/jpeg;base64,Qk9Y",
+       "article_number": "05009", "piece_count_estimate": 1000}
+      """#
     StubURLProtocol.handler = { _ in (200, Data(json.utf8)) }
     let response = try await client.lookupBarcode(ean: "4005556050093")
     let req = try XCTUnwrap(StubURLProtocol.receivedRequests.first)
@@ -270,14 +272,20 @@ final class APIClientTests: XCTestCase {
     XCTAssertEqual(response.found, true)
     XCTAssertEqual(response.articleNumber, "05009")
     XCTAssertEqual(response.boxImage, "data:image/jpeg;base64,Qk9Y")
+    XCTAssertEqual(response.pieceCountEstimate, 1000)
   }
 
   func testLookupBarcodeDecodesMissResponse() async throws {
     authStore.backendToken = "tok"
+    // No piece_count_estimate key: pre-estimate backends must still decode.
     let json = #"{"found": false, "box_image": null, "article_number": null}"#
     StubURLProtocol.handler = { _ in (200, Data(json.utf8)) }
     let response = try await client.lookupBarcode(ean: "4006381333931")
-    XCTAssertEqual(response, BarcodeLookupResponse(found: false, boxImage: nil, articleNumber: nil))
+    XCTAssertEqual(
+      response,
+      BarcodeLookupResponse(
+        found: false, boxImage: nil, articleNumber: nil, pieceCountEstimate: nil)
+    )
   }
 
   // MARK: - JSON fixtures

--- a/ios/PusselTests/BarcodeCaptureControllerTests.swift
+++ b/ios/PusselTests/BarcodeCaptureControllerTests.swift
@@ -30,15 +30,19 @@ final class FakeBarcodeLookupClient: BarcodeLookupClient {
 private let frozenEAN = "4005556050093"
 private let boxJPEG = Data("box-jpeg-bytes".utf8)
 
-private func foundResponse(jpeg: Data = boxJPEG) -> BarcodeLookupResponse {
+private func foundResponse(jpeg: Data = boxJPEG, pieceCountEstimate: Int? = nil)
+  -> BarcodeLookupResponse
+{
   BarcodeLookupResponse(
     found: true,
     boxImage: "data:image/jpeg;base64,\(jpeg.base64EncodedString())",
-    articleNumber: "05009"
+    articleNumber: "05009",
+    pieceCountEstimate: pieceCountEstimate
   )
 }
 
-private let missResponse = BarcodeLookupResponse(found: false, boxImage: nil, articleNumber: nil)
+private let missResponse = BarcodeLookupResponse(
+  found: false, boxImage: nil, articleNumber: nil, pieceCountEstimate: nil)
 
 private func detection(_ payload: String) -> EAN13Detection {
   EAN13Detection(payload: payload, boundingBox: CGRect(x: 0.2, y: 0.4, width: 0.5, height: 0.15))
@@ -65,12 +69,16 @@ final class BarcodeCaptureControllerTests: XCTestCase {
     )
     // Reference type so the closure and the test observe the same array.
     let found = FoundRecorder()
-    controller.onFound = { found.jpegs.append($0) }
+    controller.onFound = { jpeg, estimate in
+      found.jpegs.append(jpeg)
+      found.estimates.append(estimate)
+    }
     return (controller, { found.jpegs })
   }
 
   private final class FoundRecorder {
     var jpegs: [Data] = []
+    var estimates: [Int?] = []
   }
 
   func testLookupFiresOnlyAfterStableRead() async {
@@ -99,6 +107,24 @@ final class BarcodeCaptureControllerTests: XCTestCase {
 
     XCTAssertEqual(capturedJPEGs(), [boxJPEG])
     XCTAssertEqual(controller.phase, .scanning)
+  }
+
+  func testFoundResponseDeliversPieceCountEstimate() async {
+    let client = FakeBarcodeLookupClient()
+    client.lookupResponses = [.success(foundResponse(pieceCountEstimate: 1000))]
+    let controller = BarcodeCaptureController(
+      client: client, tracker: BarcodeStabilityTracker(requiredConsecutiveHits: 3))
+    let found = FoundRecorder()
+    controller.onFound = { jpeg, estimate in
+      found.jpegs.append(jpeg)
+      found.estimates.append(estimate)
+    }
+
+    for _ in 0..<3 { controller.ingest(detection(frozenEAN)) }
+    await settle()
+
+    XCTAssertEqual(found.estimates, [1000])
+    XCTAssertEqual(found.jpegs, [boxJPEG])
   }
 
   func testMissBlacklistsEANForTheSession() async {
@@ -175,7 +201,9 @@ final class BarcodeCaptureControllerTests: XCTestCase {
   func testUndecodableImageInFoundResponseIsTreatedAsMiss() async {
     let client = FakeBarcodeLookupClient()
     client.lookupResponses = [
-      .success(BarcodeLookupResponse(found: true, boxImage: nil, articleNumber: "05009"))
+      .success(
+        BarcodeLookupResponse(
+          found: true, boxImage: nil, articleNumber: "05009", pieceCountEstimate: nil))
     ]
     let (controller, capturedJPEGs) = makeController(client: client)
 


### PR DESCRIPTION
## What

A scanned box barcode already resolves the puzzle image; the piece count was still typed by hand every time. Every Ravensburger box prints the count prominently on the front, so this reads it there and prefills the field — a correct read means the user types nothing and just confirms.

**Backend.** New `piece_count_estimator` OCRs the box shot with tesseract and returns it as `BarcodeLookupResponse.piece_count_estimate`. The clean motif (`_1`) deliberately carries no text, so when the motif wins the display slot the box shot is fetched separately just for OCR (new `RavensburgerClient.fetch_box_image`). The estimate is cached with the rest of the lookup record, and OCR runs in a thread so it doesn't block the event loop.

**iOS.** The estimate rides through `BarcodeLookupResponse` → `BarcodeCaptureController.onFound` → `TrimCandidate.pieceCountEstimate` → `ConfirmTrimView`, which prefills the "How many pieces?" field (when in the existing 4–2000 range). Presets and the text field behave exactly as before; the user only touches it if the read was wrong.

## Accuracy, and why it prefers silence

A wrong prefill costs the user more than an empty field — they might not notice it and end up with a wrong grid. So the estimator is deliberately tuned to return `None` rather than guess:

- tokens must **exactly** match a piece count Ravensburger actually sells (this is what rejects the "Since 1891" tagline, `3+` age badges, article numbers, and `70x50 cm` box dimensions)
- the **tallest** matching token wins, since the count is always the biggest number on the box
- readings below tesseract confidence 60 are dropped — on the validation set every correct read scored ≥63 and every misread ≤58 (a stylized "500" comes back as "200" or "900")

Validated against 21 live box shots pulled from ravensburger.org: **19 correct, 2 conservative `None`s, 0 wrong guesses.** The two misses are a kids' "2x12" multipack (skewed rotated text) and a stylized square-box "750"; those fall back to today's behavior of an empty field. End-to-end through the real endpoint, a lookup with OCR takes ~0.7–3s.

To handle the range of real box layouts, the estimator OCRs a few targeted crops: the top band for upright badges, the left band rotated both ways for classic 5-digit boxes where the count runs down the edge, plus dark/light binarization variants (tesseract's own binarization loses pink-on-white, which is exactly how the 1000-piece badge is printed).

## Reviewer notes

- **tesseract is a system binary, not a Python dependency.** It's installed in `backend/Dockerfile` and in `backend-ci.yml`. If it's absent the estimator logs once and returns `None`, so the feature degrades silently rather than breaking lookups — there's a test for that path, and the synthetic-render OCR tests skip when the binary is missing.
- The `piece_count_estimate` field is additive and optional on both ends; `APIClientTests` covers decoding a response **without** the key, so an older backend still works with a new app.
- `estimate_piece_count` never raises — undecodable bytes, tiny images, and tesseract failures all return `None`.

## Testing

- 331 backend tests pass, 12 new: pure token-filter cases (catalog matching, multipack `N x M` → per-puzzle count, dimension/year rejection, separator cleanup) and endpoint cases for the motif / box / missing-box / unreadable paths.
- 184 iOS tests pass, including estimate passthrough and decoding with and without the new field.
- `make check` fully green (backend black/isort/flake8/pyright, iOS SwiftLint, frontend).
- Verified live against the real endpoint: scanning the dragon-puzzle EAN returns the motif plus `piece_count_estimate: 1000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)