### PR TITLE
iOS: add a 1500 chip and hide the piece-count field behind "Other"

### DIFF
--- a/ios/Pussel/Features/Capture/ConfirmTrimView.swift
+++ b/ios/Pussel/Features/Capture/ConfirmTrimView.swift
@@ -3,14 +3,18 @@ import SwiftUI
 struct ConfirmTrimView: View {
   /// Mirrors LOW_CONFIDENCE_THRESHOLD in frontend/src/app/real/page.tsx.
   private static let lowConfidence = 0.4
-  /// Piece-count quick-pick presets shown as chips above the numeric field.
-  private static let pieceCountPresets = [12, 24, 48, 100, 500, 1000]
+  /// Piece-count quick-pick presets shown as chips; anything else goes through
+  /// the "Other" chip, which reveals the numeric field.
+  private static let pieceCountPresets = [12, 24, 48, 100, 500, 1000, 1500]
   private static let pieceCountRange = 4...2000
 
   @Environment(AppModel.self) private var model
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @State private var quarterTurns = 0
   @State private var pieceCountText = ""
+  /// The numeric field is hidden until the user picks "Other" — it is only
+  /// needed for counts the preset chips don't cover.
+  @State private var showsCustomField = false
   @FocusState private var pieceCountFieldFocused: Bool
   @State private var hintOpacity = 0.0
   @State private var hintTurns = 0
@@ -29,6 +33,10 @@ struct ConfirmTrimView: View {
     // means zero typing; the user can still edit or tap a preset chip.
     if let estimate = candidate.pieceCountEstimate, Self.pieceCountRange.contains(estimate) {
       _pieceCountText = State(initialValue: String(estimate))
+      // An estimate no chip covers has to be visible somewhere, so reveal the
+      // field (and light up "Other") rather than showing a count with nothing
+      // selected.
+      _showsCustomField = State(initialValue: !Self.pieceCountPresets.contains(estimate))
     }
   }
 
@@ -143,34 +151,35 @@ struct ConfirmTrimView: View {
     VStack(spacing: 10) {
       Text("How many pieces?")
         .font(.subheadline.bold())
-      ScrollView(.horizontal, showsIndicators: false) {
-        HStack(spacing: 8) {
-          ForEach(Self.pieceCountPresets, id: \.self) { preset in
-            Button {
-              pieceCountText = String(preset)
-              pieceCountFieldFocused = false
-            } label: {
-              Text("\(preset)")
-                .font(.subheadline.weight(.medium))
-                .padding(.horizontal, 14)
-                .padding(.vertical, 8)
-                .background(
-                  pieceCount == preset ? Color.accentColor : Color.secondary.opacity(0.15),
-                  in: Capsule()
-                )
-                .foregroundStyle(pieceCount == preset ? Color.white : Color.primary)
-            }
-            .buttonStyle(.plain)
+      // Wrapping rather than horizontally scrolling: "Other" is the only way
+      // to reach a count the chips don't list, so it must never sit off the
+      // scrolled edge where nobody finds it.
+      ChipFlowLayout(spacing: 8) {
+        ForEach(Self.pieceCountPresets, id: \.self) { preset in
+          chip("\(preset)", isSelected: !showsCustomField && pieceCount == preset) {
+            pieceCountText = String(preset)
+            showsCustomField = false
+            pieceCountFieldFocused = false
           }
         }
-        .padding(.horizontal, 1)
+        chip("Other", isSelected: showsCustomField) {
+          // Coming from a chip, the field would otherwise open pre-filled
+          // with that preset — clear it so typing starts on a blank field.
+          if let pieceCount, Self.pieceCountPresets.contains(pieceCount) {
+            pieceCountText = ""
+          }
+          showsCustomField = true
+          pieceCountFieldFocused = true
+        }
       }
-      TextField("Piece count (4–2000)", text: $pieceCountText)
-        .keyboardType(.numberPad)
-        .multilineTextAlignment(.center)
-        .textFieldStyle(.roundedBorder)
-        .focused($pieceCountFieldFocused)
-        .frame(maxWidth: 220)
+      if showsCustomField {
+        TextField("Piece count (4–2000)", text: $pieceCountText)
+          .keyboardType(.numberPad)
+          .multilineTextAlignment(.center)
+          .textFieldStyle(.roundedBorder)
+          .focused($pieceCountFieldFocused)
+          .frame(maxWidth: 220)
+      }
       if let grid = estimatedGrid, let pieceCount {
         Text("\(pieceCount) pieces → \(grid.rows) × \(grid.cols) grid")
           .font(.footnote)
@@ -181,6 +190,23 @@ struct ConfirmTrimView: View {
           .foregroundStyle(.red)
       }
     }
+  }
+
+  /// A capsule quick-pick chip in the piece-count row.
+  private func chip(_ title: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+    Button(action: action) {
+      Text(title)
+        .font(.subheadline.weight(.medium))
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(
+          isSelected ? Color.accentColor : Color.secondary.opacity(0.15),
+          in: Capsule()
+        )
+        .foregroundStyle(isSelected ? Color.white : Color.primary)
+    }
+    .buttonStyle(.plain)
+    .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
   }
 
   /// One-shot "tap here to rotate" demo drawn over the photo: a tapping finger

--- a/ios/Pussel/Support/ChipFlowLayout.swift
+++ b/ios/Pussel/Support/ChipFlowLayout.swift
@@ -11,8 +11,12 @@ struct ChipFlowLayout: Layout {
   var spacing: CGFloat = 8
 
   func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) -> CGSize {
-    let rows = rows(for: subviews, width: proposal.width ?? .infinity)
-    let width = rows.map(\.width).max() ?? 0
+    let proposed = proposal.width ?? .infinity
+    let rows = rows(for: subviews, width: proposed)
+    // A chip too wide to wrap (long localization, large Dynamic Type) sits on
+    // a row of its own that overflows; report at most what we were offered so
+    // the parent isn't asked for width it won't hand back.
+    let width = min(rows.map(\.width).max() ?? 0, proposed)
     let height = rows.map(\.height).reduce(0, +) + spacing * CGFloat(max(rows.count - 1, 0))
     return CGSize(width: width, height: height)
   }
@@ -22,7 +26,9 @@ struct ChipFlowLayout: Layout {
   ) {
     var y = bounds.minY
     for row in rows(for: subviews, width: bounds.width) {
-      var x = bounds.minX + (bounds.width - row.width) / 2
+      // max() so an overflowing row starts at the leading edge rather than
+      // being centred into a negative origin, which would clip both ends.
+      var x = bounds.minX + max((bounds.width - row.width) / 2, 0)
       for index in row.indices {
         let size = subviews[index].sizeThatFits(.unspecified)
         subviews[index].place(

--- a/ios/Pussel/Support/ChipFlowLayout.swift
+++ b/ios/Pussel/Support/ChipFlowLayout.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+/// Lays capsule chips out left to right, wrapping to a new row whenever the
+/// next chip would overflow the proposed width, with every row centred.
+///
+/// SwiftUI has no built-in flow layout, and the alternatives don't fit the
+/// piece-count picker: an `HStack` clips its overflow and a horizontal
+/// `ScrollView` hides chips past the edge — including "Other", the only route
+/// to a count the presets don't cover.
+struct ChipFlowLayout: Layout {
+  var spacing: CGFloat = 8
+
+  func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) -> CGSize {
+    let rows = rows(for: subviews, width: proposal.width ?? .infinity)
+    let width = rows.map(\.width).max() ?? 0
+    let height = rows.map(\.height).reduce(0, +) + spacing * CGFloat(max(rows.count - 1, 0))
+    return CGSize(width: width, height: height)
+  }
+
+  func placeSubviews(
+    in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout Void
+  ) {
+    var y = bounds.minY
+    for row in rows(for: subviews, width: bounds.width) {
+      var x = bounds.minX + (bounds.width - row.width) / 2
+      for index in row.indices {
+        let size = subviews[index].sizeThatFits(.unspecified)
+        subviews[index].place(
+          at: CGPoint(x: x, y: y + (row.height - size.height) / 2),
+          proposal: ProposedViewSize(size)
+        )
+        x += size.width + spacing
+      }
+      y += row.height + spacing
+    }
+  }
+
+  private struct Row {
+    var indices: [Subviews.Index] = []
+    var width: CGFloat = 0
+    var height: CGFloat = 0
+  }
+
+  private func rows(for subviews: Subviews, width: CGFloat) -> [Row] {
+    var rows: [Row] = []
+    var row = Row()
+    for index in subviews.indices {
+      let size = subviews[index].sizeThatFits(.unspecified)
+      let widthWithChip = row.indices.isEmpty ? size.width : row.width + spacing + size.width
+      // Keep a lone oversized chip on its own row rather than dropping it.
+      if widthWithChip > width, !row.indices.isEmpty {
+        rows.append(row)
+        row = Row()
+      }
+      row.width = row.indices.isEmpty ? size.width : row.width + spacing + size.width
+      row.height = max(row.height, size.height)
+      row.indices.append(index)
+    }
+    if !row.indices.isEmpty { rows.append(row) }
+    return rows
+  }
+}


### PR DESCRIPTION
## What

On the confirm-trim screen ("Does this look right?"), the piece-count picker changes:

- **New `1500` preset chip** — a common box size that previously forced the manual field.
- **New `Other` chip** — the numeric text field is now hidden until you tap it. Tapping `Other` clears a preset-derived value and focuses the field so typing starts blank; tapping any number chip hides the field again and dismisses the keyboard.
- **The chip row wraps instead of scrolling** — with eight chips, a horizontal `ScrollView` would have left `Other` past the scrolled edge, and that is the one chip that has to be findable. Added a small `ChipFlowLayout` (`Layout`) that wraps and centres each row.
- If OCR prefills a count no chip covers (e.g. 750), the screen opens with `Other` selected and the field showing that value — otherwise you'd see a count with nothing selected.

## Why

The field was visible at all times but is only needed when none of the presets fit; it cost vertical space on every capture. Hiding it gives the trimmed photo noticeably more room.

## Reviewer notes

- Verified on the Simulator end to end (`make ios-run` + the debug command channel): OCR reads 1000 off a real box photo → `1000` lit, no field; tap `Other` → empty field, "Use This" disabled; type `1750` → "1.750 pieces → 45 × 39 grid", enabled; tap `1500` → 42 × 36 grid, field collapses.
- The one path not exercised on-device is the "OCR estimate isn't a preset" branch — no box photo on hand OCRs to a non-preset count. It's the three-line `showsCustomField` init in `ConfirmTrimView`.
- `make check-ios` and `make ios-test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)