### PR TITLE
Fix puzzle frame detection on textured gray carpet

### DIFF
--- a/backend/app/services/puzzle_detector.py
+++ b/backend/app/services/puzzle_detector.py
@@ -24,9 +24,28 @@ FULL_CONFIDENCE_AREA_RATIO = 0.5
 # Fraction of the shorter working dimension used as the border ring for background sampling
 BORDER_FRACTION = 0.05
 
-# If the border ring's 99th-percentile chroma deviation exceeds this, there is no
-# uniform background around the subject (e.g. an edge-to-edge image) and detection bails out
-MAX_BORDER_CHROMA_SPREAD = 0.06
+# If the border ring's 99th-percentile color residual (RGB units, see _foreground_mask)
+# exceeds this, there is no uniform background around the subject (e.g. an edge-to-edge
+# image) and detection bails out. Calibrated so a textured carpet with mild illumination
+# tint (~20) passes while a colored surround (~100+) bails.
+MAX_BORDER_COLOR_SPREAD = 30.0
+
+# Minimum color residual (RGB units) for a pixel to count as foreground
+COLOR_RESIDUAL_FLOOR = 12.0
+
+# GrabCut refinement runs on a further-downscaled copy: cost grows quadratically and
+# region shape, not pixel accuracy, is what the quad fit needs
+GRABCUT_MAX_DIM = 750
+
+# Seed components smaller than this fraction of the frame are dropped before GrabCut
+# (stray specks — e.g. a photographer's shadow patch — would otherwise grow into the region)
+GRABCUT_SEED_COMPONENT_RATIO = 0.005
+
+# GrabCut is skipped when the surviving seeds cover less than this fraction of the frame:
+# with almost no foreground evidence it would hallucinate a region from noise
+GRABCUT_MIN_SEED_RATIO = 0.02
+
+GRABCUT_ITERATIONS = 3
 
 # Auto-Canny spread: thresholds are set to (1 ± sigma) × the image's median intensity,
 # so the edge detector adapts to each photo's exposure rather than using fixed levels
@@ -87,12 +106,15 @@ class PuzzleFrameDetector:
     """Detects the puzzle picture in a photo and warps it to a flat crop.
 
     Detection is layered. The fast path segments the subject from a roughly
-    uniform background (sampled from the photo's border) using chroma distance
+    uniform background (sampled from the photo's border) using a color residual
     — which ignores shadows — plus a brighter-than-background luminance rule,
     then fits a quadrilateral to the convex hull of the largest region. When
-    the border is not a uniform background (e.g. a handheld photo where the
-    puzzle nearly fills the frame), it falls back to direct edge-based
-    detection of the puzzle's rectangular boundary.
+    that mask has real foreground evidence but no single region large enough
+    (a washed-out puzzle segments into fragments), a GrabCut pass seeded from
+    those fragments recovers the full region. When the border is not a uniform
+    background (e.g. a handheld photo where the puzzle nearly fills the frame),
+    it falls back to direct edge-based detection of the puzzle's rectangular
+    boundary.
 
     The puzzle picture is a strong quadrilateral with straight edges, so the
     fallback looks for that rectangle explicitly rather than asking a
@@ -126,6 +148,9 @@ class PuzzleFrameDetector:
 
         mask = self._foreground_mask(work)
         result = self._quad_from_mask(mask, work_w, work_h) if mask is not None else None
+
+        if result is None and mask is not None:
+            result = self._grabcut_quad(work, mask, work_w, work_h)
 
         if result is None:
             result = self._edge_quad(work, work_w, work_h)
@@ -169,6 +194,15 @@ class PuzzleFrameDetector:
     def _foreground_mask(self, work: "np.ndarray") -> Optional["np.ndarray"]:
         """Segment the subject from the background sampled along the photo's border.
 
+        Deviation from the background color is measured as the residual
+        ``||pixel - bg_chroma * luminance||`` in RGB units — the pixel compared
+        against the background's chroma scaled to the pixel's own brightness.
+        This equals chroma distance times luminance, which keeps the shadow
+        invariance of chroma but stays robust where raw chroma is not: in dark
+        pixels (a carpet's fiber shadows) the channel sum is small, so sensor
+        and JPEG noise dominate the chroma ratio, while the residual stays
+        near the noise amplitude.
+
         Args:
             work: Blurred float RGB working image.
 
@@ -183,27 +217,109 @@ class PuzzleFrameDetector:
         border_mask[:, :margin] = border_mask[:, -margin:] = True
 
         pix_chroma = _chroma(work)
-        border_chroma = pix_chroma[border_mask]
-        bg_chroma = np.median(border_chroma, axis=0)
-        border_spread = float(np.percentile(np.linalg.norm(border_chroma - bg_chroma, axis=1), 99))
-        if border_spread > MAX_BORDER_CHROMA_SPREAD:
+        bg_chroma = np.median(pix_chroma[border_mask], axis=0)
+
+        luminance = work.sum(axis=2)
+        residual = np.linalg.norm(work - bg_chroma[None, None, :] * luminance[..., None], axis=2)
+        border_spread = float(np.percentile(residual[border_mask], 99))
+        if border_spread > MAX_BORDER_COLOR_SPREAD:
             # Border pixels vary too much: no uniform background (e.g. edge-to-edge picture)
             return None
 
-        chroma_dist = np.linalg.norm(pix_chroma - bg_chroma, axis=2)
-        chroma_thresh = max(0.03, 1.5 * border_spread)
+        residual_thresh = max(COLOR_RESIDUAL_FLOOR, 1.5 * border_spread)
 
         # Brighter-than-background pixels are foreground too (a shadow is never brighter)
-        luminance = work.sum(axis=2)
         border_lum = luminance[border_mask]
         bg_lum = float(np.median(border_lum))
         lum_spread = float(np.percentile(np.abs(border_lum - bg_lum), 99))
         lum_thresh = max(60.0, 1.5 * lum_spread)
 
-        mask = ((chroma_dist > chroma_thresh) | (luminance > bg_lum + lum_thresh)).astype(np.uint8) * 255
+        mask = ((residual > residual_thresh) | (luminance > bg_lum + lum_thresh)).astype(np.uint8) * 255
         mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, np.ones((25, 25), dtype=np.uint8))
         mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, np.ones((11, 11), dtype=np.uint8))
         return cast("np.ndarray", mask)
+
+    def _grabcut_quad(
+        self, work: "np.ndarray", seed_mask: "np.ndarray", work_w: int, work_h: int
+    ) -> Optional[Tuple["np.ndarray", float]]:
+        """Recover the subject region with GrabCut when the color mask is fragmented.
+
+        A washed-out puzzle under warm light can be so close to the background
+        color that thresholding only picks up scattered colorful fragments,
+        none large enough to pass the area gate. GrabCut — seeded with those
+        fragments as probable foreground and the border ring as definite
+        background — models both sides as color mixtures with spatial
+        smoothness, growing the fragments out to the subject's true color
+        boundary. The recovered foreground is often still fragmented — a ring
+        with washed-out holes, or patches along the subject's frame — so the
+        quad is fitted (and the area gate applied) on the convex hull of all
+        significant recovered components, treating them as one convex subject.
+
+        Args:
+            work: Blurred float RGB working image.
+            seed_mask: uint8 foreground mask (0/255) from _foreground_mask.
+            work_w: Working image width.
+            work_h: Working image height.
+
+        Returns:
+            A (quad, confidence) tuple where quad has shape (4, 2), or None
+            when the seeds are too sparse or no recovered region covers at
+            least MIN_AREA_RATIO.
+        """
+        total_area = work_w * work_h
+        count, labels, stats, _ = cv2.connectedComponentsWithStats(seed_mask, connectivity=8)
+        seeds = np.zeros_like(seed_mask)
+        for label in range(1, count):
+            if stats[label, cv2.CC_STAT_AREA] >= GRABCUT_SEED_COMPONENT_RATIO * total_area:
+                seeds[labels == label] = 255
+        if np.count_nonzero(seeds) < GRABCUT_MIN_SEED_RATIO * total_area:
+            return None
+
+        scale = min(1.0, GRABCUT_MAX_DIM / max(work_w, work_h))
+        grab_w = max(1, round(work_w * scale))
+        grab_h = max(1, round(work_h * scale))
+        image = cv2.resize(np.clip(work, 0, 255).astype(np.uint8), (grab_w, grab_h))
+        seeds_small = cv2.resize(seeds, (grab_w, grab_h), interpolation=cv2.INTER_NEAREST)
+
+        margin = max(2, round(BORDER_FRACTION * min(grab_w, grab_h)))
+        grab = np.full((grab_h, grab_w), cv2.GC_PR_BGD, dtype=np.uint8)
+        grab[seeds_small > 0] = cv2.GC_PR_FGD
+        grab[:margin] = grab[-margin:] = cv2.GC_BGD
+        grab[:, :margin] = grab[:, -margin:] = cv2.GC_BGD
+
+        background_model = np.zeros((1, 65), dtype=np.float64)
+        foreground_model = np.zeros((1, 65), dtype=np.float64)
+        try:
+            # The rect argument is unused in GC_INIT_WITH_MASK mode
+            cv2.grabCut(
+                image, grab, (0, 0, 0, 0), background_model, foreground_model, GRABCUT_ITERATIONS, cv2.GC_INIT_WITH_MASK
+            )
+        except cv2.error:
+            return None
+
+        foreground = ((grab == cv2.GC_FGD) | (grab == cv2.GC_PR_FGD)).astype(np.uint8) * 255
+        foreground = cv2.resize(foreground, (work_w, work_h), interpolation=cv2.INTER_NEAREST)
+        foreground = cv2.morphologyEx(foreground, cv2.MORPH_OPEN, np.ones((11, 11), dtype=np.uint8))
+
+        count, labels, stats, _ = cv2.connectedComponentsWithStats(foreground, connectivity=8)
+        kept = np.zeros_like(foreground)
+        kept_area = 0
+        for label in range(1, count):
+            if stats[label, cv2.CC_STAT_AREA] >= GRABCUT_SEED_COMPONENT_RATIO * total_area:
+                kept[labels == label] = 255
+                kept_area += int(stats[label, cv2.CC_STAT_AREA])
+        points = cv2.findNonZero(kept)
+        if points is None:
+            return None
+        hull = cv2.convexHull(points)
+        hull_area = cv2.contourArea(hull)
+        hull_ratio = hull_area / total_area
+        if hull_ratio < MIN_AREA_RATIO:
+            return None
+
+        quad = self._quad_from_hull(hull)
+        confidence = self._confidence(quad, float(kept_area), hull_area, hull_ratio)
+        return quad, confidence
 
     def _edge_quad(self, work: "np.ndarray", work_w: int, work_h: int) -> Optional[Tuple["np.ndarray", float]]:
         """Detect the puzzle's rectangular boundary directly from image edges.
@@ -283,7 +399,10 @@ class PuzzleFrameDetector:
         the quad is, how much of the photo it covers, and how much of its
         outline actually lies on detected edges (edge support). Edge support is
         the key discriminator — a quad that traces a real bordered rectangle
-        sits on strong edges, an arbitrary quad does not.
+        sits on strong edges, an arbitrary quad does not. Support is measured
+        as the excess over the edge map's overall density: on a densely
+        textured background (a carpet) a random outline already hits many edge
+        pixels, so only support above that chance level counts.
 
         Args:
             quad: The candidate quadrilateral, shape (4, 2).
@@ -305,7 +424,13 @@ class PuzzleFrameDetector:
         outline_pixels = int(np.count_nonzero(outline))
         edge_support = float(np.count_nonzero(edges & outline)) / outline_pixels if outline_pixels else 0.0
 
-        confidence = rectangularity * edge_support * min(1.0, area_ratio / FULL_CONFIDENCE_AREA_RATIO)
+        edge_density = float(np.count_nonzero(edges)) / edges.size
+        if edge_density >= 1.0:
+            support_above_chance = 0.0
+        else:
+            support_above_chance = max(0.0, (edge_support - edge_density) / (1.0 - edge_density))
+
+        confidence = rectangularity * support_above_chance * min(1.0, area_ratio / FULL_CONFIDENCE_AREA_RATIO)
         return float(np.clip(confidence, 0.0, 1.0))
 
     def _quad_from_mask(self, mask: "np.ndarray", work_w: int, work_h: int) -> Optional[Tuple["np.ndarray", float]]:

--- a/backend/app/services/puzzle_detector.py
+++ b/backend/app/services/puzzle_detector.py
@@ -292,7 +292,13 @@ class PuzzleFrameDetector:
         try:
             # The rect argument is unused in GC_INIT_WITH_MASK mode
             cv2.grabCut(
-                image, grab, (0, 0, 0, 0), background_model, foreground_model, GRABCUT_ITERATIONS, cv2.GC_INIT_WITH_MASK
+                image,
+                grab,
+                (0, 0, 0, 0),
+                background_model,
+                foreground_model,
+                GRABCUT_ITERATIONS,
+                cv2.GC_INIT_WITH_MASK,
             )
         except cv2.error:
             return None

--- a/backend/tests/test_puzzle_detector.py
+++ b/backend/tests/test_puzzle_detector.py
@@ -395,7 +395,7 @@ class TestCarpetBackground:
         # Mostly achromatic artwork with a wash tint too weak for the threshold
         # mask, plus colorful fragments along parts of the frame (a broken ring)
         rng = np.random.default_rng(11)
-        coarse = rng.uniform(60, 200, (85, 85, 1)).astype(np.float32)
+        coarse = rng.uniform(60, 200, (85, 85)).astype(np.float32)
         base = cv2.resize(np.clip(coarse, 0, 255), (512, 512))
         art_f = np.zeros((512, 512, 3), dtype=np.float32)
         art_f[:, :, 0] = base + 18

--- a/backend/tests/test_puzzle_detector.py
+++ b/backend/tests/test_puzzle_detector.py
@@ -308,6 +308,138 @@ class TestEdgeFallback:
         ]
 
 
+class TestCarpetBackground:
+    """Regression tests for a small puzzle on speckled gray carpet.
+
+    Both fixtures reproduce real handheld photos of a small puzzle on gray
+    carpet (2026-07-24 GlareFreeDumps captures, not committed). The carpet's
+    fiber speckle carries chromatic noise that survives the working blur, which
+    corrupted the old chroma-distance segmentation into a confident wrong quad
+    or a full-frame fallback.
+    """
+
+    @staticmethod
+    def make_carpet(rng: "np.random.Generator", width: int, height: int) -> "np.ndarray":
+        """Render a speckled gray carpet with chromatic noise in the speckle.
+
+        The speckle is generated at a coarse "fiber" scale and upscaled so it
+        survives the detector's working blur, like real carpet fibers do. The
+        per-channel tint noise makes dark fibers chromatically unreliable —
+        the property that broke the raw chroma-distance formulation.
+
+        Args:
+            rng: Seeded random generator.
+            width: Output width in pixels.
+            height: Output height in pixels.
+
+        Returns:
+            uint8 RGB array of shape (height, width, 3).
+        """
+        fiber = 6
+        coarse_w, coarse_h = width // fiber, height // fiber
+        fibers = rng.uniform(40, 200, (coarse_h, coarse_w, 1)).astype(np.float32)
+        tint = rng.normal(0, 10, (coarse_h, coarse_w, 3)).astype(np.float32)
+        coarse = np.clip(fibers + tint, 0, 255)
+        return cv2.resize(coarse, (width, height), interpolation=cv2.INTER_LINEAR).astype(np.uint8)
+
+    @staticmethod
+    def compose(carpet: "np.ndarray", art: "np.ndarray", dst_quad: "np.ndarray") -> Image.Image:
+        """Warp the artwork onto the carpet at the given destination quad."""
+        height, width = carpet.shape[:2]
+        size = art.shape[0]
+        src = np.array([[0, 0], [size, 0], [size, size], [0, size]], dtype=np.float32)
+        matrix = cv2.getPerspectiveTransform(src, dst_quad.astype(np.float32))
+        warped = cv2.warpPerspective(art, matrix, (width, height))
+        mask = cv2.warpPerspective(np.full((size, size), 255, np.uint8), matrix, (width, height))
+        return Image.fromarray(np.where(mask[..., None] > 0, warped, carpet))
+
+    def test_small_colorful_puzzle_on_speckled_carpet(self, detector: PuzzleFrameDetector) -> None:
+        """A colorful puzzle covering ~18% of the frame is found on noisy carpet.
+
+        Regression for the real capture where the border ring's noisy chroma
+        made the old segmentation return a confident wrong quad: the color
+        residual must treat the speckle as one uniform background.
+        """
+        width, height = 1200, 1600
+        carpet = self.make_carpet(np.random.default_rng(3), width, height)
+
+        art = np.zeros((512, 512, 3), dtype=np.uint8)
+        art[:, :, 0] = np.linspace(60, 230, 512, dtype=np.uint8)[None, :]
+        art[:, :, 1] = np.linspace(200, 40, 512, dtype=np.uint8)[:, None]
+        art[:, :, 2] = 160
+        art[::32] = (240, 120, 40)
+
+        dst_quad = np.array([[370, 430], [850, 445], [840, 1160], [360, 1150]], dtype=np.float32)
+        photo = self.compose(carpet, art, dst_quad)
+
+        corners, confidence = detector.detect_corners(photo)
+
+        expected = [(float(x) / width, float(y) / height) for x, y in dst_quad.tolist()]
+        assert confidence > 0.25
+        assert_corners_close(corners, expected)
+
+    def test_washed_out_puzzle_recovered_by_grabcut(self, detector: PuzzleFrameDetector) -> None:
+        """A washed-out puzzle whose colors barely differ from the carpet is recovered.
+
+        Regression for the real capture under warm light where thresholding
+        only finds scattered colorful fragments, none passing the area gate:
+        the GrabCut stage must grow the fragments and fit the quad on their
+        combined convex hull instead of falling through to the edge path
+        (which traces a garbage quad on the carpet texture).
+        """
+        from unittest.mock import patch
+
+        width, height = 1200, 1600
+        carpet = self.make_carpet(np.random.default_rng(5), width, height)
+
+        # Mostly achromatic artwork with a wash tint too weak for the threshold
+        # mask, plus colorful fragments along parts of the frame (a broken ring)
+        rng = np.random.default_rng(11)
+        coarse = rng.uniform(60, 200, (85, 85, 1)).astype(np.float32)
+        base = cv2.resize(np.clip(coarse, 0, 255), (512, 512))
+        art_f = np.zeros((512, 512, 3), dtype=np.float32)
+        art_f[:, :, 0] = base + 18
+        art_f[:, :, 1] = base
+        art_f[:, :, 2] = base + 18
+        art = np.clip(art_f, 0, 255).astype(np.uint8)
+        art[:45, :, :] = (210, 90, 40)
+        art[:, -45:, :] = (60, 60, 200)
+        art[-45:, :150, :] = (200, 40, 160)
+        art[100:220, :45, :] = (240, 150, 30)
+        art[220:300, 200:300] = (40, 160, 60)
+
+        dst_quad = np.array([[330, 380], [890, 400], [880, 1210], [320, 1190]], dtype=np.float32)
+        photo = self.compose(carpet, art, dst_quad)
+
+        cv2.setRNGSeed(7)  # pin GrabCut's k-means initialization
+        with (
+            patch.object(detector, "_grabcut_quad", wraps=detector._grabcut_quad) as grabcut_spy,
+            patch.object(detector, "_edge_quad", wraps=detector._edge_quad) as edge_spy,
+        ):
+            corners, confidence = detector.detect_corners(photo)
+        grabcut_spy.assert_called_once()
+        edge_spy.assert_not_called()
+
+        expected = [(float(x) / width, float(y) / height) for x, y in dst_quad.tolist()]
+        assert confidence > 0.05
+        assert_corners_close(corners, expected)
+
+    def test_dense_edge_map_gives_no_confidence(self, detector: PuzzleFrameDetector) -> None:
+        """Edge support on a texture-saturated edge map scores near zero.
+
+        On carpet, the dilated Canny map is dense enough that any outline
+        "hits" edges by chance; confidence must count only support above that
+        chance level, so a garbage quad on texture cannot score well.
+        """
+        rng = np.random.default_rng(2)
+        edges = ((rng.random((600, 800)) < 0.5) * 255).astype(np.uint8)
+        quad = np.array([[100, 80], [700, 90], [690, 520], [110, 510]], dtype=np.float32)
+
+        confidence = detector._rect_confidence(quad, edges, 800, 600)
+
+        assert confidence < 0.1
+
+
 def test_get_puzzle_detector_is_singleton() -> None:
     """get_puzzle_detector returns the same instance on repeated calls."""
     assert get_puzzle_detector() is get_puzzle_detector()


### PR DESCRIPTION
## What

Fixes `PuzzleFrameDetector` failing on real handheld captures of a small puzzle lying on gray carpet — one photo returned a confident garbage quad (conf 0.358), the other fell back to full-frame (conf 0.0).

## Why it failed

Two layers broke at once on carpet:

1. **Mask path bailed wrongly.** The border-uniformity check measured raw *chroma* spread; in the dark shadows between carpet fibers the channel sum is tiny, so sensor/JPEG noise inflates chroma to ~0.15 against the 0.06 limit — on a background that is genuinely uniform.
2. **Edge fallback drowned in texture.** Dilated Canny covers ~35% of the frame on carpet, so a giant fiber blob quad-fit and hit enough random edges to score confidently, while the actual puzzle (below the 15% area gate) was never found.

## Changes

- **Color residual instead of chroma distance**: deviation is `‖pixel − bg_chroma·luminance‖` in RGB units (mathematically chroma distance × luminance) — keeps shadow invariance, stays bounded by noise amplitude in dark pixels. Border limit recalibrated in the new units (carpet ≈ 16–22; the non-uniform surrounds that must still bail sit at ≈ 105).
- **New GrabCut refinement stage** between the mask and edge paths: when the threshold mask has real signal but no region passes the area gate (a washed-out puzzle under warm light segments into fragments), GrabCut seeded with those fragments (border ring = definite background) grows them to the true color boundary, and the quad is fitted on the convex hull of the significant recovered components. Runs at ≤750 px only on this fall-through path (~0.5 s); the fast path is untouched (~30 ms).
- **Edge support measured above chance**: support is discounted by the edge map's overall density, so garbage quads on texture-saturated edge maps drop to ~0.16 while legitimate edge-fallback detections stay above 0.4.

## Verification

- Both motivating photos (not committed) now yield pixel-accurate quads: conf 0.25 via the GrabCut path and 0.31 via the fast path.
- New `TestCarpetBackground` tests use synthetic carpet — coarse-scale speckle with chromatic noise so it survives the working blur like real fibers. Both scene fixtures were verified to **fail on the previous implementation** (corner error ~0.3, confidently wrong) and detect with corner error ≤0.003 now; spies confirm the washed-out fixture goes through the GrabCut stage, not the edge path.
- Full backend suite: 336 passed; `make check-backend` clean.

## Reviewer notes

- Confidence on small-puzzle captures is inherently modest (~0.2–0.35) because the score scales with frame coverage; the quads themselves are exact.
- `cv2.setRNGSeed(7)` in the GrabCut test pins k-means initialization for determinism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)