### PR TITLE
Add deployment sections to root and backend READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ Quality is enforced by pre-commit hooks and GitHub Actions: Black/isort/flake8/
 pyright for Python, OxLint/Prettier/TypeScript/Vitest/Playwright for the
 frontend, swift-format + SwiftLint for iOS, and Codecov for coverage.
 
+## Deployment
+
+The backend is the only deployed component. It runs on the home server as a
+Docker Compose stack behind Cloudflare, reachable at
+https://pussel.sabeltiger.dk and https://pussel.thomasen.dk (the URL the iOS
+app ships with).
+
+Merging to `main` is the deploy: a systemd timer on the server polls the
+repository every 5 minutes and, on a new commit, rebuilds the image natively
+and restarts the stack — no registry and no deploy secrets in CI, which only
+verifies that the image still builds. Setup and operations are documented in
+[backend/deploy/README.md](backend/deploy/README.md).
+
 ## License
 
 MIT.

--- a/backend/README.md
+++ b/backend/README.md
@@ -77,6 +77,20 @@ make check-backend       # black, isort, flake8, pyright — what CI runs
 make format-backend      # auto-fix formatting
 ```
 
+## Deployment
+
+Runs on the home server as a Docker Compose stack, routed through the
+Appwrite stack's Traefik and fronted by Cloudflare at
+https://pussel.sabeltiger.dk and https://pussel.thomasen.dk (the URL in the
+iOS app's Release config).
+
+Merging to `main` deploys: `pussel-deploy.timer` on the server polls every
+5 minutes and rebuilds/restarts on a new commit; a failed build leaves the
+running container untouched. The image builds from the **repo root**
+(`docker build -f backend/Dockerfile .`), since the backend depends on
+`shared/puzzle_shapes`. First-time setup, secrets layout, and operations
+commands live in [deploy/README.md](deploy/README.md).
+
 ## Layout
 
 ```


### PR DESCRIPTION
Short **Deployment** sections in `README.md` and `backend/README.md`: where the backend runs (home server behind Cloudflare, both hostnames), how deploys happen (merge to `main` → server-side timer rebuilds and restarts), and a pointer to `backend/deploy/README.md` for setup and operations. Docs only — no code tests needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)