### PR TITLE
Keep deployment identity out of the repo

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ photograph a loose piece to get its position, rotation, and confidence.
 ## Components
 
 - `backend/` — FastAPI service (Python 3.12): piece matching, puzzle store,
-  Google auth. Deployed to the home server from `main`
+  Google auth. Deployed from `main` to the project's own server
   (see `backend/deploy/README.md`).
 - `ios/` — native SwiftUI app (iOS 26), the shipped client.
 - `frontend/` — Next.js 16 + Bun + Tailwind web app. Dev/test client, **not
@@ -78,7 +78,7 @@ Per-component workflows in `.github/workflows/` (`backend-ci`, `frontend-ci`,
 `ios-ci`, `network-ci`, plus a Dependabot lockfile job) run the same checks as
 `make check`, on pushes and PRs touching that component. Backend CI also builds
 the container image to prove the Dockerfile; deployment itself is pull-based
-on the home server (`backend/deploy/README.md`). All checks must pass — run
+on the server (`backend/deploy/README.md`). All checks must pass — run
 `make check` locally first.
 
 ## More detail

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -80,8 +80,8 @@ jobs:
           # Only treat upload errors as fatal when a token is actually present.
           fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
 
-  # Deployment is pull-based on the home server (backend/deploy/README.md):
-  # a systemd timer on delectosoft polls origin/main, rebuilds the image
+  # Deployment is pull-based on the server (backend/deploy/README.md):
+  # a systemd timer there polls origin/main, rebuilds the image
   # natively, and restarts the stack. This job only proves the Dockerfile
   # still builds so a broken image can't reach main.
   docker-build:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,10 @@ Pussel is a computer vision puzzle solver: photograph an assembled puzzle, then
 photograph a loose piece to get its position, rotation, and confidence.
 
 - `backend/` — FastAPI service (piece matching, puzzle store, Google auth).
-  Deployed to the home server (see `backend/deploy/README.md`): merging to
-  `main` triggers a pull-based redeploy at https://pussel.sabeltiger.dk.
+  Deployed to the project's own server (see `backend/deploy/README.md`):
+  merging to `main` triggers a pull-based redeploy. Keep production hostnames,
+  server names, and paths out of the repo — they belong in the deploy env file
+  on the server and in the gitignored `ios/Config/Secrets.xcconfig`.
 - `ios/` — native SwiftUI app, the shipped client. See `ios/README.md`.
 - `frontend/` — Next.js 16 + Bun web app. Dev/test client, **not deployed**.
 - `network/` — PyTorch Lightning experiments. Research, not the shipped path.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,8 @@ pussel/
 **Backend** — FastAPI service exposing puzzle upload, frame detection, piece
 matching, piece geometry, and Google-based auth. Piece matching defaults to a
 classical SIFT → NCC hybrid (`MATCHER=classical`); the CNN from `network/` is
-selectable with `MATCHER=cnn`. Deployed to the home server at
-https://pussel.sabeltiger.dk — merging to `main` triggers a pull-based
-redeploy (see `backend/deploy/README.md`).
+selectable with `MATCHER=cnn`. Deployed to the project's own server — merging
+to `main` triggers a pull-based redeploy (see `backend/deploy/README.md`).
 
 **iOS app** — SwiftUI, iOS 26, Google Sign-In, on-device persistence of every
 puzzle and its pieces. This is the real mobile client; see
@@ -77,10 +76,10 @@ frontend, swift-format + SwiftLint for iOS, and Codecov for coverage.
 
 ## Deployment
 
-The backend is the only deployed component. It runs on the home server as a
-Docker Compose stack behind Cloudflare, reachable at
-https://pussel.sabeltiger.dk and https://pussel.thomasen.dk (the URL the iOS
-app ships with).
+The backend is the only deployed component. It runs on the project's own
+server as a Docker Compose stack behind a CDN, under two hostnames: the
+server-native one and the one the iOS app ships with. Hostnames and other
+site-specific values live in an env file on the server, not in this repo.
 
 Merging to `main` is the deploy: a systemd timer on the server polls the
 repository every 5 minutes and, on a new commit, rebuilds the image natively

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,9 +2,8 @@
 
 FastAPI service behind the Pussel puzzle solver: stores an uploaded puzzle,
 matches loose pieces against it, and returns each piece's position, rotation,
-and confidence. Deployed to the home server at https://pussel.sabeltiger.dk —
-merging to `main` triggers a pull-based redeploy (see
-[deploy/README.md](deploy/README.md)).
+and confidence. Deployed to the project's own server — merging to `main`
+triggers a pull-based redeploy (see [deploy/README.md](deploy/README.md)).
 
 ## Setup
 
@@ -79,10 +78,10 @@ make format-backend      # auto-fix formatting
 
 ## Deployment
 
-Runs on the home server as a Docker Compose stack, routed through the
-Appwrite stack's Traefik and fronted by Cloudflare at
-https://pussel.sabeltiger.dk and https://pussel.thomasen.dk (the URL in the
-iOS app's Release config).
+Runs as a Docker Compose stack behind a Traefik instance already on the
+server, fronted by a CDN under two hostnames: the server-native one and the
+one in the iOS app's Release config. Both — and every other site-specific
+value — come from a deploy env file outside the checkout, never from git.
 
 Merging to `main` deploys: `pussel-deploy.timer` on the server polls every
 5 minutes and rebuilds/restarts on a new commit; a failed build leaves the
@@ -104,6 +103,6 @@ backend/
 ├── tests/
 ├── scripts/             # dev helpers (e.g. generate_test_token.py)
 ├── api.http             # sample requests
-├── deploy/              # home-server compose stack + systemd deploy units
+├── deploy/              # compose stack + systemd deploy units
 └── Dockerfile           # container image (build from the repo root)
 ```

--- a/backend/deploy/README.md
+++ b/backend/deploy/README.md
@@ -1,7 +1,11 @@
-# Backend deployment (delectosoft home server)
+# Backend deployment
 
-The backend runs as a Docker Compose stack on the home server, routed through
-the Appwrite stack's existing Traefik at **https://pussel.sabeltiger.dk**.
+The backend runs as a Docker Compose stack on a single server, routed through
+a Traefik instance that is already running there for another stack. Every
+site-specific value — hostnames, Traefik constraint/entrypoint names, paths,
+the server itself — lives in the deploy env file outside the checkout, never
+in this repository. The shell snippets below use `$DEPLOY_HOST` (the server)
+and `$PUSSEL_ROOT` (the directory holding the checkout) as stand-ins.
 
 ## How it deploys
 
@@ -10,70 +14,77 @@ Pull-based, no registry and no secrets in CI:
 1. CI (`backend-ci.yml`) builds the image on every PR to catch Dockerfile
    breakage — it never pushes or deploys.
 2. On the server, `pussel-deploy.timer` runs [pussel-deploy.sh](pussel-deploy.sh)
-   every 5 minutes. When `origin/main` has moved, it hard-resets the checkout
-   at `/home/claus/pussel/repo`, rebuilds the image natively, and
-   `docker compose up -d`'s the stack. A failed build leaves the previous
-   container running.
+   every 5 minutes. When `origin/main` has moved, it hard-resets the checkout,
+   rebuilds the image natively, and `docker compose up -d`'s the stack. A
+   failed build leaves the previous container running.
 
 Merging to `main` is the deploy button; worst-case latency is ~5 min poll +
 the image build.
 
 ## Routing and TLS
 
-Appwrite's Traefik (`appwrite-traefik`, owns ports 80/443) has its Docker
-provider constrained to containers labeled
-`traefik.constraint-label-stack=appwrite` on the external `gateway` network.
-The labels in [docker-compose.yml](docker-compose.yml) register the backend
-under two hostnames: `pussel.sabeltiger.dk` (home-server-native) and
-`pussel.thomasen.dk` (the URL shipped in the iOS app's Release build,
-formerly pointing at Azure). Each is a proxied Cloudflare CNAME →
-`sabeltiger.dk` in its own zone; Cloudflare terminates public TLS (SSL mode
-"Full"), Traefik serves its default certificate to Cloudflare — the same
-recipe as `photos.sabeltiger.dk` in the home-server repo.
+The existing Traefik owns ports 80/443 and has its Docker provider constrained
+to containers that carry its constraint label on the external `gateway`
+network. The labels in [docker-compose.yml](docker-compose.yml) opt the backend
+into exactly that, so it is published without editing the other stack's compose
+file — set `PUSSEL_TRAEFIK_CONSTRAINT` and the two entrypoint names to match
+that instance.
+
+Two hostnames are routed (`PUSSEL_HOST_PRIMARY`, `PUSSEL_HOST_ALT`): the
+server-native one and the one shipped in the iOS app's Release build. Each is
+a proxied CDN CNAME to the server in its own DNS zone; the CDN terminates
+public TLS ("Full" SSL mode) and Traefik serves its default certificate
+behind it.
 
 ## Server layout
 
 ```
-/home/claus/pussel/
+$PUSSEL_ROOT/
 ├── repo/          # clone of claust/pussel (managed by pussel-deploy.sh)
-└── backend.env    # production secrets, NOT in git (see backend.env.example)
+└── backend.env    # production secrets + deploy settings, NOT in git
+                   # (see backend.env.example)
 ```
+
+`pussel-deploy.sh` derives the checkout from its own location and the env file
+from `$PUSSEL_ROOT/backend.env`; `PUSSEL_REPO_DIR` and `PUSSEL_ENV_FILE`
+override both.
 
 ## First-time setup / recovery
 
 ```bash
-ssh claus@delectosoft
-mkdir -p /home/claus/pussel
-git clone https://github.com/claust/pussel.git /home/claus/pussel/repo
-cp /home/claus/pussel/repo/backend/deploy/backend.env.example /home/claus/pussel/backend.env
-vi /home/claus/pussel/backend.env   # JWT_SECRET, GOOGLE_CLIENT_ID, ...
+ssh $DEPLOY_HOST
+mkdir -p $PUSSEL_ROOT
+git clone https://github.com/claust/pussel.git $PUSSEL_ROOT/repo
+cp $PUSSEL_ROOT/repo/backend/deploy/backend.env.example $PUSSEL_ROOT/backend.env
+vi $PUSSEL_ROOT/backend.env   # hostnames, Traefik names, JWT_SECRET, ...
 
-sudo cp /home/claus/pussel/repo/backend/deploy/pussel-deploy.{service,timer} /etc/systemd/system/
+sudo cp $PUSSEL_ROOT/repo/backend/deploy/pussel-deploy.{service,timer} /etc/systemd/system/
+sudoedit /etc/systemd/system/pussel-deploy.service   # real User= and ExecStart=
 sudo systemctl daemon-reload
 sudo systemctl enable --now pussel-deploy.timer
 
-/home/claus/pussel/repo/backend/deploy/pussel-deploy.sh --force   # first build + start
+$PUSSEL_ROOT/repo/backend/deploy/pussel-deploy.sh --force   # first build + start
 ```
 
 ## Operations
 
 ```bash
 # Status / logs
-ssh claus@delectosoft 'docker ps --filter name=pussel-backend'
-ssh claus@delectosoft 'docker logs -n 100 pussel-backend'
-ssh claus@delectosoft 'systemctl list-timers pussel-deploy.timer'
-ssh claus@delectosoft 'journalctl -u pussel-deploy.service -n 50'
+ssh $DEPLOY_HOST 'docker ps --filter name=pussel-backend'
+ssh $DEPLOY_HOST 'docker logs -n 100 pussel-backend'
+ssh $DEPLOY_HOST 'systemctl list-timers pussel-deploy.timer'
+ssh $DEPLOY_HOST 'journalctl -u pussel-deploy.service -n 50'
 
 # Manual redeploy (e.g. after editing backend.env)
-ssh claus@delectosoft '/home/claus/pussel/repo/backend/deploy/pussel-deploy.sh --force'
+ssh $DEPLOY_HOST '$PUSSEL_ROOT/repo/backend/deploy/pussel-deploy.sh --force'
 
-# Health
-curl https://pussel.sabeltiger.dk/health
+# Health (hostname from PUSSEL_HOST_PRIMARY in the deploy env file)
+curl https://$PUSSEL_HOST_PRIMARY/health
 ```
 
 Caveats:
 
 - The puzzle store is in-memory, so every deploy drops stored puzzles; the
   iOS app re-uploads with one tap.
-- If the server is asleep (it has wake-on-lan, see the home-server repo),
-  the backend is unreachable until it wakes.
+- If the server is asleep (wake-on-lan), the backend is unreachable until it
+  wakes.

--- a/backend/deploy/README.md
+++ b/backend/deploy/README.md
@@ -75,8 +75,9 @@ ssh $DEPLOY_HOST 'docker logs -n 100 pussel-backend'
 ssh $DEPLOY_HOST 'systemctl list-timers pussel-deploy.timer'
 ssh $DEPLOY_HOST 'journalctl -u pussel-deploy.service -n 50'
 
-# Manual redeploy (e.g. after editing backend.env)
-ssh $DEPLOY_HOST '$PUSSEL_ROOT/repo/backend/deploy/pussel-deploy.sh --force'
+# Manual redeploy (e.g. after editing backend.env). Double-quoted so the
+# local stand-in expands before the command is sent.
+ssh $DEPLOY_HOST "$PUSSEL_ROOT/repo/backend/deploy/pussel-deploy.sh --force"
 
 # Health (hostname from PUSSEL_HOST_PRIMARY in the deploy env file)
 curl https://$PUSSEL_HOST_PRIMARY/health

--- a/backend/deploy/README.md
+++ b/backend/deploy/README.md
@@ -79,8 +79,8 @@ ssh $DEPLOY_HOST 'journalctl -u pussel-deploy.service -n 50'
 # local stand-in expands before the command is sent.
 ssh $DEPLOY_HOST "$PUSSEL_ROOT/repo/backend/deploy/pussel-deploy.sh --force"
 
-# Health (hostname from PUSSEL_HOST_PRIMARY in the deploy env file)
-curl https://$PUSSEL_HOST_PRIMARY/health
+# Health — substitute the PUSSEL_HOST_PRIMARY value from backend.env
+curl https://<backend-host>/health
 ```
 
 Caveats:

--- a/backend/deploy/backend.env.example
+++ b/backend/deploy/backend.env.example
@@ -13,8 +13,8 @@ ENVIRONMENT=production
 # Public hostnames Traefik routes to this backend: the server-native name and
 # the name shipped in the iOS app's Release build. Use the same value twice if
 # there is only one.
-PUSSEL_HOST_PRIMARY=pussel.example.com
-PUSSEL_HOST_ALT=pussel.example.com
+PUSSEL_HOST_PRIMARY=pussel.example.invalid
+PUSSEL_HOST_ALT=pussel.example.invalid
 
 # The constraint label and entrypoint names of the Traefik instance that owns
 # ports 80/443 on this server (read them off that stack's compose file).

--- a/backend/deploy/backend.env.example
+++ b/backend/deploy/backend.env.example
@@ -1,7 +1,28 @@
-# Production env for the pussel backend on delectosoft.
-# Copy to /home/claus/pussel/backend.env (outside the git checkout) and fill in.
+# Production env for the pussel backend.
+#
+# Copy to backend.env in the directory holding the checkout (i.e. one level
+# above the repo, outside it — the deploy hard-resets and cleans the checkout)
+# and fill in. Override the location with PUSSEL_ENV_FILE.
 
 ENVIRONMENT=production
+
+# --- Deploy-time settings ------------------------------------------------
+# pussel-deploy.sh exports every PUSSEL_* entry so docker-compose.yml can
+# substitute them; they are what keeps the site's real names out of git.
+
+# Public hostnames Traefik routes to this backend: the server-native name and
+# the name shipped in the iOS app's Release build. Use the same value twice if
+# there is only one.
+PUSSEL_HOST_PRIMARY=pussel.example.com
+PUSSEL_HOST_ALT=pussel.example.com
+
+# The constraint label and entrypoint names of the Traefik instance that owns
+# ports 80/443 on this server (read them off that stack's compose file).
+PUSSEL_TRAEFIK_CONSTRAINT=fill-me-in
+PUSSEL_TRAEFIK_ENTRYPOINT_HTTPS=websecure
+PUSSEL_TRAEFIK_ENTRYPOINT_HTTP=web
+
+# --- Application secrets --------------------------------------------------
 
 # openssl rand -base64 32
 JWT_SECRET=fill-me-in

--- a/backend/deploy/docker-compose.yml
+++ b/backend/deploy/docker-compose.yml
@@ -1,19 +1,19 @@
-# Home-server (delectosoft) deployment of the pussel backend.
+# Server deployment of the pussel backend.
 #
-# Runs alongside the existing Appwrite stack and is routed by Appwrite's
-# Traefik: its Docker provider only picks up containers labeled with
-# `traefik.constraint-label-stack=appwrite` (see the constraint in
-# /home/claus/appwrite/appwrite/docker-compose.yml) that share the external
-# `gateway` network, so the labels below publish the backend at
-# https://pussel.sabeltiger.dk without touching Appwrite's own compose file.
+# Runs alongside an existing Traefik-fronted stack rather than owning ports
+# 80/443 itself: that Traefik's Docker provider only picks up containers
+# carrying its constraint label and sharing the external `gateway` network,
+# so the labels below publish the backend without touching the other stack's
+# compose file.
 #
-# TLS: Traefik serves its default certificate for this host; Cloudflare
-# (SSL mode "Full", proxy enabled) accepts that and terminates the real
-# certificate at the edge — same recipe as photos.sabeltiger.dk.
+# TLS: Traefik serves its default certificate for these hosts; the CDN in
+# front of it (proxying, "Full" SSL mode) accepts that and terminates the
+# real certificate at the edge.
 #
-# Secrets live OUTSIDE the git checkout (a `git reset --hard`/`clean` must
-# never touch them): /home/claus/pussel/backend.env, seeded from
-# backend.env.example.
+# Everything site-specific — hostnames, Traefik constraint/entrypoint names,
+# and the path to the secrets file — comes from the deploy env file, which
+# lives OUTSIDE the git checkout (a `git reset --hard`/`clean` must never
+# touch it) and is exported by pussel-deploy.sh. See backend.env.example.
 
 name: pussel
 
@@ -26,27 +26,27 @@ services:
     container_name: pussel-backend
     restart: unless-stopped
     env_file:
-      - /home/claus/pussel/backend.env
+      - ${PUSSEL_ENV_FILE:?set PUSSEL_ENV_FILE to the deploy env file}
     volumes:
       - pussel-uploads:/app/backend/uploads
     networks:
       - gateway
     labels:
       - traefik.enable=true
-      - traefik.constraint-label-stack=appwrite
+      - traefik.constraint-label-stack=${PUSSEL_TRAEFIK_CONSTRAINT:?not set in the deploy env file}
       - traefik.docker.network=gateway
       - traefik.http.services.pussel.loadbalancer.server.port=8000
-      # pussel.thomasen.dk is the URL shipped in the iOS app's
-      # Release.xcconfig (formerly a CNAME to Azure App Service);
-      # pussel.sabeltiger.dk is the home-server-native name.
-      - traefik.http.routers.pussel.rule=Host(`pussel.sabeltiger.dk`) || Host(`pussel.thomasen.dk`)
-      - traefik.http.routers.pussel.entrypoints=appwrite_websecure
+      # Two hostnames: the server-native one and the one shipped in the iOS
+      # app's Release build. Set both in the deploy env file (use the same
+      # value twice when there is only one).
+      - traefik.http.routers.pussel.rule=Host(`${PUSSEL_HOST_PRIMARY:?not set in the deploy env file}`) || Host(`${PUSSEL_HOST_ALT:?not set in the deploy env file}`)
+      - traefik.http.routers.pussel.entrypoints=${PUSSEL_TRAEFIK_ENTRYPOINT_HTTPS:?not set in the deploy env file}
       - traefik.http.routers.pussel.tls=true
       - traefik.http.routers.pussel.service=pussel
-      # Plain-HTTP router for LAN testing; public traffic arrives via
-      # Cloudflare over the TLS entrypoint.
-      - traefik.http.routers.pussel-http.rule=Host(`pussel.sabeltiger.dk`) || Host(`pussel.thomasen.dk`)
-      - traefik.http.routers.pussel-http.entrypoints=appwrite_web
+      # Plain-HTTP router for LAN testing; public traffic arrives via the CDN
+      # over the TLS entrypoint.
+      - traefik.http.routers.pussel-http.rule=Host(`${PUSSEL_HOST_PRIMARY:?not set in the deploy env file}`) || Host(`${PUSSEL_HOST_ALT:?not set in the deploy env file}`)
+      - traefik.http.routers.pussel-http.entrypoints=${PUSSEL_TRAEFIK_ENTRYPOINT_HTTP:?not set in the deploy env file}
       - traefik.http.routers.pussel-http.service=pussel
 
 volumes:

--- a/backend/deploy/pussel-deploy.service
+++ b/backend/deploy/pussel-deploy.service
@@ -1,5 +1,6 @@
-# Installed at /etc/systemd/system/pussel-deploy.service on delectosoft.
-# Triggered by pussel-deploy.timer; see backend/deploy/README.md.
+# Template for /etc/systemd/system/pussel-deploy.service — set User= and the
+# ExecStart path to the deploy user and checkout on your server before
+# installing. Triggered by pussel-deploy.timer; see backend/deploy/README.md.
 [Unit]
 Description=Deploy pussel backend when origin/main moves
 After=docker.service network-online.target
@@ -8,5 +9,5 @@ Requires=docker.service
 
 [Service]
 Type=oneshot
-User=claus
-ExecStart=/home/claus/pussel/repo/backend/deploy/pussel-deploy.sh
+User=DEPLOY_USER
+ExecStart=/path/to/pussel/repo/backend/deploy/pussel-deploy.sh

--- a/backend/deploy/pussel-deploy.sh
+++ b/backend/deploy/pussel-deploy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Pull-based deploy of the pussel backend on delectosoft.
+# Pull-based deploy of the pussel backend on the server.
 #
 # Run periodically by pussel-deploy.timer (see the systemd units next to this
 # script): when origin/main has moved, hard-reset the checkout to it, rebuild
@@ -12,9 +12,20 @@
 
 set -euo pipefail
 
-REPO_DIR=${PUSSEL_REPO_DIR:-/home/claus/pussel/repo}
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_DIR=${PUSSEL_REPO_DIR:-$(cd -- "$script_dir/../.." && pwd)}
 BRANCH=${PUSSEL_BRANCH:-main}
 COMPOSE_FILE="$REPO_DIR/backend/deploy/docker-compose.yml"
+
+# Secrets and site-specific deploy settings live next to the checkout, not in
+# it. Compose substitutes the PUSSEL_* settings (hostnames, Traefik names)
+# from the environment, so export those; the application secrets stay in the
+# file and reach the container through the compose `env_file`.
+PUSSEL_ENV_FILE=${PUSSEL_ENV_FILE:-$(dirname -- "$REPO_DIR")/backend.env}
+export PUSSEL_ENV_FILE
+while IFS='=' read -r key value; do
+    export "$key=$value"
+done < <(grep -E '^PUSSEL_[A-Za-z0-9_]+=' "$PUSSEL_ENV_FILE")
 
 cd "$REPO_DIR"
 git fetch --quiet origin "$BRANCH"
@@ -39,7 +50,7 @@ docker compose -f "$COMPOSE_FILE" up -d backend
 
 # Drop superseded image layers so repeated deploys don't fill the disk.
 # Label-filtered so only this compose project's dangling images are pruned —
-# the server also runs Appwrite, whose layers must be left alone.
+# the server runs other stacks whose layers must be left alone.
 docker image prune -f --filter "label=com.docker.compose.project=pussel" >/dev/null
 
 echo "Deployed $(git rev-parse --short HEAD)"

--- a/backend/deploy/pussel-deploy.sh
+++ b/backend/deploy/pussel-deploy.sh
@@ -44,6 +44,12 @@ if ! settings=$(grep -E '^PUSSEL_[A-Za-z0-9_]+=' "$PUSSEL_ENV_FILE"); then
     exit 1
 fi
 while IFS= read -r setting; do
+    # A PUSSEL_ENV_FILE line inside the env file would point compose at a
+    # different file than the one validated above; it is a process-environment
+    # setting only.
+    if [[ $setting == PUSSEL_ENV_FILE=* ]]; then
+        continue
+    fi
     export "$setting"
 done <<<"$settings"
 

--- a/backend/deploy/pussel-deploy.sh
+++ b/backend/deploy/pussel-deploy.sh
@@ -23,9 +23,18 @@ COMPOSE_FILE="$REPO_DIR/backend/deploy/docker-compose.yml"
 # file and reach the container through the compose `env_file`.
 PUSSEL_ENV_FILE=${PUSSEL_ENV_FILE:-$(dirname -- "$REPO_DIR")/backend.env}
 export PUSSEL_ENV_FILE
-while IFS='=' read -r key value; do
-    export "$key=$value"
-done < <(grep -E '^PUSSEL_[A-Za-z0-9_]+=' "$PUSSEL_ENV_FILE")
+
+if [[ ! -r "$PUSSEL_ENV_FILE" ]]; then
+    echo "Deploy env file not readable: $PUSSEL_ENV_FILE" >&2
+    exit 1
+fi
+if ! settings=$(grep -E '^PUSSEL_[A-Za-z0-9_]+=' "$PUSSEL_ENV_FILE"); then
+    echo "No PUSSEL_* deploy settings in $PUSSEL_ENV_FILE — see backend.env.example" >&2
+    exit 1
+fi
+while IFS= read -r setting; do
+    export "$setting"
+done <<<"$settings"
 
 cd "$REPO_DIR"
 git fetch --quiet origin "$BRANCH"

--- a/backend/deploy/pussel-deploy.sh
+++ b/backend/deploy/pussel-deploy.sh
@@ -12,6 +12,17 @@
 
 set -euo pipefail
 
+# The derived defaults below are absolute; an override must be too. A relative
+# one would resolve against this script's working directory here but against
+# the compose project directory in docker-compose.yml — same value, two
+# different files.
+for var in PUSSEL_REPO_DIR PUSSEL_ENV_FILE; do
+    if [[ -n "${!var:-}" && "${!var}" != /* ]]; then
+        echo "$var must be an absolute path (got: ${!var})" >&2
+        exit 1
+    fi
+done
+
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_DIR=${PUSSEL_REPO_DIR:-$(cd -- "$script_dir/../.." && pwd)}
 BRANCH=${PUSSEL_BRANCH:-main}

--- a/backend/deploy/pussel-deploy.timer
+++ b/backend/deploy/pussel-deploy.timer
@@ -1,4 +1,4 @@
-# Installed at /etc/systemd/system/pussel-deploy.timer on delectosoft.
+# Template for /etc/systemd/system/pussel-deploy.timer.
 [Unit]
 Description=Poll origin/main every 5 minutes and deploy the pussel backend
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,9 +16,9 @@ cp .env.example .env.local     # then fill in the values
 
 `.env.local` needs Google OAuth credentials (`GOOGLE_CLIENT_ID`,
 `GOOGLE_CLIENT_SECRET`), an `AUTH_SECRET` (`openssl rand -base64 32`),
-`AUTH_URL`, and `NEXT_PUBLIC_API_URL` pointing at the backend — `http://localhost:8000`
-locally, or `https://pussel.sabeltiger.dk` for the deployed backend. See
-`.env.example` for the full list.
+`AUTH_URL`, and `NEXT_PUBLIC_API_URL` pointing at the backend —
+`http://localhost:8000` locally, or the deployed backend's URL (see
+`backend/deploy/docker-compose.yml`). See `.env.example` for the full list.
 
 Start the backend first (`make start-backend` from the repo root), then:
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -17,8 +17,10 @@ cp .env.example .env.local     # then fill in the values
 `.env.local` needs Google OAuth credentials (`GOOGLE_CLIENT_ID`,
 `GOOGLE_CLIENT_SECRET`), an `AUTH_SECRET` (`openssl rand -base64 32`),
 `AUTH_URL`, and `NEXT_PUBLIC_API_URL` pointing at the backend —
-`http://localhost:8000` locally, or the deployed backend's URL (see
-`backend/deploy/docker-compose.yml`). See `.env.example` for the full list.
+`http://localhost:8000` locally, or the deployed backend's URL for the deployed
+one (that hostname is not in the repo; it is `PUSSEL_HOST_PRIMARY` in the
+server's deploy env file, see `backend/deploy/README.md`). See `.env.example`
+for the full list.
 
 Start the backend first (`make start-backend` from the repo root), then:
 

--- a/ios/Config/Release.xcconfig
+++ b/ios/Config/Release.xcconfig
@@ -1,4 +1,7 @@
 #include "Secrets.xcconfig"
 
-// Deployed Azure backend.
-API_BASE_URL = https:/$()/pussel.thomasen.dk
+// Deployed backend. The URL is site-specific and deliberately not in git: set
+// RELEASE_API_BASE_URL in Config/Secrets.xcconfig (gitignored). Assigned here
+// rather than taken from Secrets directly so a machine-specific API_BASE_URL
+// there (a LAN IP for Debug device builds) can't leak into Release.
+API_BASE_URL = $(RELEASE_API_BASE_URL)

--- a/ios/Config/Secrets.example.xcconfig
+++ b/ios/Config/Secrets.example.xcconfig
@@ -24,8 +24,14 @@
 //   (the Simulator default). Debug.xcconfig includes this file last, so a value
 //   here overrides its localhost default. The `$()` splits the `//` so xcconfig
 //   doesn't treat it as a comment: http:/$()/192.168.1.23:8000
+//
+// RELEASE_API_BASE_URL (required for Release builds):
+//   URL of the deployed backend. Kept here, out of git, so the production
+//   hostname isn't published — Release.xcconfig reads it from this file.
+//   Same `$()` trick: https:/$()/pussel.example.com
 
 GOOGLE_IOS_CLIENT_ID = YOUR_IOS_CLIENT_ID.apps.googleusercontent.com
 GOOGLE_SERVER_CLIENT_ID = YOUR_WEB_CLIENT_ID.apps.googleusercontent.com
 GOOGLE_URL_SCHEME = com.googleusercontent.apps.YOUR_IOS_CLIENT_ID
 DEVELOPMENT_TEAM = YOUR_TEAM_ID
+RELEASE_API_BASE_URL = https:/$()/pussel.example.com

--- a/ios/Config/Secrets.example.xcconfig
+++ b/ios/Config/Secrets.example.xcconfig
@@ -28,10 +28,10 @@
 // RELEASE_API_BASE_URL (required for Release builds):
 //   URL of the deployed backend. Kept here, out of git, so the production
 //   hostname isn't published — Release.xcconfig reads it from this file.
-//   Same `$()` trick: https:/$()/pussel.example.com
+//   Same `$()` trick: https:/$()/pussel.example.invalid
 
 GOOGLE_IOS_CLIENT_ID = YOUR_IOS_CLIENT_ID.apps.googleusercontent.com
 GOOGLE_SERVER_CLIENT_ID = YOUR_WEB_CLIENT_ID.apps.googleusercontent.com
 GOOGLE_URL_SCHEME = com.googleusercontent.apps.YOUR_IOS_CLIENT_ID
 DEVELOPMENT_TEAM = YOUR_TEAM_ID
-RELEASE_API_BASE_URL = https:/$()/pussel.example.com
+RELEASE_API_BASE_URL = https:/$()/pussel.example.invalid

--- a/ios/README.md
+++ b/ios/README.md
@@ -9,8 +9,8 @@ belongs (position, rotation, confidence) — powered by the FastAPI backend.
 - Xcode 26+ (deployment target iOS 26)
 - [XcodeGen](https://github.com/yonaskolb/XcodeGen): `brew install xcodegen`
 - A running backend: `make start-backend` from the repo root (Debug builds
-  point at `http://localhost:8000`; Release points at
-  `https://pussel.thomasen.dk`)
+  point at `http://localhost:8000`; Release builds use `RELEASE_API_BASE_URL`
+  from the gitignored `Config/Secrets.xcconfig`)
 
 ## Setup
 


### PR DESCRIPTION
The deployment docs and configs spelled out the public hostnames, the server
name, its filesystem paths and the fronting stack's Traefik names — in a public
repository. This moves every site-specific value behind configuration that
lives on the server, and rewords the docs to describe the shape of the
deployment without naming the site.

## Config

- `docker-compose.yml` takes the two routed hostnames, the Traefik constraint
  and entrypoint names, and the secrets-file path from `PUSSEL_*` variables.
  All are required (`${VAR:?…}`), so a missing one fails the deploy while
  compose parses — before `up`, leaving the running container untouched.
- `pussel-deploy.sh` derives the checkout from its own location, defaults the
  env file to the checkout's parent, and exports only the `PUSSEL_*` entries of
  it. Application secrets stay in the file and reach the container through
  compose's `env_file`, rather than being sourced into the deploy shell.
- The systemd units are templates now: placeholder `User=`/`ExecStart=`, with
  the setup steps telling you to edit them before installing.
- iOS Release builds read `RELEASE_API_BASE_URL` from the gitignored
  `Secrets.xcconfig`. It is assigned in `Release.xcconfig` rather than used
  directly so a machine-specific `API_BASE_URL` there (a LAN IP for Debug
  device builds) cannot leak into a Release build.

## Docs

`README.md`, `backend/README.md`, `backend/deploy/README.md`, `CLAUDE.md`,
`ios/README.md`, `frontend/README.md`, the Copilot instructions and a CI
comment no longer name the host, the server or the neighbouring stack. The
deploy README uses `$DEPLOY_HOST`/`$PUSSEL_ROOT` placeholders.

`dk.delectosoft.pussel` stays — it is the bundle id, published in the App Store
record and tied to the Google OAuth client.

## Deploying this

The server's `backend.env` needs the new `PUSSEL_*` entries **before** this
merges, or the first deploy after it fails (safely: the old container keeps
serving).

## Verification

`make check` passes. The env-export loop was tested against a secrets file
containing a value with backticks and `$` to confirm nothing is evaluated and
that only `PUSSEL_*` keys are exported; the compose file parses and every
substitution carries an explicit error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)