### PR TITLE
Fix per-page max in copilot-review.sh latest_copilot_ts

### DIFF
--- a/.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh
+++ b/.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh
@@ -87,9 +87,15 @@ pr_node_id() {
 # returns gh's exit status, so callers can tell "query succeeded, no review yet"
 # (rc 0, empty) apart from "query failed" (rc != 0). stderr is kept for the
 # caller to surface on failure rather than swallowed here.
+#
+# The max is taken in the shell, not in jq: `--paginate` runs `--jq` per page and
+# concatenates the outputs, so a jq-side `max_by` emits one timestamp *per page*
+# — fine on a single-page PR (<30 reviews), silently multi-line beyond that. With
+# `pipefail` set, gh's exit status still propagates through the pipeline.
 latest_copilot_ts() {
   gh api "repos/$OWNER/$REPO/pulls/$PR/reviews" --paginate --jq \
-    "[.[] | select(.user.login==\"$BOT_REVIEW_LOGIN\" or .user.login==\"$BOT_DISPLAY_LOGIN\")] | max_by(.submitted_at) | .submitted_at // empty"
+    ".[] | select(.user.login==\"$BOT_REVIEW_LOGIN\" or .user.login==\"$BOT_DISPLAY_LOGIN\") | .submitted_at" \
+    | sort | tail -n 1
 }
 
 case "$cmd" in

--- a/.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh
+++ b/.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh
@@ -92,9 +92,14 @@ pr_node_id() {
 # concatenates the outputs, so a jq-side `max_by` emits one timestamp *per page*
 # — fine on a single-page PR (<30 reviews), silently multi-line beyond that. With
 # `pipefail` set, gh's exit status still propagates through the pipeline.
+#
+# `// empty` is per-item and must stay that way: a PENDING review carries
+# submitted_at null, jq would print it as a bare `null`, and under LC_ALL=C
+# `null` sorts *above* every digit — so `tail -n 1` would hand `wait` the string
+# "null" as a valid-looking timestamp.
 latest_copilot_ts() {
   gh api "repos/$OWNER/$REPO/pulls/$PR/reviews" --paginate --jq \
-    ".[] | select(.user.login==\"$BOT_REVIEW_LOGIN\" or .user.login==\"$BOT_DISPLAY_LOGIN\") | .submitted_at" \
+    ".[] | select(.user.login==\"$BOT_REVIEW_LOGIN\" or .user.login==\"$BOT_DISPLAY_LOGIN\") | .submitted_at // empty" \
     | sort | tail -n 1
 }
 


### PR DESCRIPTION
## What changed

`latest_copilot_ts()` in `.claude/skills/gh-pr-copilot-review/scripts/copilot-review.sh` now emits every matching Copilot `submitted_at` and takes the max in the shell (`| sort | tail -n 1`), instead of asking jq for `max_by(.submitted_at)`.

## Why

`gh api --paginate` applies the `--jq` filter to **each page response separately** and concatenates the outputs. A jq-side `max_by` therefore emits one timestamp *per page*, not a single overall max. The `wait` subcommand then ran `[[ "$latest" > "$BASELINE" ]]` against a multi-line string, which is unreliable. Below 30 reviews (one page) it worked by accident, so the bug stayed latent.

Reproduced on this repo before the change:

```
$ gh api "repos/claust/pussel/pulls/140/reviews?per_page=10" --paginate --jq \
    '[.[] | select(.user.login=="copilot-pull-request-reviewer[bot]" or .user.login=="Copilot")] | max_by(.submitted_at) | .submitted_at // empty'
2026-07-24T15:49:47Z
2026-07-24T16:05:52Z     # two lines
```

Same bug and same fix as claust/hand-warmer@b978e30, where Copilot review caught it.

`--slurp` is not a usable alternative here — gh rejects it with "the `--slurp` option is not supported with `--jq` or `--template`".

## Verification

- The forced-pagination query above now returns the single true max (`16:05:52Z`); `wait` on #140 and #137 (44 reviews, real default pagination) both report the correct latest.
- Baseline compare is now a clean single-line `>`: baseline == latest -> `WATCHER_TIMEOUT_NO_NEW_REVIEW`; older baseline -> `COPILOT_REVIEW_READY`.
- **Exit-status propagation preserved.** `pipefail` is already set, so a 404 from gh gives the pipeline `rc=1` even though `sort`/`tail` succeed. Note gh dumps its error JSON to *stdout*, so `$latest` holds non-empty garbage while rc is non-zero — `wait` checks rc first, so that never reaches the baseline compare. Retry/abort behaviour is unchanged: three `warn: ... retrying...` lines, then the `die`.
- `shellcheck` clean; no new `# shellcheck disable` needed.

## Reviewer note

The lexicographic `sort` is only equivalent to chronological because GitHub returns `submitted_at` as fixed-width UTC `Z`-suffixed ISO-8601 — which is what the script's existing `export LC_ALL=C` protects. If the API ever returned offsets like `+02:00` this would break, but so would the pre-existing `[[ "$latest" > "$BASELINE" ]]` in `wait`; the fix inherits that assumption rather than adding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
