### PR TITLE
Switch the iOS backend URL from the account menu (Debug builds)

### DIFF
--- a/ios/Pussel/App/PusselApp.swift
+++ b/ios/Pussel/App/PusselApp.swift
@@ -6,18 +6,35 @@ final class AppModel {
   let auth: AuthStore
   let flow: AppFlowStore
   let store: PuzzleStore
+  let backend: BackendSelection
   @ObservationIgnored let api: APIClient
   @ObservationIgnored let authService: AuthService
 
   init() {
     let auth = AuthStore()
-    let api = APIClient(authStore: auth)
+    let backend = BackendSelection()
+    let api = APIClient(baseURL: backend.baseURL, authStore: auth)
     self.auth = auth
     self.flow = AppFlowStore()
     self.store = PuzzleStore()
+    self.backend = backend
     self.api = api
     self.authService = AuthService(authStore: auth, apiClient: api)
     authService.configure()
+  }
+
+  /// Repoints the app at the other backend (Debug builds only — see
+  /// `BackendSelection`). The JWT and every `puzzle_id` in flight were issued
+  /// by the backend being left behind, so the session and the wizard are
+  /// dropped and a fresh token minted from the new one; the persisted Google
+  /// sign-in makes that silent.
+  func useLocalBackend(_ useLocal: Bool) {
+    guard backend.isSwitchable, backend.usesLocalBackend != useLocal else { return }
+    backend.setUsesLocalBackend(useLocal)
+    api.baseURL = backend.baseURL
+    auth.clearSession()
+    flow.reset()
+    Task { await authService.restoreSession() }
   }
 }
 

--- a/ios/Pussel/App/RootView.swift
+++ b/ios/Pussel/App/RootView.swift
@@ -41,6 +41,9 @@ struct AppFlowView: View {
             if let user = model.auth.user {
               Text(user.email)
             }
+            #if DEBUG
+              BackendMenuSection()
+            #endif
             Button("Sign Out", role: .destructive) {
               model.authService.signOut()
               model.flow.reset()
@@ -54,6 +57,31 @@ struct AppFlowView: View {
     }
   }
 }
+
+#if DEBUG
+  /// Debug-only backend switch inside the account menu: a checkmark row that
+  /// flips between the local FastAPI server and the deployed home server, with
+  /// the current URL underneath it. Release builds don't show it — they only
+  /// ever have the one backend (see `BackendSelection`).
+  private struct BackendMenuSection: View {
+    @Environment(AppModel.self) private var model
+
+    var body: some View {
+      Section("Backend") {
+        if model.backend.isSwitchable {
+          Toggle(
+            "Use Local Backend",
+            isOn: Binding(
+              get: { model.backend.usesLocalBackend },
+              set: { model.useLocalBackend($0) }
+            )
+          )
+        }
+        Text(model.backend.baseURL.absoluteString)
+      }
+    }
+  }
+#endif
 
 /// The account menu icon: the user's Google profile picture when available
 /// (fetched via AsyncImage), otherwise the generic person symbol.

--- a/ios/Pussel/Features/Auth/SignInView.swift
+++ b/ios/Pussel/Features/Auth/SignInView.swift
@@ -53,7 +53,10 @@ struct SignInView: View {
 
   private var statusFooter: some View {
     VStack(spacing: 2) {
-      Text(Config.apiBaseURL.absoluteString)
+      // The selected backend, not the build's default — Debug builds can be
+      // pointed elsewhere from the account menu, and this is the screen you
+      // land back on after such a switch drops the session.
+      Text(model.backend.baseURL.absoluteString)
       Text("Backend: \(backendHealthy.map { $0 ? "healthy" : "unreachable" } ?? "checking…")")
     }
     .font(.caption.monospaced())

--- a/ios/Pussel/Networking/APIClient.swift
+++ b/ios/Pussel/Networking/APIClient.swift
@@ -3,7 +3,10 @@ import Foundation
 /// Async client for the Pussel FastAPI backend, mirroring frontend/src/lib/api.ts.
 @MainActor
 final class APIClient {
-  private let baseURL: URL
+  /// The backend every request is addressed to. Mutable so the account menu's
+  /// backend switch can repoint the live client (see `AppModel`) rather than
+  /// rebuild it and everything holding on to it.
+  var baseURL: URL
   private let session: URLSession
   private let authStore: AuthStore
   private let decoder: JSONDecoder

--- a/ios/Pussel/Support/BackendSelection.swift
+++ b/ios/Pussel/Support/BackendSelection.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Observation
+
+/// Which backend the app talks to, and whether that is still up for debate.
+///
+/// Release builds are fixed to the deployed backend baked into the build.
+/// Debug builds carry both URLs — the local FastAPI server (`API_BASE_URL`,
+/// `make start-backend`) and the deployed one (`RELEASE_API_BASE_URL`) — and
+/// the account menu flips between them without a rebuild, so the same install
+/// can check a home-server deploy and then go back to local work. The choice
+/// persists across launches in UserDefaults.
+@Observable
+@MainActor
+final class BackendSelection {
+  private static let defaultsKey = "usesLocalBackend"
+
+  /// True when requests go to the local backend rather than the deployed one.
+  /// Always false in Release builds. Change it through `AppModel`, which also
+  /// repoints the live `APIClient` and drops the now-foreign session.
+  private(set) var usesLocalBackend: Bool
+
+  @ObservationIgnored private let defaults: UserDefaults
+
+  init(defaults: UserDefaults = .standard) {
+    self.defaults = defaults
+    #if DEBUG
+      // Debug builds keep pointing at the local backend by default — the
+      // deployed one is opt-in, and only offered when the build knows it.
+      let stored = defaults.object(forKey: Self.defaultsKey) as? Bool
+      usesLocalBackend = Config.remoteAPIBaseURL == nil || (stored ?? true)
+    #else
+      usesLocalBackend = false
+    #endif
+  }
+
+  /// The backend every request is currently addressed to.
+  var baseURL: URL {
+    #if DEBUG
+      if !usesLocalBackend, let remote = Config.remoteAPIBaseURL {
+        return remote
+      }
+    #endif
+    return Config.apiBaseURL
+  }
+
+  /// False when there is nothing to switch to, so the account menu can leave
+  /// the row out entirely: Release builds, and Debug builds whose
+  /// Secrets.xcconfig defines no `RELEASE_API_BASE_URL`.
+  var isSwitchable: Bool {
+    #if DEBUG
+      return Config.remoteAPIBaseURL != nil
+    #else
+      return false
+    #endif
+  }
+
+  /// Records the choice. Callers go through `AppModel.useLocalBackend(_:)`,
+  /// which pairs this with the session and wizard reset the switch requires.
+  func setUsesLocalBackend(_ useLocal: Bool) {
+    guard isSwitchable else { return }
+    usesLocalBackend = useLocal
+    defaults.set(useLocal, forKey: Self.defaultsKey)
+  }
+}

--- a/ios/Pussel/Support/Config.swift
+++ b/ios/Pussel/Support/Config.swift
@@ -5,7 +5,7 @@ import Foundation
 enum Config {
   static var apiBaseURL: URL {
     let raw = string(for: "APIBaseURL")
-    if let url = URL(string: raw), url.scheme != nil {
+    if let url = backendURL(from: raw) {
       return url
     }
     #if DEBUG
@@ -22,7 +22,23 @@ enum Config {
   /// resolve `apiBaseURL` to this; Debug builds keep it alongside their local
   /// URL so `BackendSelection` can flip between the two at runtime.
   static var remoteAPIBaseURL: URL? {
-    guard let url = URL(string: string(for: "RemoteAPIBaseURL")), url.scheme != nil else {
+    backendURL(from: string(for: "RemoteAPIBaseURL"))
+  }
+
+  /// Parses a configured backend URL, rejecting anything requests can't be
+  /// built against. A scheme alone is too weak a test: `https://` and `http:/`
+  /// both parse with a scheme and no host, and this project's xcconfigs have
+  /// to write URLs as `https:/$()/host` to keep `//` from starting a comment —
+  /// so a value truncated at the `$()` is exactly the shape that slips
+  /// through. Without the host check that yields a Debug build offering a
+  /// backend switch whose requests go nowhere, and a Release build making
+  /// malformed requests where the `fatalError` above is meant to fire.
+  static func backendURL(from raw: String) -> URL? {
+    guard let url = URL(string: raw),
+      let scheme = url.scheme?.lowercased(),
+      scheme == "http" || scheme == "https",
+      let host = url.host(), !host.isEmpty
+    else {
       return nil
     }
     return url

--- a/ios/Pussel/Support/Config.swift
+++ b/ios/Pussel/Support/Config.swift
@@ -17,6 +17,17 @@ enum Config {
     #endif
   }
 
+  /// The deployed backend (`RELEASE_API_BASE_URL` in Config/Secrets.xcconfig),
+  /// or nil when the build has no valid value for it. Release builds already
+  /// resolve `apiBaseURL` to this; Debug builds keep it alongside their local
+  /// URL so `BackendSelection` can flip between the two at runtime.
+  static var remoteAPIBaseURL: URL? {
+    guard let url = URL(string: string(for: "RemoteAPIBaseURL")), url.scheme != nil else {
+      return nil
+    }
+    return url
+  }
+
   static var googleIOSClientID: String { string(for: "GoogleIOSClientID") }
 
   static var googleServerClientID: String { string(for: "GoogleServerClientID") }

--- a/ios/PusselTests/ConfigTests.swift
+++ b/ios/PusselTests/ConfigTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+
+@testable import Pussel
+
+/// Covers `Config.backendURL(from:)`, the gate both `apiBaseURL` and
+/// `remoteAPIBaseURL` run configured values through.
+final class ConfigTests: XCTestCase {
+  func testAcceptsConfiguredBackendURLs() {
+    for raw in [
+      "http://localhost:8000",
+      "http://192.168.86.63:8000",
+      "https://pussel.example.invalid",
+      "https://pussel.example.invalid/",
+      "HTTPS://pussel.example.invalid",
+    ] {
+      XCTAssertEqual(Config.backendURL(from: raw)?.absoluteString, raw, "raw=\(raw)")
+    }
+  }
+
+  /// A scheme-only check would admit the first two: both parse with a scheme
+  /// and no host. They are the realistic failure here because xcconfigs must
+  /// write `https:/$()/host` to stop `//` starting a comment, so a value
+  /// truncated at the `$()` lands exactly on `https://`.
+  func testRejectsSchemeWithoutHost() {
+    XCTAssertNil(Config.backendURL(from: "https://"))
+    XCTAssertNil(Config.backendURL(from: "http:/"))
+  }
+
+  func testRejectsMissingOrUnexpandedValues() {
+    // Empty when the xcconfig omits the key; the literal when a build setting
+    // never got substituted.
+    XCTAssertNil(Config.backendURL(from: ""))
+    XCTAssertNil(Config.backendURL(from: "$(RELEASE_API_BASE_URL)"))
+    XCTAssertNil(Config.backendURL(from: "pussel.example.invalid"))
+  }
+
+  /// Requests are built with `URLRequest`, so a non-http(s) scheme could not
+  /// reach a backend even though it parses.
+  func testRejectsNonHTTPSchemes() {
+    XCTAssertNil(Config.backendURL(from: "ftp://pussel.example.invalid"))
+    XCTAssertNil(Config.backendURL(from: "pusseldebug://camera"))
+  }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -46,6 +46,11 @@ targets:
           NSAllowsLocalNetworking: true
         ITSAppUsesNonExemptEncryption: false
         APIBaseURL: $(API_BASE_URL)
+        # The deployed backend, carried by Debug builds too so the account
+        # menu's backend switch has something to switch to (see
+        # BackendSelection); in Release it is what APIBaseURL already resolves
+        # to. Empty when Secrets.xcconfig omits it — the switch then hides.
+        RemoteAPIBaseURL: $(RELEASE_API_BASE_URL)
         GoogleIOSClientID: $(GOOGLE_IOS_CLIENT_ID)
         GoogleServerClientID: $(GOOGLE_SERVER_CLIENT_ID)
         CFBundleURLTypes:


### PR DESCRIPTION
## Why

Debug builds could only talk to whatever `API_BASE_URL` was baked in at build time. Checking the newly deployed home server meant editing `Secrets.xcconfig` and rebuilding — then rebuilding again to get back to local work. Now Debug builds carry both URLs and flip between them at runtime.

## What changed

Tap the profile icon → **Backend** → **Use Local Backend**, with the currently selected URL shown underneath it. The choice persists across launches (`UserDefaults`), defaulting to local.

- `RELEASE_API_BASE_URL` now reaches Debug builds too, as `RemoteAPIBaseURL` in Info.plist (`ios/project.yml`). No new value is needed in `Secrets.xcconfig` — it reuses the one Release builds already require.
- New `BackendSelection` owns the choice, its persistence, and whether there is anything to switch to.
- `AppModel.useLocalBackend(_:)` performs the switch; `APIClient.baseURL` became mutable so the live client is repointed in place.
- `SignInView`'s footer shows the *selected* backend rather than the build default — that is the screen you land back on after a switch.

## Notes for a reviewer

**Release builds are unaffected.** `APIBaseURL` already resolves to `RELEASE_API_BASE_URL` there, and the whole switch is behind `#if DEBUG` — in `BackendSelection`, in the menu, and in the base-URL resolution. A shipped build cannot be pointed at someone's laptop.

**Session handling is the load-bearing part.** The JWT and every in-flight `puzzle_id` were issued by the backend being left behind, so switching clears the session, resets the wizard, and re-mints a token against the new backend from the persisted Google sign-in — silent in practice, but it does drop an in-progress puzzle. That seemed right for a developer-facing switch; say so if you'd rather it warned first.

**Degrades quietly.** With no `RELEASE_API_BASE_URL` in `Secrets.xcconfig` the toggle hides and only the URL label remains, so a fresh checkout following `Secrets.example.xcconfig` doesn't get a toggle that does nothing.

No deployment hostnames are added to the repo — `project.yml` references the variable, and the generated Info.plist stays gitignored.

## Testing

- `make check-ios` clean (swift-format + SwiftLint strict).
- `make ios-test` — 247 tests pass, 0 failures.
- Deployed to a physical iPhone via `make ios-deploy`; the on-device switch itself is still to be exercised end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)