### PR TITLE
iOS: cancel out of the confirm-trim screen

### DIFF
--- a/ios/Pussel/Features/Capture/ConfirmTrimView.swift
+++ b/ios/Pussel/Features/Capture/ConfirmTrimView.swift
@@ -145,6 +145,22 @@ struct ConfirmTrimView: View {
       }
     }
     .padding(24)
+    .toolbar {
+      // Neither "Retake" nor "Use This" leads back out of the wizard, so the
+      // standard back chevron is the way to abandon this photo and return to
+      // the home screen. Hidden mid-upload: the session is already being
+      // created by then, and leaving would strand it.
+      ToolbarItem(placement: .topBarLeading) {
+        if !model.flow.isBusy {
+          Button {
+            model.flow.reset()
+          } label: {
+            Image(systemName: "chevron.left")
+          }
+          .accessibilityLabel("Back to puzzles")
+        }
+      }
+    }
   }
 
   private var pieceCountSection: some View {


### PR DESCRIPTION
## What

Adds the standard back chevron (`chevron.left`, `topBarLeading`) to the confirm-trim screen — the "Does this look right?" step where you rotate the photo and pick the piece count.

## Why

That screen had only two exits: **Retake** (back to the camera) and **Use This** (on into a solve session). A user who started adding a puzzle by mistake was stuck bouncing between the camera and the confirm screen with no way back to the home screen.

## Notes for the reviewer

- The action is `model.flow.reset()` with the accessibility label "Back to puzzles" — identical to the back button `SolvingView` already has, so the two behave the same.
- The button is hidden while `flow.isBusy`. That flag is only true on this screen during the upload "Use This" starts, and leaving mid-upload would strand a session that is already being created. (Detection-time busy state belongs to the capture screen, not this one.)
- Verified on the Simulator: driving to the confirm screen and tapping the chevron returns to the home screen with the saved-puzzles list intact and no stale candidate. Also built and installed on a device. `make check-ios` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)