### PR TITLE
Stop the account menu's email and backend URL wrapping

### DIFF
--- a/ios/Pussel/App/RootView.swift
+++ b/ios/Pussel/App/RootView.swift
@@ -38,15 +38,22 @@ struct AppFlowView: View {
       .toolbar {
         ToolbarItem(placement: .topBarTrailing) {
           Menu {
-            if let user = model.auth.user {
-              Text(user.email)
-            }
             #if DEBUG
               BackendMenuSection()
             #endif
-            Button("Sign Out", role: .destructive) {
-              model.authService.signOut()
-              model.flow.reset()
+            // The email is the section's header rather than a row of its own:
+            // headers render in a smaller font, so a full address fits on one
+            // line where a body row wraps, and it reads as context for the
+            // button it sits above.
+            Section {
+              Button("Sign Out", role: .destructive) {
+                model.authService.signOut()
+                model.flow.reset()
+              }
+            } header: {
+              if let user = model.auth.user {
+                Text(user.email)
+              }
             }
           } label: {
             ProfileIconView(pictureURL: model.auth.avatarURL)
@@ -77,7 +84,7 @@ struct AppFlowView: View {
             )
           )
         }
-        Text(model.backend.baseURL.absoluteString)
+        Text(model.backend.displayName)
       }
     }
   }

--- a/ios/Pussel/Support/BackendSelection.swift
+++ b/ios/Pussel/Support/BackendSelection.swift
@@ -43,6 +43,20 @@ final class BackendSelection {
     return Config.apiBaseURL
   }
 
+  /// The selected backend as the account menu shows it: host and port without
+  /// the scheme. Menu rows are only about 250pt wide, so a full URL wraps onto
+  /// a second line — and the scheme is the part worth dropping, since by then
+  /// the only question is which server you are pointed at.
+  var displayName: String { Self.displayName(for: baseURL) }
+
+  /// Split out from `displayName` so it can be tested without a build whose
+  /// Info.plist carries a particular backend.
+  nonisolated static func displayName(for url: URL) -> String {
+    guard let host = url.host() else { return url.absoluteString }
+    guard let port = url.port else { return host }
+    return "\(host):\(port)"
+  }
+
   /// False when there is nothing to switch to, so the account menu can leave
   /// the row out entirely: Release builds, and Debug builds whose
   /// Secrets.xcconfig defines no `RELEASE_API_BASE_URL`.

--- a/ios/PusselTests/BackendSelectionTests.swift
+++ b/ios/PusselTests/BackendSelectionTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+
+@testable import Pussel
+
+/// Covers the account menu's backend label. The menu is only about 250pt
+/// wide, so a full URL wraps onto a second line; these lock in the compact
+/// form that fits.
+final class BackendSelectionTests: XCTestCase {
+  func testDropsTheSchemeAndKeepsANonDefaultPort() {
+    XCTAssertEqual(
+      BackendSelection.displayName(for: URL(string: "http://localhost:8000")!),
+      "localhost:8000")
+    XCTAssertEqual(
+      BackendSelection.displayName(for: URL(string: "http://192.168.86.63:8000")!),
+      "192.168.86.63:8000")
+  }
+
+  /// A default port is not in the URL, so nothing is appended — the deployed
+  /// backend reads as a bare hostname.
+  func testOmitsAnImplicitPort() {
+    XCTAssertEqual(
+      BackendSelection.displayName(for: URL(string: "https://pussel.example.invalid")!),
+      "pussel.example.invalid")
+    XCTAssertEqual(
+      BackendSelection.displayName(for: URL(string: "https://pussel.example.invalid/")!),
+      "pussel.example.invalid")
+  }
+
+  /// Config.backendURL(from:) already guarantees a host upstream, so this is
+  /// only a belt-and-braces fallback rather than a case the menu can hit.
+  func testFallsBackToTheWholeURLWithoutAHost() {
+    XCTAssertEqual(
+      BackendSelection.displayName(for: URL(string: "https://")!),
+      "https://")
+  }
+}


### PR DESCRIPTION
Follow-up to #149, which was merged before this last commit landed on its branch.

## Why

Menu rows are only about 250pt wide, so both long strings in the account menu wrapped onto a second line and the menu looked ragged.

```
BEFORE                          AFTER
─────────────────────────       ──────────────────────────
claus.thomasen@gmail.com        Backend
   ← wrapped                    ✓ Use Local Backend
Backend                           192.168.86.63:8000
✓ Use Local Backend             ──────────────────────────
http://192.168.86.63:8000       <account email>
   ← wrapped                    Sign Out
Sign Out
```

## What changed

Each string is shortened at the source of its length rather than truncated with an ellipsis:

- **Backend row** drops the scheme and shows `host[:port]`. By the time you are reading that row the only question is which server you are pointed at, so `https://` was eight characters of the width spent on the least useful part.
- **Email** becomes the section's header instead of a row of its own. Headers render in a smaller font, so a full address fits on one line where a body row wrapped, and it reads as context for the Sign Out button beneath it.

`BackendSelection.displayName(for:)` is split out as a `nonisolated static` so it is testable without a build whose Info.plist carries a particular backend.

## Notes for a reviewer

The email fitting is the part worth a second opinion. The debug user's address is 17 characters and a real one is ~24, and the measured margin at 24 was only about 5% — so rather than infer it, I temporarily swapped a 24-character address into the debug user, confirmed on screen that the menu auto-widens and keeps it on one line, and reverted that change. Anything substantially longer than that would wrap again, though in the smaller header font rather than as a body row.

Both `Text` rows still rely on the menu's own sizing; nothing here sets an explicit width.

## Testing

- Verified visually in the Simulator by opening the real menu — a `UIMenu` renders `Section` headers and sizes rows differently from a sheet, so this could not be confirmed from a preview.
- `make check-ios` clean; `make ios-test` 254 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)