### PR TITLE
Pin the simulator arch in the iOS xcodebuild destination

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -36,7 +36,10 @@ jobs:
       SCHEME: Pussel
       # Concrete simulator so `xcodebuild test` has a bootable destination.
       # iPhone 17 Pro ships with the Xcode 26 iOS 26 runtime (matches ios/README).
-      DESTINATION: 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest'
+      # arch=arm64 disambiguates the arm64/x86_64 pair xcodebuild lists for the
+      # same simulator on Apple Silicon runners ("first of multiple matching
+      # destinations" warning); arm64 is what it picked anyway.
+      DESTINATION: 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest,arch=arm64'
 
     steps:
       - uses: actions/checkout@v7

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,11 @@ IOS_BUNDLE_ID  = dk.delectosoft.pussel
 IOS_PROJECT    = ios/Pussel.xcodeproj
 IOS_SIMULATOR ?= iPhone 17 Pro
 IOS_DERIVED    = ios/.build
+# xcodebuild lists the same simulator once per supported arch, then warns that
+# it is "using the first of multiple matching destinations". Pinning the host
+# arch resolves it to exactly one — the one it picked anyway.
+IOS_SIM_ARCH  ?= $(shell uname -m)
+IOS_DESTINATION = platform=iOS Simulator,name=$(IOS_SIMULATOR),arch=$(IOS_SIM_ARCH)
 
 # Canonical (gitignored, machine-local) copy of the real secrets. It lives
 # outside every worktree so a fresh worktree or a `git clean` never loses it;
@@ -163,14 +168,14 @@ ios-run: ios-generate
 	xcrun simctl boot "$(IOS_SIMULATOR)" 2>/dev/null || true
 	open -a Simulator
 	xcodebuild build -project "$(IOS_PROJECT)" -scheme "$(IOS_SCHEME)" \
-		-destination 'platform=iOS Simulator,name=$(IOS_SIMULATOR)' -derivedDataPath "$(IOS_DERIVED)"
+		-destination '$(IOS_DESTINATION)' -derivedDataPath "$(IOS_DERIVED)"
 	xcrun simctl install booted "$(IOS_DERIVED)/Build/Products/Debug-iphonesimulator/$(IOS_APP_NAME).app"
 	xcrun simctl launch booted "$(IOS_BUNDLE_ID)"
 
 # Run the unit tests on the Simulator.
 ios-test: ios-generate
 	xcodebuild test -project "$(IOS_PROJECT)" -scheme "$(IOS_SCHEME)" \
-		-destination 'platform=iOS Simulator,name=$(IOS_SIMULATOR)' -derivedDataPath "$(IOS_DERIVED)"
+		-destination '$(IOS_DESTINATION)' -derivedDataPath "$(IOS_DERIVED)"
 
 # Build a Debug build, then install + launch on a connected device (iPhone/iPad).
 # Requires DEVELOPMENT_TEAM in ios/Config/Secrets.xcconfig (device signing).

--- a/ios/README.md
+++ b/ios/README.md
@@ -130,7 +130,9 @@ RSD tunnel without root; without it the command demands
 
 `arch=` pins the host architecture; without it xcodebuild matches the same
 simulator once per arch and warns that it is "using the first of multiple
-matching destinations". Use `arch=x86_64` on an Intel Mac.
+matching destinations". The commands below spell out `arch=arm64` for Apple
+Silicon — on an Intel Mac substitute `arch=x86_64`. (`make ios-run` /
+`make ios-test` fill this in from `uname -m`, so they need no editing.)
 
 ```bash
 xcodebuild build -project Pussel.xcodeproj -scheme Pussel \

--- a/ios/README.md
+++ b/ios/README.md
@@ -128,12 +128,16 @@ RSD tunnel without root; without it the command demands
 <details>
 <summary>Equivalent raw <code>xcodebuild</code> / <code>simctl</code> commands</summary>
 
+`arch=` pins the host architecture; without it xcodebuild matches the same
+simulator once per arch and warns that it is "using the first of multiple
+matching destinations". Use `arch=x86_64` on an Intel Mac.
+
 ```bash
 xcodebuild build -project Pussel.xcodeproj -scheme Pussel \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath .build
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,arch=arm64' -derivedDataPath .build
 
 xcodebuild test -project Pussel.xcodeproj -scheme Pussel \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath .build
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,arch=arm64' -derivedDataPath .build
 
 xcrun simctl install booted .build/Build/Products/Debug-iphonesimulator/Pussel.app
 xcrun simctl launch booted dk.delectosoft.pussel


### PR DESCRIPTION
## What

Adds `arch=` to the iOS Simulator destination in CI, the Makefile, and the README's raw-command block.

## Why

`xcodebuild` lists the same simulator once per supported arch — arm64 and the Rosetta x86_64 slice share a UDID — so every iOS build and test run opened with:

```
xcodebuild: WARNING: Using the first of multiple matching destinations:
{ platform:iOS Simulator, arch:arm64, id:391F24B0-…, OS:26.2, name:iPhone 17 Pro }
{ platform:iOS Simulator, arch:x86_64, id:391F24B0-…, OS:26.2, name:iPhone 17 Pro }
```

Pinning the arch resolves it to exactly one entry — the one `xcodebuild` was already picking — so nothing about what gets built or run changes.

## How

- **`.github/workflows/ios-ci.yml`** — `arch=arm64` in `DESTINATION`; the `macos-15` runner is Apple Silicon.
- **`Makefile`** — new `IOS_SIM_ARCH ?= $(shell uname -m)` so an Intel Mac still works, and the destination is hoisted into `IOS_DESTINATION` instead of being repeated in `ios-run` and `ios-test`. Overridable: `make ios-test IOS_SIM_ARCH=x86_64`.
- **`ios/README.md`** — raw commands match, with a note explaining `arch=` and pointing Intel users at `x86_64`.

`id=<UDID>` would also disambiguate, but the UDID differs per machine and per runner image, so `arch` is the portable knob.

## Verification

`make ios-test` locally: exit 0, 254 tests pass (1 skipped), and the full log has zero occurrences of "multiple matching destinations". CI is unverified until this PR's run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)