### PR TITLE
Clear the iOS CI Build step's Swift warnings

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -59,6 +59,13 @@ jobs:
 
       # xcbeautify is used to prettify xcodebuild output in the Build/Test steps;
       # install it explicitly rather than relying on it being preinstalled.
+      #
+      # This step logs "The following taps are not trusted: aws/tap" — aws/tap
+      # is tapped by the runner image, not by us, and none of the formulae below
+      # come from it. The only ways to silence it are untapping someone else's
+      # tap or setting HOMEBREW_NO_REQUIRE_TAP_TRUST=1, which turns the trust
+      # check off for every tap; neither is worth it for a cosmetic line, so the
+      # warning stays.
       - name: Install tooling (XcodeGen + SwiftLint + xcbeautify)
         run: |
           brew install xcodegen swiftlint xcbeautify

--- a/ios/Pussel/Features/Capture/BarcodeDetector.swift
+++ b/ios/Pussel/Features/Capture/BarcodeDetector.swift
@@ -14,12 +14,20 @@ struct EAN13Detection: Equatable {
 
 /// On-device EAN-13 reader for the live box-capture preview. A thin wrapper
 /// around `VNDetectBarcodesRequest` restricted to `.ean13`, pinned to
-/// request revision 1: later revisions decode via an ML model whose
+/// request revision 1: every later revision decodes via an ML model whose
 /// inference context the Simulator cannot create ("Error code: 9" per
-/// frame, observed live), while revision 1 is classic CV and runs
-/// everywhere — and is entirely adequate for a close-range 1D EAN-13 on a
-/// 1080px frame. Unlike `PieceLiveDetector`'s subject lifting, no
-/// availability/fallback split is needed.
+/// frame, observed live, and re-confirmed on the iOS 26 Simulator for
+/// revisions 2, 3 and 4 as well as the modern `DetectBarcodesRequest`,
+/// whose only revision is 4). Revision 1 is classic CV, runs everywhere,
+/// and is entirely adequate for a close-range 1D EAN-13 on a 1080px frame:
+/// across 240 synthetic renders (four payloads × six rotations × five
+/// sizes × with/without speckle) decoded on macOS, where every revision
+/// runs, revisions 1 and 3 returned the same payload in every case that
+/// either read one — revision 3 never disagreed, it only missed three
+/// small tilted codes revision 1 read. So the pin costs no accuracy and
+/// the checksum filter in `detect` sees the same payloads either way.
+/// Unlike `PieceLiveDetector`'s subject lifting, no availability/fallback
+/// split is needed.
 ///
 /// Stateless and thread-safe: each `detect` call builds its own request.
 /// Called from `BarcodeScanStreamer`'s background task, never the main
@@ -33,6 +41,13 @@ final class BarcodeDetector: Sendable {
   /// so gating on width alone would reject every rotated read.
   static let minBoundingBoxLongSide: CGFloat = 0.15
 
+  /// `VNDetectBarcodesRequestRevision1`, written as the literal value the
+  /// SDK header gives it: the constant carries a blanket "deprecated in iOS
+  /// 17.0: renamed to `VNDetectBarcodesRequestRevision3`" annotation, so
+  /// naming it warns on every build even though the rename does not hold
+  /// here — see the type's doc comment for why revision 1 stays.
+  private static let classicRevision = 1
+
   /// Reads an EAN-13 from an upright frame, or nil when none is legible.
   ///
   /// Only payloads that pass the local checksum (`EAN13.isValidChecksum`)
@@ -40,7 +55,7 @@ final class BarcodeDetector: Sendable {
   /// Vision request throws and the caller drops the frame.
   func detect(cgImage: CGImage) throws -> EAN13Detection? {
     let request = VNDetectBarcodesRequest()
-    request.revision = VNDetectBarcodesRequestRevision1
+    request.revision = Self.classicRevision
     request.symbologies = [.ean13]
     let handler = VNImageRequestHandler(cgImage: cgImage, orientation: .up)
     try handler.perform([request])

--- a/ios/Pussel/Features/Capture/GlareFree/GlareFreeComposer.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/GlareFreeComposer.swift
@@ -288,7 +288,7 @@ enum GlareFreeComposer {
     reference: RegistrationProxies, proxyExtent: CGRect
   ) -> matrix_float3x3? {
     var total = seed
-    for pass in 1...maxRegistrationPasses {
+    for _ in 1...maxRegistrationPasses {
       guard
         let current = rendered(floatingProxies.fine, warpedBy: total, extent: proxyExtent),
         let step = homographyOnce(mapping: current, ontoReference: reference.fine)


### PR DESCRIPTION
The iOS CI **Build** step emitted three warnings on `main` (run 30161182312). Two were ours; the third is the runner's.

## 1. `BarcodeDetector.swift:43` — deprecated `VNDetectBarcodesRequestRevision1`

The SDK annotation says the constant was "renamed to `VNDetectBarcodesRequestRevision3`". That rename does not hold for this app, and I checked rather than assumed — a throwaway test probed every option on the iOS 26 Simulator:

| revision | Simulator result |
| --- | --- |
| 1 | runs (classic CV) |
| 2 / 3 / 4 | `Error Domain=com.apple.Vision Code=9 "Could not create inference context"` |
| unpinned default | same error 9 |
| modern `DetectBarcodesRequest` (only revision: 4) | `operationFailed("Failed to create barcode detector.")` |

So the pin is **functional, not a stability freeze**: revision 1 is the only revision that runs everywhere the app runs, and dropping the line to take Vision's default would break barcode scanning in the Simulator — including the barcode tests in `PusselTests`, which decode through the real Vision request.

On the payload question the caller cares about (`EAN13.isValidChecksum`): decoding 240 synthetic EAN-13 renders (4 payloads × 6 rotations × 5 sizes × with/without speckle) on macOS, where every revision runs, revisions 1 and 3 agreed on the payload in **every case where either read one**. Revision 3 never returned a different string; it only missed three small tilted codes revision 1 read (and it dedupes the repeated observations revision 1 returns for one code, which the caller ignores — it takes the first checksum-valid hit). The pin costs no accuracy.

The real box photos in `~/Pictures/puzzles/box_photos` turned out to be box fronts with no barcode in frame — neither revision reads anything from them — hence the synthetic sweep, which is also what the existing tests decode.

Fix: keep revision 1, written as the literal value the SDK header gives it (`static const NSUInteger ... = 1`) via a named `classicRevision` constant, with the reasoning in the doc comments. That clears the warning without giving up the symbol's meaning.

## 2. `GlareFreeComposer.swift:291` — unused `pass` binding

I read the loop body first, per the "maybe a log line was meant to report it" possibility: the file contains no logging at all, and convergence is decided by the per-step displacement and the `alignmentError` gate, neither of which depends on the pass index. There is no report the binding was meant to feed, so it becomes `_`.

## 3. `The following taps are not trusted: aws/tap` — left as is

`aws/tap` is tapped by the runner image; none of `xcodegen`, `swiftlint`, `xcbeautify` come from it. The only ways to silence it are untapping someone else's tap or `HOMEBREW_NO_REQUIRE_TAP_TRUST=1`, which disables the trust check for every tap — Homebrew discourages it and it is not worth a cosmetic log line. The workflow now carries a comment saying so.

## Verification

- `make ios-test` → **254 passing, 1 skipped, 0 failures** (unchanged baseline).
- Clean `build-for-testing` → no Swift warnings (only the unrelated `appintentsmetadataprocessor` tool notices, which are present on `main` too).
- `make check-ios` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)