### PR TITLE
Keep the back chevron mounted across the wizard's phase switch

### DIFF
--- a/ios/Pussel/App/AppActions.swift
+++ b/ios/Pussel/App/AppActions.swift
@@ -207,12 +207,22 @@ extension AppModel {
   /// Reopens a stored puzzle from disk and resumes solving it. Pieces that
   /// were never predicted are re-queued; if the server forgot this puzzle_id
   /// (in-memory store restarted) the solve view's expired banner recovers it.
-  func openPuzzle(_ id: UUID) {
-    guard let session = store.loadSession(id: id) else {
+  func openPuzzle(_ id: UUID) async {
+    // One open at a time. The read no longer blocks the main thread, so the
+    // list stays live while it runs and a second tap — on this row or another
+    // — would otherwise race a second session onto the same phase.
+    guard flow.openingPuzzle == nil else { return }
+    flow.errorMessage = nil
+    flow.openingPuzzle = id
+    let session = await store.loadSession(id: id)
+    // Whatever cleared the token while the files were being read (a reset, a
+    // delete) means this open is no longer the one the user is waiting for.
+    guard flow.openingPuzzle == id else { return }
+    flow.openingPuzzle = nil
+    guard let session else {
       flow.errorMessage = "Could not open that puzzle."
       return
     }
-    flow.errorMessage = nil
     flow.phase = .solving(session)
     session.resume(api: api)
   }
@@ -222,6 +232,11 @@ extension AppModel {
   func deletePuzzle(_ id: UUID) {
     if case .solving(let session) = flow.phase, session.id == id {
       flow.reset()
+    }
+    // A swipe-delete can land on a row whose open is still in flight; drop
+    // the token so that read doesn't arrive on top of the deletion.
+    if flow.openingPuzzle == id {
+      flow.openingPuzzle = nil
     }
     store.deleteWithUndo(id)
   }

--- a/ios/Pussel/App/AppFlow.swift
+++ b/ios/Pussel/App/AppFlow.swift
@@ -86,6 +86,14 @@ final class AppFlowStore {
   /// picker on appear; cleared once consumed.
   var pendingRetake: CaptureSource?
 
+  /// The stored puzzle whose files are being read for a solve session, if any
+  /// (see `AppModel.openPuzzle`). Doubles as the home-screen row's spinner and
+  /// as the token that tells a finished read whether it is still wanted:
+  /// anything that resets the wizard — going back, signing out — clears it,
+  /// so a read that lands afterwards drops its session instead of pushing the
+  /// user into a screen they already left.
+  var openingPuzzle: UUID?
+
   #if DEBUG
     /// Forces CapturePuzzleView's capture cover open even when
     /// `BoxCameraSession.isCameraAvailable` is false (the Simulator), so
@@ -100,6 +108,7 @@ final class AppFlowStore {
     isBusy = false
     errorMessage = nil
     pendingRetake = nil
+    openingPuzzle = nil
   }
 
   /// Whether the navigation bar's leading chevron leads anywhere from here.

--- a/ios/Pussel/App/AppFlow.swift
+++ b/ios/Pussel/App/AppFlow.swift
@@ -101,6 +101,30 @@ final class AppFlowStore {
     errorMessage = nil
     pendingRetake = nil
   }
+
+  /// Whether the navigation bar's leading chevron leads anywhere from here.
+  ///
+  /// The home screen is the wizard's root, so it has nothing to go back to.
+  /// Confirm-trim hides the chevron mid-upload: the solve session is already
+  /// being created by then, and leaving would strand it.
+  var canGoBack: Bool {
+    switch phase {
+    case .capturePuzzle:
+      return false
+    case .confirmTrim:
+      return !isBusy
+    case .solving:
+      return true
+    }
+  }
+
+  /// The leading chevron's action, from any phase that has one. Work is saved
+  /// locally, so leaving a solve session keeps it on the home screen — this is
+  /// a plain "back", not a discard.
+  func goBack() {
+    guard canGoBack else { return }
+    reset()
+  }
 }
 
 /// State for one solving session. The trimmed image is kept so the puzzle can
@@ -157,11 +181,21 @@ final class SolveSession {
   /// `trimmedJPEG` decoding is otherwise load-bearing enough that the session
   /// has bigger problems by then.
   @ObservationIgnored lazy var puzzleAspect: CGFloat = {
-    guard let size = UIImage(data: trimmedJPEG)?.size, size.width > 0, size.height > 0 else {
+    guard let size = overviewImage?.size, size.width > 0, size.height > 0 else {
       return 1
     }
     return size.width / size.height
   }()
+
+  /// `trimmedJPEG` decoded once, for the inline overlay to draw (and for
+  /// `puzzleAspect` to measure).
+  ///
+  /// Kept rather than decoded per read for the same reason as `puzzleAspect`,
+  /// and then some: `PuzzleOverlayView` decodes it from its `body`, which runs
+  /// again on every prediction that lands and every layout pass. The first of
+  /// those decodes happens while the solve screen is being put on screen, so
+  /// it is also main-thread time the navigation bar spends not yet updated.
+  @ObservationIgnored lazy var overviewImage: UIImage? = UIImage(data: trimmedJPEG)
 
   @ObservationIgnored private let store: PuzzleStore?
 

--- a/ios/Pussel/App/RootView.swift
+++ b/ios/Pussel/App/RootView.swift
@@ -35,7 +35,13 @@ struct AppFlowView: View {
       }
       .navigationTitle("Pussel")
       .navigationBarTitleDisplayMode(.inline)
+      // Every bar item the wizard has is declared here, in one toolbar that
+      // outlives the phase switch above — see `backButton` for why the phases
+      // must not bring their own.
       .toolbar {
+        ToolbarItem(placement: .topBarLeading) {
+          backButton
+        }
         ToolbarItem(placement: .topBarTrailing) {
           Menu {
             #if DEBUG
@@ -62,6 +68,40 @@ struct AppFlowView: View {
         }
       }
     }
+  }
+
+  /// The wizard's back chevron.
+  ///
+  /// Deliberately one button that is always in the bar, dimmed and disabled on
+  /// the phases it doesn't apply to, rather than a `.toolbar` inside each
+  /// phase's own view. A phase-owned toolbar item is inserted into the
+  /// navigation bar only once SwiftUI has committed the new phase's content,
+  /// and the bar crossfades it in from the previous phase's (empty) leading
+  /// slot. Taps that land in that window hit the bar itself and are dropped —
+  /// which is exactly what a tap right after opening a puzzle does, because
+  /// reading and decoding that puzzle's images blocks the main thread first
+  /// and pushes the item's arrival out past the tap. Reopening the same puzzle
+  /// hits warm file and image caches, so the window is short enough to miss.
+  ///
+  /// Keeping the item mounted for the whole flow means only its content
+  /// changes across a phase switch: the button is already installed and
+  /// hit-testable the instant `canGoBack` turns true, so there is no window
+  /// left to tap into.
+  @ViewBuilder
+  private var backButton: some View {
+    let canGoBack = model.flow.canGoBack
+    Button {
+      model.flow.goBack()
+    } label: {
+      Image(systemName: "chevron.left")
+    }
+    .accessibilityLabel("Back to puzzles")
+    // Hidden rather than omitted, so the item itself stays put. Disabled and
+    // hidden from VoiceOver with it, so an invisible chevron is never a live
+    // control on the home screen.
+    .opacity(canGoBack ? 1 : 0)
+    .disabled(!canGoBack)
+    .accessibilityHidden(!canGoBack)
   }
 }
 

--- a/ios/Pussel/Features/Capture/ConfirmTrimView.swift
+++ b/ios/Pussel/Features/Capture/ConfirmTrimView.swift
@@ -145,22 +145,10 @@ struct ConfirmTrimView: View {
       }
     }
     .padding(24)
-    .toolbar {
-      // Neither "Retake" nor "Use This" leads back out of the wizard, so the
-      // standard back chevron is the way to abandon this photo and return to
-      // the home screen. Hidden mid-upload: the session is already being
-      // created by then, and leaving would strand it.
-      ToolbarItem(placement: .topBarLeading) {
-        if !model.flow.isBusy {
-          Button {
-            model.flow.reset()
-          } label: {
-            Image(systemName: "chevron.left")
-          }
-          .accessibilityLabel("Back to puzzles")
-        }
-      }
-    }
+    // Neither "Retake" nor "Use This" leads back out of the wizard, so the
+    // back chevron is the way to abandon this photo and return to the home
+    // screen. It lives in `AppFlowView`'s toolbar, which owns it for every
+    // phase (including the mid-upload hiding — see `AppFlowStore.canGoBack`).
   }
 
   private var pieceCountSection: some View {

--- a/ios/Pussel/Features/Library/SavedPuzzlesSection.swift
+++ b/ios/Pussel/Features/Library/SavedPuzzlesSection.swift
@@ -44,9 +44,11 @@ struct SavedPuzzlesSection: View {
               }
             }
           ),
-          onOpen: { model.openPuzzle(puzzle.id) },
+          onOpen: { Task { await model.openPuzzle(puzzle.id) } },
           onDelete: { delete(puzzle) },
-          content: { SavedPuzzleRow(puzzle: puzzle) }
+          content: {
+            SavedPuzzleRow(puzzle: puzzle, isOpening: model.flow.openingPuzzle == puzzle.id)
+          }
         )
         .contextMenu {
           Button(role: .destructive) {
@@ -299,6 +301,11 @@ private struct HorizontalPanGesture: UIGestureRecognizerRepresentable {
 
 private struct SavedPuzzleRow: View {
   let puzzle: PuzzleSummary
+  /// True while this puzzle's files are being read (see
+  /// `AppModel.openPuzzle`). That read is off the main actor now, so the tap
+  /// leaves the list responsive — and with nothing else moving, the row has
+  /// to say for itself that it was heard.
+  var isOpening = false
 
   var body: some View {
     HStack(spacing: 12) {
@@ -313,9 +320,16 @@ private struct SavedPuzzleRow: View {
           .foregroundStyle(.secondary)
       }
       Spacer(minLength: 0)
-      Image(systemName: "chevron.right")
-        .font(.footnote.weight(.semibold))
-        .foregroundStyle(.tertiary)
+      // In the chevron's place rather than beside it, so the row's layout
+      // doesn't shift under the finger that just tapped it.
+      if isOpening {
+        ProgressView()
+          .controlSize(.small)
+      } else {
+        Image(systemName: "chevron.right")
+          .font(.footnote.weight(.semibold))
+          .foregroundStyle(.tertiary)
+      }
     }
     .padding(10)
     .background(

--- a/ios/Pussel/Features/Solve/PuzzleOverlayView.swift
+++ b/ios/Pussel/Features/Solve/PuzzleOverlayView.swift
@@ -14,7 +14,10 @@ struct PuzzleOverlayView: View {
   var onTap: () -> Void = {}
 
   var body: some View {
-    if let image = UIImage(data: session.trimmedJPEG) {
+    // The session's kept decode, not a fresh `UIImage(data:)`: this body runs
+    // again on every prediction that lands, and the first run of it is on the
+    // main thread while the solve screen is appearing (see `overviewImage`).
+    if let image = session.overviewImage {
       Image(uiImage: image)
         .resizable()
         .scaledToFit()

--- a/ios/Pussel/Features/Solve/SolvingView.swift
+++ b/ios/Pussel/Features/Solve/SolvingView.swift
@@ -27,20 +27,11 @@ struct SolvingView: View {
       }
       .padding()
     }
+    // No `.toolbar` here: the back chevron belongs to `AppFlowView`, which
+    // keeps it mounted across the phase switch so a tap right after this
+    // screen appears can't land before the item does (see its `backButton`).
     .fullScreenCover(item: $zoomFocus) { focus in
       PuzzleZoomView(session: session, focus: focus)
-    }
-    .toolbar {
-      // Work is saved locally, so leaving the session keeps it around on
-      // the home screen — this is a plain "back", not a discard.
-      ToolbarItem(placement: .topBarLeading) {
-        Button {
-          model.flow.reset()
-        } label: {
-          Image(systemName: "chevron.left")
-        }
-        .accessibilityLabel("Back to puzzles")
-      }
     }
   }
 

--- a/ios/Pussel/Persistence/PuzzleStore.swift
+++ b/ios/Pussel/Persistence/PuzzleStore.swift
@@ -127,16 +127,14 @@ final class PuzzleStore {
     try? FileManager.default.createDirectory(at: pieces, withIntermediateDirectories: true)
 
     let trimmed = trimmedURL(session.id)
-    if !FileManager.default.fileExists(atPath: trimmed.path) {
+    if !exists(trimmed) {
       try? session.trimmedJPEG.write(to: trimmed, options: .atomic)
     }
     // The zoom copy is optional and immutable, so it's written once and its
     // absence is a valid state (puzzles from before it was kept, and captures
     // whose re-warp failed) — loadSession falls back to the trimmed image.
     let display = puzzleDisplayURL(session.id)
-    if let displayJPEG = session.displayJPEG,
-      !FileManager.default.fileExists(atPath: display.path)
-    {
+    if let displayJPEG = session.displayJPEG, !exists(display) {
       try? displayJPEG.write(to: display, options: .atomic)
     }
     // The trimmed image is immutable, so its downsampled thumbnail is
@@ -152,12 +150,12 @@ final class PuzzleStore {
     var persistedEntries: [CaptureEntry] = []
     for entry in session.entries {
       let upload = uploadURL(session.id, entry.id)
-      if !FileManager.default.fileExists(atPath: upload.path) {
+      if !exists(upload) {
         try? entry.uploadJPEG.write(to: upload, options: .atomic)
       }
       // Skip entries whose upload image didn't make it to disk; they'll be
       // retried on the next persist() rather than left dangling.
-      guard FileManager.default.fileExists(atPath: upload.path) else { continue }
+      guard exists(upload) else { continue }
       keep.insert(entry.id.uuidString)
 
       let display = displayURL(session.id, entry.id)
@@ -165,9 +163,7 @@ final class PuzzleStore {
       // differs from the raw capture, otherwise the bytes are duplicated.
       // The cleaned image is immutable once predicted, so skip the rewrite
       // if it already exists (avoids rewriting every piece on each persist).
-      if entry.displayImage != entry.uploadJPEG,
-        !FileManager.default.fileExists(atPath: display.path)
-      {
+      if entry.displayImage != entry.uploadJPEG, !exists(display) {
         try? entry.displayImage.write(to: display, options: .atomic)
       }
       persistedEntries.append(entry)
@@ -427,6 +423,12 @@ final class PuzzleStore {
   private nonisolated var rootURL: URL {
     let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
     return docs.appendingPathComponent("Puzzles", isDirectory: true)
+  }
+
+  /// Whether a stored file is already there. `save` asks this of every image
+  /// it might write, so it earns a name of its own.
+  private nonisolated func exists(_ url: URL) -> Bool {
+    FileManager.default.fileExists(atPath: url.path)
   }
 
   private nonisolated func puzzleDir(_ id: UUID) -> URL {

--- a/ios/Pussel/Persistence/PuzzleStore.swift
+++ b/ios/Pussel/Persistence/PuzzleStore.swift
@@ -23,7 +23,7 @@ struct PuzzleSummary: Identifiable, Equatable {
 /// On-disk manifest for one puzzle. Image bytes live in sibling files, so the
 /// JSON stays small; the piece's `cleanedImage` base64 is never persisted here
 /// (the display image is stored as a `<id>-display.jpg` file instead).
-private struct PuzzleManifest: Codable {
+private struct PuzzleManifest: Codable, Sendable {
   let id: UUID
   var serverPuzzleId: String
   var name: String
@@ -36,7 +36,7 @@ private struct PuzzleManifest: Codable {
   var cols: Int
 }
 
-private struct StoredPiece: Codable {
+private struct StoredPiece: Codable, Sendable {
   let id: UUID
   /// nil while the piece is captured but not yet predicted.
   var result: StoredResult?
@@ -46,7 +46,7 @@ private struct StoredPiece: Codable {
   var scanPieceId: String?
 }
 
-private struct StoredResult: Codable {
+private struct StoredResult: Codable, Sendable {
   let position: NormalizedPoint
   let positionConfidence: Double
   let rotation: Int
@@ -57,6 +57,18 @@ private struct StoredResult: Codable {
   let gridRow: Int?
   let gridCol: Int?
   let snappedPosition: NormalizedPoint?
+}
+
+/// Everything `PuzzleStore.loadSession` needs from one puzzle's folder, read
+/// and decoded away from the main actor by `readSnapshot`. `CaptureEntry` and
+/// the manifest are plain value types, so the whole thing crosses back as data.
+private struct SessionSnapshot: Sendable {
+  let manifest: PuzzleManifest
+  let trimmed: Data
+  /// The zoom-quality overview, absent for puzzles stored without one.
+  let display: Data?
+  /// Pieces in manifest order, minus any whose upload image has gone.
+  let entries: [CaptureEntry]
 }
 
 /// Local, on-device persistence for solved/in-progress puzzles. Everything is
@@ -81,7 +93,6 @@ final class PuzzleStore {
   static let undoWindow: Duration = .seconds(5)
 
   @ObservationIgnored private var purgeTask: Task<Void, Never>?
-  @ObservationIgnored private let fileManager = FileManager.default
   @ObservationIgnored private let encoder: JSONEncoder
   @ObservationIgnored private let decoder: JSONDecoder
 
@@ -89,12 +100,19 @@ final class PuzzleStore {
     let encoder = JSONEncoder()
     encoder.dateEncodingStrategy = .iso8601
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    self.encoder = encoder
+    self.decoder = Self.makeDecoder()
+    try? FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    refresh()
+  }
+
+  /// The manifest decoder's configuration in one place: `readSnapshot` runs
+  /// off the main actor, so it can't reach the store's own `decoder` and
+  /// builds its own from here instead.
+  private nonisolated static func makeDecoder() -> JSONDecoder {
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .iso8601
-    self.encoder = encoder
-    self.decoder = decoder
-    try? fileManager.createDirectory(at: rootURL, withIntermediateDirectories: true)
-    refresh()
+    return decoder
   }
 
   // MARK: Public API
@@ -106,17 +124,19 @@ final class PuzzleStore {
     let pieces = piecesDir(session.id)
     // Creating the pieces dir with intermediates also creates its parent
     // puzzle dir, so no separate puzzle-dir creation is needed.
-    try? fileManager.createDirectory(at: pieces, withIntermediateDirectories: true)
+    try? FileManager.default.createDirectory(at: pieces, withIntermediateDirectories: true)
 
     let trimmed = trimmedURL(session.id)
-    if !fileManager.fileExists(atPath: trimmed.path) {
+    if !FileManager.default.fileExists(atPath: trimmed.path) {
       try? session.trimmedJPEG.write(to: trimmed, options: .atomic)
     }
     // The zoom copy is optional and immutable, so it's written once and its
     // absence is a valid state (puzzles from before it was kept, and captures
     // whose re-warp failed) — loadSession falls back to the trimmed image.
     let display = puzzleDisplayURL(session.id)
-    if let displayJPEG = session.displayJPEG, !fileManager.fileExists(atPath: display.path) {
+    if let displayJPEG = session.displayJPEG,
+      !FileManager.default.fileExists(atPath: display.path)
+    {
       try? displayJPEG.write(to: display, options: .atomic)
     }
     // The trimmed image is immutable, so its downsampled thumbnail is
@@ -132,12 +152,12 @@ final class PuzzleStore {
     var persistedEntries: [CaptureEntry] = []
     for entry in session.entries {
       let upload = uploadURL(session.id, entry.id)
-      if !fileManager.fileExists(atPath: upload.path) {
+      if !FileManager.default.fileExists(atPath: upload.path) {
         try? entry.uploadJPEG.write(to: upload, options: .atomic)
       }
       // Skip entries whose upload image didn't make it to disk; they'll be
       // retried on the next persist() rather than left dangling.
-      guard fileManager.fileExists(atPath: upload.path) else { continue }
+      guard FileManager.default.fileExists(atPath: upload.path) else { continue }
       keep.insert(entry.id.uuidString)
 
       let display = displayURL(session.id, entry.id)
@@ -145,7 +165,9 @@ final class PuzzleStore {
       // differs from the raw capture, otherwise the bytes are duplicated.
       // The cleaned image is immutable once predicted, so skip the rewrite
       // if it already exists (avoids rewriting every piece on each persist).
-      if entry.displayImage != entry.uploadJPEG, !fileManager.fileExists(atPath: display.path) {
+      if entry.displayImage != entry.uploadJPEG,
+        !FileManager.default.fileExists(atPath: display.path)
+      {
         try? entry.displayImage.write(to: display, options: .atomic)
       }
       persistedEntries.append(entry)
@@ -237,29 +259,47 @@ final class PuzzleStore {
   /// missing/corrupt. Pieces with a stored result come back `.done`; pieces
   /// captured but never predicted come back `.queued` so the solve view can
   /// resume them.
-  func loadSession(id: UUID) -> SolveSession? {
-    guard let data = try? Data(contentsOf: manifestURL(id)),
-      let manifest = try? decoder.decode(PuzzleManifest.self, from: data),
-      let trimmed = try? Data(contentsOf: trimmedURL(id))
-    else {
-      return nil
-    }
+  ///
+  /// Async because everything up to building the session runs off the main
+  /// actor (`readSnapshot`): a puzzle is megabytes of image files, and each
+  /// piece costs a decode, an alpha crop and a PNG re-encode in
+  /// `CaptureEntry.init`. Doing that inline froze the UI for as long as it
+  /// took to open a puzzle whose files weren't already in the page cache.
+  func loadSession(id: UUID) async -> SolveSession? {
+    let snapshot = await Task.detached(priority: .userInitiated) { [self] in
+      readSnapshot(id: id)
+    }.value
+    guard let snapshot else { return nil }
     // The folder name is the canonical identity — use it (not manifest.id)
     // so persist() always writes back to the directory we loaded from,
     // even if the manifest was copied or moved.
     let session = SolveSession(
       id: id,
-      name: manifest.name,
-      puzzleId: manifest.serverPuzzleId,
-      trimmedJPEG: trimmed,
-      displayJPEG: try? Data(contentsOf: puzzleDisplayURL(id)),
-      targetPieceCount: manifest.pieceCount,
-      rows: manifest.rows,
-      cols: manifest.cols,
-      createdAt: manifest.createdAt,
+      name: snapshot.manifest.name,
+      puzzleId: snapshot.manifest.serverPuzzleId,
+      trimmedJPEG: snapshot.trimmed,
+      displayJPEG: snapshot.display,
+      targetPieceCount: snapshot.manifest.pieceCount,
+      rows: snapshot.manifest.rows,
+      cols: snapshot.manifest.cols,
+      createdAt: snapshot.manifest.createdAt,
       store: self
     )
-    session.entries = manifest.pieces.compactMap { piece in
+    session.entries = snapshot.entries
+    return session
+  }
+
+  /// Reads and decodes one puzzle's folder. `nonisolated` so `loadSession`
+  /// can run it off the main actor; it touches no mutable store state, only
+  /// the file layout (which is `nonisolated` for the same reason).
+  private nonisolated func readSnapshot(id: UUID) -> SessionSnapshot? {
+    guard let data = try? Data(contentsOf: manifestURL(id)),
+      let manifest = try? Self.makeDecoder().decode(PuzzleManifest.self, from: data),
+      let trimmed = try? Data(contentsOf: trimmedURL(id))
+    else {
+      return nil
+    }
+    let entries: [CaptureEntry] = manifest.pieces.compactMap { piece in
       guard let upload = try? Data(contentsOf: uploadURL(id, piece.id)) else { return nil }
       let display = (try? Data(contentsOf: displayURL(id, piece.id))) ?? upload
       let result = piece.result.map {
@@ -284,12 +324,17 @@ final class PuzzleStore {
         scanPieceId: piece.scanPieceId
       )
     }
-    return session
+    return SessionSnapshot(
+      manifest: manifest,
+      trimmed: trimmed,
+      display: try? Data(contentsOf: puzzleDisplayURL(id)),
+      entries: entries
+    )
   }
 
   /// Permanently removes a puzzle and all of its images from disk.
   func delete(_ id: UUID) {
-    try? fileManager.removeItem(at: puzzleDir(id))
+    try? FileManager.default.removeItem(at: puzzleDir(id))
     refresh()
   }
 
@@ -335,7 +380,7 @@ final class PuzzleStore {
   /// is still on disk, so it has to be filtered back out or it reappears.
   func refresh() {
     let dirs =
-      (try? fileManager.contentsOfDirectory(
+      (try? FileManager.default.contentsOfDirectory(
         at: rootURL,
         includingPropertiesForKeys: [.isDirectoryKey]
       )) ?? []
@@ -376,54 +421,57 @@ final class PuzzleStore {
 
   // MARK: File layout
 
-  private var rootURL: URL {
-    let docs = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+  // Pure path arithmetic over a fixed directory tree, so it is `nonisolated`
+  // throughout — `readSnapshot` needs these off the main actor.
+
+  private nonisolated var rootURL: URL {
+    let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
     return docs.appendingPathComponent("Puzzles", isDirectory: true)
   }
 
-  private func puzzleDir(_ id: UUID) -> URL {
+  private nonisolated func puzzleDir(_ id: UUID) -> URL {
     rootURL.appendingPathComponent(id.uuidString, isDirectory: true)
   }
 
-  private func piecesDir(_ id: UUID) -> URL {
+  private nonisolated func piecesDir(_ id: UUID) -> URL {
     puzzleDir(id).appendingPathComponent("pieces", isDirectory: true)
   }
 
-  private func trimmedURL(_ id: UUID) -> URL {
+  private nonisolated func trimmedURL(_ id: UUID) -> URL {
     puzzleDir(id).appendingPathComponent("trimmed.jpg")
   }
 
   /// The puzzle's optional zoom-quality overview (`SolveSession.displayJPEG`),
   /// distinct from a piece's `<pieceId>-display.jpg` under `pieces/`.
-  private func puzzleDisplayURL(_ id: UUID) -> URL {
+  private nonisolated func puzzleDisplayURL(_ id: UUID) -> URL {
     puzzleDir(id).appendingPathComponent("display.jpg")
   }
 
-  private func thumbnailURL(_ id: UUID) -> URL {
+  private nonisolated func thumbnailURL(_ id: UUID) -> URL {
     puzzleDir(id).appendingPathComponent("thumb.jpg")
   }
 
-  private func manifestURL(_ id: UUID) -> URL {
+  private nonisolated func manifestURL(_ id: UUID) -> URL {
     puzzleDir(id).appendingPathComponent("manifest.json")
   }
 
-  private func uploadURL(_ puzzle: UUID, _ piece: UUID) -> URL {
+  private nonisolated func uploadURL(_ puzzle: UUID, _ piece: UUID) -> URL {
     piecesDir(puzzle).appendingPathComponent("\(piece.uuidString)-upload.jpg")
   }
 
-  private func displayURL(_ puzzle: UUID, _ piece: UUID) -> URL {
+  private nonisolated func displayURL(_ puzzle: UUID, _ piece: UUID) -> URL {
     piecesDir(puzzle).appendingPathComponent("\(piece.uuidString)-display.jpg")
   }
 
   /// Deletes piece image files whose id is no longer in the session.
   private func pruneOrphanPieceFiles(in dir: URL, keeping keep: Set<String>) {
     let files =
-      (try? fileManager.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)) ?? []
+      (try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)) ?? []
     for file in files {
       // Filenames are "<uuid>-upload.jpg" / "<uuid>-display.jpg".
       let id = String(file.lastPathComponent.prefix(36))
       if !keep.contains(id) {
-        try? fileManager.removeItem(at: file)
+        try? FileManager.default.removeItem(at: file)
       }
     }
   }

--- a/ios/Pussel/Support/DebugNavigation.swift
+++ b/ios/Pussel/Support/DebugNavigation.swift
@@ -91,7 +91,7 @@
       case "reupload":
         await debugReupload()
       case "open":
-        debugOpen(index: value("index"))
+        await debugOpen(index: value("index"))
       case "delete":
         debugDelete(index: value("index"))
       case "camera":
@@ -138,11 +138,11 @@
       }
     }
 
-    private func debugOpen(index: String?) {
+    private func debugOpen(index: String?) async {
       guard let index = index.flatMap(Int.init), store.puzzles.indices.contains(index) else {
         return
       }
-      openPuzzle(store.puzzles[index].id)
+      await openPuzzle(store.puzzles[index].id)
     }
 
     private func debugDelete(index: String?) {

--- a/ios/PusselTests/AppFlowNavigationTests.swift
+++ b/ios/PusselTests/AppFlowNavigationTests.swift
@@ -83,6 +83,19 @@ final class AppFlowNavigationTests: XCTestCase {
     XCTAssertTrue(flow.canGoBack)
   }
 
+  /// Opening a puzzle reads its files off the main actor, so the user can go
+  /// back before that read lands. Clearing the token is what tells the read it
+  /// is stale — without it the finished session would arrive on top of the
+  /// home screen the user had just returned to.
+  func testGoBackCancelsAnInFlightOpen() {
+    let flow = AppFlowStore()
+    flow.phase = .solving(session())
+    flow.openingPuzzle = UUID()
+
+    flow.goBack()
+    XCTAssertNil(flow.openingPuzzle)
+  }
+
   func testGoBackClearsWizardState() {
     let flow = AppFlowStore()
     flow.phase = .solving(session())

--- a/ios/PusselTests/AppFlowNavigationTests.swift
+++ b/ios/PusselTests/AppFlowNavigationTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+
+@testable import Pussel
+
+/// Covers the back chevron's state machine (`AppFlowStore.canGoBack` /
+/// `goBack`), which `AppFlowView` renders as one bar item kept mounted across
+/// every phase — so the button's availability is decided here rather than by
+/// whichever phase view happens to be on screen.
+@MainActor
+final class AppFlowNavigationTests: XCTestCase {
+  private func candidate() -> TrimCandidate {
+    .wholeImage(jpeg: Data("not-a-real-jpeg".utf8), source: .library)
+  }
+
+  private func session() -> SolveSession {
+    SolveSession(
+      name: "Test", puzzleId: "p1", trimmedJPEG: Data(), targetPieceCount: 100, rows: 10, cols: 10)
+  }
+
+  func testHomeScreenHasNothingToGoBackTo() {
+    let flow = AppFlowStore()
+    XCTAssertFalse(flow.canGoBack)
+  }
+
+  func testGoBackLeavesASolveSession() {
+    let flow = AppFlowStore()
+    flow.phase = .solving(session())
+    XCTAssertTrue(flow.canGoBack)
+
+    flow.goBack()
+    guard case .capturePuzzle = flow.phase else {
+      return XCTFail("expected the capture phase, got \(flow.phase)")
+    }
+  }
+
+  /// The back chevron is live from the moment the phase flips, with no
+  /// intermediate state in which it is mounted but inert — the window a tap
+  /// used to fall into.
+  func testGoBackIsAvailableImmediatelyAfterOpeningASession() {
+    let flow = AppFlowStore()
+    flow.phase = .solving(session())
+    flow.goBack()
+    flow.phase = .solving(session())
+
+    XCTAssertTrue(flow.canGoBack)
+    flow.goBack()
+    guard case .capturePuzzle = flow.phase else {
+      return XCTFail("expected the capture phase, got \(flow.phase)")
+    }
+  }
+
+  func testGoBackFromConfirmTrimReturnsHome() {
+    let flow = AppFlowStore()
+    flow.phase = .confirmTrim(candidate())
+    XCTAssertTrue(flow.canGoBack)
+
+    flow.goBack()
+    guard case .capturePuzzle = flow.phase else {
+      return XCTFail("expected the capture phase, got \(flow.phase)")
+    }
+  }
+
+  /// Leaving mid-upload would strand the session being created, so the chevron
+  /// is withheld there — and `goBack` honours that on its own, not just by the
+  /// button being dimmed.
+  func testConfirmTrimHidesBackWhileUploading() {
+    let flow = AppFlowStore()
+    flow.phase = .confirmTrim(candidate())
+    flow.isBusy = true
+    XCTAssertFalse(flow.canGoBack)
+
+    flow.goBack()
+    guard case .confirmTrim = flow.phase else {
+      return XCTFail("expected to stay on confirm-trim, got \(flow.phase)")
+    }
+  }
+
+  /// A solve session is never mid-upload, so the chevron stays available.
+  func testSolvingKeepsBackAvailable() {
+    let flow = AppFlowStore()
+    flow.phase = .solving(session())
+    flow.isBusy = true
+    XCTAssertTrue(flow.canGoBack)
+  }
+
+  func testGoBackClearsWizardState() {
+    let flow = AppFlowStore()
+    flow.phase = .solving(session())
+    flow.errorMessage = "boom"
+    flow.pendingRetake = .camera
+
+    flow.goBack()
+    XCTAssertNil(flow.errorMessage)
+    XCTAssertNil(flow.pendingRetake)
+  }
+}

--- a/ios/PusselTests/PuzzleStoreTests.swift
+++ b/ios/PusselTests/PuzzleStoreTests.swift
@@ -69,7 +69,7 @@ final class PuzzleStoreTests: XCTestCase {
 
   // MARK: Zoom copy (display.jpg)
 
-  func testZoomCopyIsPersistedAndReloaded() throws {
+  func testZoomCopyIsPersistedAndReloaded() async throws {
     let store = PuzzleStore()
     // Real JPEG bytes, as the zoom viewer decodes these for display — and a
     // different colour from the trimmed image the session is built with, so
@@ -83,7 +83,7 @@ final class PuzzleStoreTests: XCTestCase {
     session.persist()
     XCTAssertTrue(FileManager.default.fileExists(atPath: displayFile(session.id).path))
 
-    let reloaded = try XCTUnwrap(store.loadSession(id: session.id))
+    let reloaded = try XCTUnwrap(await store.loadSession(id: session.id))
     // Byte-for-byte: the copy is stored as given, never re-encoded.
     XCTAssertEqual(reloaded.displayJPEG, displayJPEG)
     XCTAssertNotNil(UIImage(data: try XCTUnwrap(reloaded.displayJPEG)))
@@ -91,7 +91,7 @@ final class PuzzleStoreTests: XCTestCase {
     XCTAssertEqual(reloaded.zoomJPEG, displayJPEG)
   }
 
-  func testPuzzleWithoutZoomCopyReloadsAndFallsBackToTrimmed() throws {
+  func testPuzzleWithoutZoomCopyReloadsAndFallsBackToTrimmed() async throws {
     // The compatibility path for every puzzle saved before the zoom copy
     // existed, and for a capture whose re-warp failed: no display.jpg on disk,
     // and the viewer falls back to the trimmed image rather than showing
@@ -103,12 +103,12 @@ final class PuzzleStoreTests: XCTestCase {
     session.persist()
     XCTAssertFalse(FileManager.default.fileExists(atPath: displayFile(session.id).path))
 
-    let reloaded = try XCTUnwrap(store.loadSession(id: session.id))
+    let reloaded = try XCTUnwrap(await store.loadSession(id: session.id))
     XCTAssertNil(reloaded.displayJPEG)
     XCTAssertEqual(reloaded.zoomJPEG, reloaded.trimmedJPEG)
   }
 
-  func testSavePersistsSummaryAndSurvivesReload() throws {
+  func testSavePersistsSummaryAndSurvivesReload() async throws {
     let store = PuzzleStore()
     let session = makeSession(store: store, name: "Frosty field")
     addTeardownBlock { @MainActor in store.delete(session.id) }
@@ -145,7 +145,7 @@ final class PuzzleStoreTests: XCTestCase {
     XCTAssertNotNil(summary.thumbnail)
 
     // A brand-new store instance reads purely from disk.
-    let reloaded = try XCTUnwrap(PuzzleStore().loadSession(id: session.id))
+    let reloaded = try XCTUnwrap(await PuzzleStore().loadSession(id: session.id))
     XCTAssertEqual(reloaded.name, "Frosty field")
     XCTAssertEqual(reloaded.puzzleId, "server-123")
     XCTAssertEqual(reloaded.trimmedJPEG, session.trimmedJPEG)
@@ -167,7 +167,7 @@ final class PuzzleStoreTests: XCTestCase {
     XCTAssertEqual(entry.scanPieceId, "p001")
   }
 
-  func testUnpredictedPieceReloadsAsQueued() throws {
+  func testUnpredictedPieceReloadsAsQueued() async throws {
     let store = PuzzleStore()
     let session = makeSession(store: store)
     addTeardownBlock { @MainActor in store.delete(session.id) }
@@ -179,7 +179,7 @@ final class PuzzleStoreTests: XCTestCase {
     ]
     session.persist()
 
-    let reloaded = try XCTUnwrap(PuzzleStore().loadSession(id: session.id))
+    let reloaded = try XCTUnwrap(await PuzzleStore().loadSession(id: session.id))
     let entry = try XCTUnwrap(reloaded.entries.first)
     XCTAssertEqual(entry.status, .queued)
     XCTAssertNil(entry.result)
@@ -187,7 +187,7 @@ final class PuzzleStoreTests: XCTestCase {
     XCTAssertEqual(entry.displayImage, raw)
   }
 
-  func testRemovedPieceIsPrunedFromDisk() throws {
+  func testRemovedPieceIsPrunedFromDisk() async throws {
     let store = PuzzleStore()
     let session = makeSession(store: store)
     addTeardownBlock { @MainActor in store.delete(session.id) }
@@ -210,7 +210,7 @@ final class PuzzleStoreTests: XCTestCase {
     XCTAssertFalse(fileManager.fileExists(atPath: uploadFile(session.id, drop.id).path))
     XCTAssertTrue(fileManager.fileExists(atPath: uploadFile(session.id, keep.id).path))
 
-    let reloaded = try XCTUnwrap(PuzzleStore().loadSession(id: session.id))
+    let reloaded = try XCTUnwrap(await PuzzleStore().loadSession(id: session.id))
     XCTAssertEqual(reloaded.entries.map(\.id), [keep.id])
   }
 
@@ -276,7 +276,7 @@ final class PuzzleStoreTests: XCTestCase {
     XCTFail("No request for \(path) within the timeout")
   }
 
-  func testDeleteRemovesPuzzle() throws {
+  func testDeleteRemovesPuzzle() async throws {
     let store = PuzzleStore()
     let session = makeSession(store: store)
     // Clean up even if an assertion fails before the delete below.
@@ -287,7 +287,8 @@ final class PuzzleStoreTests: XCTestCase {
 
     store.delete(session.id)
     XCTAssertFalse(store.puzzles.contains { $0.id == session.id })
-    XCTAssertNil(store.loadSession(id: session.id))
+    let reloaded = await store.loadSession(id: session.id)
+    XCTAssertNil(reloaded)
     XCTAssertFalse(FileManager.default.fileExists(atPath: puzzleDir(session.id).path))
   }
 
@@ -309,7 +310,7 @@ final class PuzzleStoreTests: XCTestCase {
     XCTAssertFalse(store.puzzles.contains { $0.id == session.id })
   }
 
-  func testUndoDeleteRestoresPuzzle() throws {
+  func testUndoDeleteRestoresPuzzle() async throws {
     let store = PuzzleStore()
     let session = makeSession(store: store)
     addTeardownBlock { @MainActor in store.delete(session.id) }
@@ -320,7 +321,8 @@ final class PuzzleStoreTests: XCTestCase {
 
     XCTAssertNil(store.pendingDelete)
     XCTAssertTrue(store.puzzles.contains { $0.id == session.id })
-    XCTAssertNotNil(store.loadSession(id: session.id))
+    let reloaded = await store.loadSession(id: session.id)
+    XCTAssertNotNil(reloaded)
     XCTAssertTrue(FileManager.default.fileExists(atPath: puzzleDir(session.id).path))
   }
 

--- a/ios/PusselTests/PuzzleStoreTests.swift
+++ b/ios/PusselTests/PuzzleStoreTests.swift
@@ -83,7 +83,8 @@ final class PuzzleStoreTests: XCTestCase {
     session.persist()
     XCTAssertTrue(FileManager.default.fileExists(atPath: displayFile(session.id).path))
 
-    let reloaded = try XCTUnwrap(await store.loadSession(id: session.id))
+    let loaded = await store.loadSession(id: session.id)
+    let reloaded = try XCTUnwrap(loaded)
     // Byte-for-byte: the copy is stored as given, never re-encoded.
     XCTAssertEqual(reloaded.displayJPEG, displayJPEG)
     XCTAssertNotNil(UIImage(data: try XCTUnwrap(reloaded.displayJPEG)))
@@ -103,7 +104,8 @@ final class PuzzleStoreTests: XCTestCase {
     session.persist()
     XCTAssertFalse(FileManager.default.fileExists(atPath: displayFile(session.id).path))
 
-    let reloaded = try XCTUnwrap(await store.loadSession(id: session.id))
+    let loaded = await store.loadSession(id: session.id)
+    let reloaded = try XCTUnwrap(loaded)
     XCTAssertNil(reloaded.displayJPEG)
     XCTAssertEqual(reloaded.zoomJPEG, reloaded.trimmedJPEG)
   }
@@ -145,7 +147,8 @@ final class PuzzleStoreTests: XCTestCase {
     XCTAssertNotNil(summary.thumbnail)
 
     // A brand-new store instance reads purely from disk.
-    let reloaded = try XCTUnwrap(await PuzzleStore().loadSession(id: session.id))
+    let loaded = await PuzzleStore().loadSession(id: session.id)
+    let reloaded = try XCTUnwrap(loaded)
     XCTAssertEqual(reloaded.name, "Frosty field")
     XCTAssertEqual(reloaded.puzzleId, "server-123")
     XCTAssertEqual(reloaded.trimmedJPEG, session.trimmedJPEG)
@@ -179,7 +182,8 @@ final class PuzzleStoreTests: XCTestCase {
     ]
     session.persist()
 
-    let reloaded = try XCTUnwrap(await PuzzleStore().loadSession(id: session.id))
+    let loaded = await PuzzleStore().loadSession(id: session.id)
+    let reloaded = try XCTUnwrap(loaded)
     let entry = try XCTUnwrap(reloaded.entries.first)
     XCTAssertEqual(entry.status, .queued)
     XCTAssertNil(entry.result)
@@ -210,7 +214,8 @@ final class PuzzleStoreTests: XCTestCase {
     XCTAssertFalse(fileManager.fileExists(atPath: uploadFile(session.id, drop.id).path))
     XCTAssertTrue(fileManager.fileExists(atPath: uploadFile(session.id, keep.id).path))
 
-    let reloaded = try XCTUnwrap(await PuzzleStore().loadSession(id: session.id))
+    let loaded = await PuzzleStore().loadSession(id: session.id)
+    let reloaded = try XCTUnwrap(loaded)
     XCTAssertEqual(reloaded.entries.map(\.id), [keep.id])
   }
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -34,7 +34,10 @@ open Pussel.xcodeproj
 ## Architecture
 
 - **App/** — `AppModel` (root object graph), `AppFlow` (phase state machine:
-  capture → confirm trim → solving), `AppActions` (shared wizard actions)
+  capture → confirm trim → solving), `AppActions` (shared wizard actions).
+  `RootView` owns the navigation bar for every phase, back chevron included —
+  a phase view must not add its own `.toolbar`, because a bar item that comes
+  and goes with the phase swap drops taps that land before it is installed
 - **Persistence/** — `PuzzleStore`, on-device storage of every puzzle under
   `Documents/Puzzles/<uuid>/` (a `manifest.json`, the `trimmed.jpg` picture,
   and a `pieces/` folder of per-piece image files). No server storage: a

--- a/ios/README.md
+++ b/ios/README.md
@@ -42,7 +42,9 @@ open Pussel.xcodeproj
   `Documents/Puzzles/<uuid>/` (a `manifest.json`, the `trimmed.jpg` picture,
   and a `pieces/` folder of per-piece image files). No server storage: a
   session is saved on every change (create, prediction done, remove, reupload)
-  and rehydrated purely from disk when reopened
+  and rehydrated purely from disk when reopened — the reopen reads and decodes
+  off the main actor (`loadSession` is async), so a puzzle whose files aren't
+  in the page cache doesn't freeze the UI while it opens
 - **Networking/** — `APIClient` (async URLSession, Bearer auth, central
   401 → silent re-auth → retry), `MultipartFormData`
 - **Features/Auth/** — Google Sign-In via the GoogleSignIn SDK; the backend


### PR DESCRIPTION
Tapping back right after opening a puzzle sometimes did nothing. The
chevron was a `.toolbar` declared inside SolvingView (and ConfirmTrimView),
so the bar item only existed while that phase's branch was mounted: it is
inserted once SwiftUI commits the new phase's content and crossfades in
from the previous phase's empty leading slot, and a tap landing in that
window hits the bar itself and is dropped. Opening a puzzle widens the
window, because loadSession's file reads and the overview decode block the
main thread first; reopening the same puzzle hits warm caches, which is why
it only reproduced on a puzzle that hadn't just been opened.

Declare one leading item in AppFlowView's toolbar instead, kept mounted for
the whole flow and dimmed/disabled where it doesn't apply, so the button is
already installed and hit-testable the instant the phase turns solvable.
Its availability moves to AppFlowStore.canGoBack/goBack, which also keeps
confirm-trim's mid-upload hiding — now enforced by the action, not just by
the button being hidden.

Also cache the overview decode on SolveSession, the way puzzleAspect
already is: PuzzleOverlayView decoded trimmedJPEG from its body, so the
puzzle re-decoded on every landed prediction and every layout pass, the
first of them on the main thread while the solve screen appears.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SsWaFvhXiUMf2cVsbdhT27