### PR TITLE
Cut the post-scan wait: pipelined registration, Accelerate healing, slim detect-frame

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,21 @@ IOS_DERIVED    = ios/.build
 IOS_SIM_ARCH  ?= $(shell uname -m)
 IOS_DESTINATION = platform=iOS Simulator,name=$(IOS_SIMULATOR),arch=$(IOS_SIM_ARCH)
 
+# Device deploys (ios-deploy) build the Debug configuration with Swift
+# optimization turned on. Unoptimized (-Onone) code makes the glare-free
+# compose step ~8-10x slower — 19.5s vs 2.5s on a real capture — and the phone
+# is where the app is actually used, so an unoptimized deploy misrepresents it.
+# These are codegen settings only: the Debug configuration still defines DEBUG,
+# so `#if DEBUG` features (GlareFreeDumps recording, the debug command channel)
+# keep working. Opt out with `make ios-deploy IOS_OPTIMIZE=0`.
+IOS_OPTIMIZE  ?= 1
+IOS_OPTIMIZE_ON = $(filter-out 0,$(IOS_OPTIMIZE))
+IOS_OPT_FLAGS  = $(if $(IOS_OPTIMIZE_ON),SWIFT_OPTIMIZATION_LEVEL=-O SWIFT_COMPILATION_MODE=wholemodule)
+# Flipping the optimization settings invalidates every object file, so sharing
+# IOS_DERIVED with ios-run/ios-test would mean a full rebuild on every switch
+# between simulator and device. The optimized build gets its own derived data.
+IOS_DEPLOY_DERIVED = $(if $(IOS_OPTIMIZE_ON),$(IOS_DERIVED)-opt,$(IOS_DERIVED))
+
 # Canonical (gitignored, machine-local) copy of the real secrets. It lives
 # outside every worktree so a fresh worktree or a `git clean` never loses it;
 # ios-generate restores ios/Config/Secrets.xcconfig from here automatically.
@@ -180,6 +195,8 @@ ios-test: ios-generate
 # Build a Debug build, then install + launch on a connected device (iPhone/iPad).
 # Requires DEVELOPMENT_TEAM in ios/Config/Secrets.xcconfig (device signing).
 # The device is auto-detected; override with IOS_DEVICE=<name-or-udid>.
+# Swift optimization is on by default (see IOS_OPTIMIZE above), which puts the
+# build in its own derived-data directory, $(IOS_DERIVED)-opt.
 ios-deploy: ios-generate
 	@DEVICE="$(IOS_DEVICE)"; \
 	if [ -z "$$DEVICE" ]; then \
@@ -191,9 +208,10 @@ ios-deploy: ios-generate
 	fi; \
 	echo "Deploying to device: $$DEVICE"; \
 	xcodebuild build -project "$(IOS_PROJECT)" -scheme "$(IOS_SCHEME)" \
-		-destination 'generic/platform=iOS' -derivedDataPath "$(IOS_DERIVED)" -allowProvisioningUpdates && \
+		-destination 'generic/platform=iOS' -derivedDataPath "$(IOS_DEPLOY_DERIVED)" \
+		-allowProvisioningUpdates $(IOS_OPT_FLAGS) && \
 	xcrun devicectl device install app --device "$$DEVICE" \
-		"$(IOS_DERIVED)/Build/Products/Debug-iphoneos/$(IOS_APP_NAME).app" && \
+		"$(IOS_DEPLOY_DERIVED)/Build/Products/Debug-iphoneos/$(IOS_APP_NAME).app" && \
 	xcrun devicectl device process launch --device "$$DEVICE" "$(IOS_BUNDLE_ID)"
 
 # Screenshot a connected device or a booted Simulator, whichever is available

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -58,7 +58,7 @@ from app.services.piece_geometry.service import (
 from app.services.piece_geometry.store import get_piece_geometry_store
 from app.services.piece_shape import PieceShapeGenerator, calculate_grid_dimensions
 from app.services.puzzle_cutter import get_puzzle_cutter
-from app.services.puzzle_detector import get_puzzle_detector
+from app.services.puzzle_detector import PuzzleFrameDetector, get_puzzle_detector
 from app.services.puzzle_store import PuzzleRecord, get_puzzle_store
 from app.services.ravensburger_client import get_ravensburger_client
 from app.services.ravensburger_lookup import RAVENSBURGER_ADULT_PREFIX, candidate_article_numbers, ean_checksum_valid
@@ -298,6 +298,7 @@ class _UndecodableImageError(Exception):
 
 
 def _detect_frame_blocking(
+    detector: PuzzleFrameDetector,
     contents: bytes,
     quad: Optional[QuadCorners],
     include_image: bool,
@@ -309,6 +310,9 @@ def _detect_frame_blocking(
     stall concurrent piece predictions.
 
     Args:
+        detector: The frame detector to run. Resolved by the caller on the
+            event loop — `get_puzzle_detector`'s lazy singleton isn't locked,
+            so it must not be raced from worker threads.
         contents: The raw uploaded photo bytes.
         quad: Manually supplied corners, or None to auto-detect.
         include_image: Whether to also warp and JPEG/base64-encode the crop.
@@ -326,7 +330,6 @@ def _detect_frame_blocking(
     except (UnidentifiedImageError, OSError, ValueError) as exc:
         raise _UndecodableImageError() from exc
 
-    detector = get_puzzle_detector()
     if quad is not None:
         used_corners = quad
         confidence = 1.0
@@ -411,7 +414,7 @@ async def detect_frame(
 
     try:
         used_corners, confidence, trimmed_image = await asyncio.to_thread(
-            _detect_frame_blocking, contents, quad, include_image
+            _detect_frame_blocking, get_puzzle_detector(), contents, quad, include_image
         )
     except _UndecodableImageError as exc:
         raise HTTPException(status_code=400, detail="Invalid image file") from exc

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -289,6 +289,62 @@ async def list_puzzles(
     )
 
 
+class _UndecodableImageError(Exception):
+    """Raised by `_detect_frame_blocking` when the uploaded bytes aren't a decodable image.
+
+    The worker runs off the event loop in a thread, so it signals failures with a
+    plain exception that `detect_frame` translates into an HTTPException.
+    """
+
+
+def _detect_frame_blocking(
+    contents: bytes,
+    quad: Optional[QuadCorners],
+    include_image: bool,
+) -> tuple[QuadCorners, float, Optional[str]]:
+    """Run the CPU-bound half of frame detection: decode, detect, and optionally warp.
+
+    Kept synchronous so `detect_frame` can hand it to `asyncio.to_thread`; the
+    ~100-300 ms of OpenCV/Pillow work would otherwise block the event loop and
+    stall concurrent piece predictions.
+
+    Args:
+        contents: The raw uploaded photo bytes.
+        quad: Manually supplied corners, or None to auto-detect.
+        include_image: Whether to also warp and JPEG/base64-encode the crop.
+
+    Returns:
+        Tuple of (corners used, confidence, trimmed image data URL or None).
+
+    Raises:
+        _UndecodableImageError: If the bytes can't be opened as an image.
+    """
+    try:
+        image = Image.open(io.BytesIO(contents))
+        # Phone photos carry EXIF orientation; correct it so corners match what the user sees
+        image = ImageOps.exif_transpose(image).convert("RGB")
+    except (UnidentifiedImageError, OSError, ValueError) as exc:
+        raise _UndecodableImageError() from exc
+
+    detector = get_puzzle_detector()
+    if quad is not None:
+        used_corners = quad
+        confidence = 1.0
+        points = quad.as_points()
+    else:
+        points, confidence = detector.detect_corners(image)
+        used_corners = QuadCorners.from_points(points)
+
+    trimmed_image: Optional[str] = None
+    if include_image:
+        trimmed = detector.warp(image, points)
+        buffer = io.BytesIO()
+        trimmed.save(buffer, format="JPEG", quality=90)
+        trimmed_image = f"data:image/jpeg;base64,{base64.b64encode(buffer.getvalue()).decode()}"
+
+    return used_corners, confidence, trimmed_image
+
+
 @app.post(
     "/api/v1/puzzle/detect-frame",
     response_model=DetectFrameResponse,
@@ -297,13 +353,24 @@ async def list_puzzles(
 async def detect_frame(
     file: Optional[UploadFile] = None,
     corners: Annotated[Optional[str], Form(description="Manually adjusted corners as JSON QuadCorners")] = None,
+    include_image: Annotated[
+        bool,
+        Form(
+            description=(
+                "Whether to warp the crop server-side and echo it back as `trimmed_image`. Send "
+                '"false" to opt out (the iOS app warps locally from `corners`), which skips the '
+                "warp/JPEG/base64 work and returns `trimmed_image` as null. Defaults to true, so "
+                "clients that omit the field are unaffected."
+            )
+        ),
+    ] = True,
 ) -> DetectFrameResponse:
     """Detect the puzzle picture in a photo and return a perspective-corrected crop.
 
     This endpoint is stateless: nothing is persisted. The frontend previews the
     trimmed image and, once accepted, uploads it via the regular upload endpoint.
     When ``corners`` is provided (manual adjustment), detection is skipped and
-    the supplied corners are used for the warp with confidence 1.0.
+    the supplied corners are used with confidence 1.0.
 
     The printed piece count is read from the photo on-device (iOS Vision, see
     the app's `PieceCountReader`), so this endpoint no longer OCRs it.
@@ -314,10 +381,12 @@ async def detect_frame(
     Args:
         file: The raw photo of the puzzle.
         corners: Optional JSON-encoded QuadCorners overriding auto-detection.
+        include_image: When false, skips the server-side warp and returns
+            `trimmed_image` as null; corners and confidence are unaffected.
 
     Returns:
-        DetectFrameResponse with the trimmed image (base64 data URL), the
-        corners used, and a detection confidence.
+        DetectFrameResponse with the corners used, a detection confidence, and
+        the trimmed image as a base64 data URL (null when include_image is false).
 
     Raises:
         HTTPException: If no/invalid file is provided, the file is too large,
@@ -333,33 +402,22 @@ async def detect_frame(
     if len(contents) > settings.MAX_UPLOAD_SIZE:
         raise HTTPException(status_code=413, detail="File too large")
 
-    try:
-        image = Image.open(io.BytesIO(contents))
-        # Phone photos carry EXIF orientation; correct it so corners match what the user sees
-        image = ImageOps.exif_transpose(image).convert("RGB")
-    except (UnidentifiedImageError, OSError, ValueError) as exc:
-        raise HTTPException(status_code=400, detail="Invalid image file") from exc
-
-    detector = get_puzzle_detector()
+    quad: Optional[QuadCorners] = None
     if corners is not None:
         try:
             quad = QuadCorners.model_validate_json(corners)
         except ValidationError as exc:
             raise HTTPException(status_code=400, detail="Invalid corners payload") from exc
-        used_corners = quad
-        confidence = 1.0
-        trimmed = detector.warp(image, quad.as_points())
-    else:
-        points, confidence = detector.detect_corners(image)
-        used_corners = QuadCorners.from_points(points)
-        trimmed = detector.warp(image, points)
 
-    buffer = io.BytesIO()
-    trimmed.save(buffer, format="JPEG", quality=90)
-    trimmed_base64 = base64.b64encode(buffer.getvalue()).decode()
+    try:
+        used_corners, confidence, trimmed_image = await asyncio.to_thread(
+            _detect_frame_blocking, contents, quad, include_image
+        )
+    except _UndecodableImageError as exc:
+        raise HTTPException(status_code=400, detail="Invalid image file") from exc
 
     return DetectFrameResponse(
-        trimmed_image=f"data:image/jpeg;base64,{trimmed_base64}",
+        trimmed_image=trimmed_image,
         corners=used_corners,
         confidence=confidence,
     )

--- a/backend/app/models/puzzle_model.py
+++ b/backend/app/models/puzzle_model.py
@@ -161,7 +161,13 @@ class PiecePreviewResponse(BaseModel):
 class DetectFrameResponse(BaseModel):
     """Response model for puzzle frame detection."""
 
-    trimmed_image: str = Field(..., description="Base64 data URL (JPEG) of the perspective-corrected puzzle image")
+    trimmed_image: Optional[str] = Field(
+        default=None,
+        description=(
+            "Base64 data URL (JPEG) of the perspective-corrected puzzle image; null when the request "
+            "opted out with include_image=false and warps client-side from `corners` instead"
+        ),
+    )
     corners: QuadCorners = Field(..., description="Corners used, normalized 0-1 relative to the EXIF-corrected photo")
     confidence: float = Field(..., ge=0.0, le=1.0, description="Detection confidence; 1.0 for manual corners")
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -414,6 +414,62 @@ def test_detect_frame_manual_corners() -> None:
     assert result["trimmed_image"].startswith("data:image/jpeg;base64,")
 
 
+def test_detect_frame_include_image_false_omits_trimmed_image() -> None:
+    """include_image=false skips the server-side warp but still returns corners and confidence."""
+    response = client.post(
+        "/api/v1/puzzle/detect-frame",
+        files=photo_files(make_photo_jpeg()),
+        data={"include_image": "false"},
+        headers=get_auth_header(),
+    )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["trimmed_image"] is None
+    assert 0.0 <= result["confidence"] <= 1.0
+    assert result["confidence"] > 0.5
+    for name in ("top_left", "top_right", "bottom_right", "bottom_left"):
+        corner = result["corners"][name]
+        assert 0.0 <= corner["x"] <= 1.0
+        assert 0.0 <= corner["y"] <= 1.0
+    assert abs(result["corners"]["top_left"]["x"] - 100 / 800) < 0.03
+    assert abs(result["corners"]["top_left"]["y"] - 80 / 600) < 0.03
+
+
+def test_detect_frame_manual_corners_include_image_false() -> None:
+    """Manual corners are still validated and echoed with confidence 1.0 when the image is skipped."""
+    manual_corners = {
+        "top_left": {"x": 0.125, "y": 0.1333},
+        "top_right": {"x": 0.875, "y": 0.1333},
+        "bottom_right": {"x": 0.875, "y": 0.8667},
+        "bottom_left": {"x": 0.125, "y": 0.8667},
+    }
+
+    response = client.post(
+        "/api/v1/puzzle/detect-frame",
+        files=photo_files(make_photo_jpeg()),
+        data={"corners": json.dumps(manual_corners), "include_image": "false"},
+        headers=get_auth_header(),
+    )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["trimmed_image"] is None
+    assert result["confidence"] == 1.0
+    assert result["corners"] == manual_corners
+
+
+def test_detect_frame_invalid_corners_json_include_image_false() -> None:
+    """A malformed corners payload is still rejected when the image is skipped."""
+    response = client.post(
+        "/api/v1/puzzle/detect-frame",
+        files=photo_files(make_photo_jpeg()),
+        data={"corners": "not valid json", "include_image": "false"},
+        headers=get_auth_header(),
+    )
+    assert response.status_code == 400
+
+
 def test_detect_frame_omits_piece_count_estimate() -> None:
     """The count is read on-device (iOS Vision), so detect-frame no longer OCRs it."""
     with patch("app.main.estimate_piece_count") as estimator:

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -3,5 +3,7 @@
 Pussel/Resources/Info.plist
 DerivedData/
 .build/
+# Derived data for the optimized device build (make ios-deploy).
+.build-opt/
 xcuserdata/
 Config/Secrets.xcconfig

--- a/ios/Pussel/App/AppActions.swift
+++ b/ios/Pussel/App/AppActions.swift
@@ -44,11 +44,22 @@ extension AppModel {
     }
     do {
       let detection = try await api.detectFrame(jpegData: jpeg)
+      // The backend is asked not to echo its crop back (`include_image=false`),
+      // so straighten the photo here from the corners it did return. Started
+      // as soon as the corners land and awaited below, so it overlaps whatever
+      // is left of the zoom encode and the OCR instead of queueing behind
+      // them; off the main actor because decoding, warping and re-encoding a
+      // multi-megapixel photo would otherwise freeze the screen. Computed once
+      // here rather than per access — see `TrimCandidate.trimmedJPEG`.
+      let trimTask = Task.detached(priority: .userInitiated) {
+        TrimCandidate.croppedJPEG(from: jpeg, corners: detection.corners)
+      }
       flow.phase = .confirmTrim(
         TrimCandidate(
           rawJPEG: jpeg, zoomSourceJPEG: await zoomSourceTask.value, detection: detection,
           source: source,
-          pieceCountEstimate: await countTask.value)
+          pieceCountEstimate: await countTask.value,
+          trimmedJPEG: await trimTask.value)
       )
     } catch {
       // Marks the encode and the OCR unwanted and drops them without waiting.
@@ -137,12 +148,12 @@ extension AppModel {
 
   /// Re-warps the kept zoom-quality photo to the accepted trim, so the solve
   /// screen can zoom into real detail instead of magnifying the
-  /// upload-resolution crop the backend returned.
+  /// upload-resolution crop.
   ///
   /// Uses the corners from the same detect-frame response the accepted
-  /// preview came from, so both copies frame the same region; `quarterTurns`
-  /// is the user's rotation, baked in here exactly as it is for the uploaded
-  /// image so the two stay in the same orientation.
+  /// preview was warped from, so both copies frame the same region;
+  /// `quarterTurns` is the user's rotation, baked in here exactly as it is for
+  /// the uploaded image so the two stay in the same orientation.
   ///
   /// Best-effort throughout: every failure yields nil, leaving the session to
   /// fall back to `trimmedJPEG` rather than blocking a working capture over a

--- a/ios/Pussel/App/AppFlow.swift
+++ b/ios/Pussel/App/AppFlow.swift
@@ -42,16 +42,48 @@ struct TrimCandidate {
   /// (`PieceCountReader`) on the detect-frame path — used to prefill the
   /// confirm screen's piece-count field; nil for boxes it couldn't read.
   var pieceCountEstimate: Int?
+  /// The straightened crop: what the confirm screen shows and what
+  /// `AppModel.acceptTrim` uploads. Warped out of `rawJPEG` by
+  /// `detection.corners` on this device — the backend is asked not to echo its
+  /// own copy back (`include_image=false`), and `perspectiveCorrected` frames
+  /// the same region from the same normalized corners (see its docs).
+  ///
+  /// Stored rather than recomputed per access: decode + warp + encode is the
+  /// expensive half of a capture, and both `ConfirmTrimView` (which re-reads
+  /// on every rotate tap) and `acceptTrim` want the same bytes.
+  /// `AppModel.startTrim` fills it in once, off the main actor, via
+  /// `croppedJPEG(from:corners:)`. Nil when that warp or encode failed, which
+  /// the confirm screen shows as its could-not-decode placeholder and
+  /// `acceptTrim` refuses to upload.
+  let trimmedJPEG: Data?
 
-  var trimmedJPEG: Data? {
-    ImageUtilities.decodeDataURL(detection.trimmedImage)
+  /// Straightens `rawJPEG` to `corners` and re-encodes it as JPEG — the local
+  /// stand-in for the server's `trimmed_image`.
+  ///
+  /// No extra downscale: `rawJPEG` is already the upload-size copy (capped at
+  /// 1920 by `normalizedJPEG`), so a cap here could only throw away detail the
+  /// upload is entitled to — a quad seen at an angle straightens to something
+  /// longer than the photo's own long side.
+  ///
+  /// Blocking, multi-megapixel work (see `AppModel.startTrim`): call it off
+  /// the main actor. Returns nil when the bytes can't be decoded or the quad
+  /// is degenerate.
+  static func croppedJPEG(from rawJPEG: Data, corners: QuadCorners) -> Data? {
+    guard let image = UIImage(data: rawJPEG),
+      let corrected = ImageUtilities.perspectiveCorrected(
+        from: image, corners: corners, maxDimension: .greatestFiniteMagnitude)
+    else {
+      return nil
+    }
+    return ImageUtilities.normalizedJPEG(
+      from: corrected, maxDimension: .greatestFiniteMagnitude, quality: 0.9)
   }
 
   /// Synthetic candidate for an image obtained without a detect-frame round
   /// trip — the barcode lookup's box image is already a clean product shot,
-  /// so the whole image *is* the trim: identity corners, confidence 1.0
-  /// (suppressing the low-confidence banner), and the same JPEG as its own
-  /// zoom source (the identity re-warp is a no-op crop).
+  /// so the whole image *is* the trim: it stands as its own crop (the identity
+  /// warp would be a no-op), identity corners, confidence 1.0 (suppressing the
+  /// low-confidence banner), and the same JPEG as its own zoom source.
   static func wholeImage(jpeg: Data, source: CaptureSource, pieceCountEstimate: Int? = nil)
     -> TrimCandidate
   {
@@ -59,7 +91,9 @@ struct TrimCandidate {
       rawJPEG: jpeg,
       zoomSourceJPEG: jpeg,
       detection: DetectFrameResponse(
-        trimmedImage: "data:image/jpeg;base64,\(jpeg.base64EncodedString())",
+        // This path never talks to detect-frame, so there is no server crop to
+        // carry — `trimmedJPEG` below is the image itself.
+        trimmedImage: nil,
         corners: QuadCorners(
           topLeft: NormalizedPoint(x: 0, y: 0),
           topRight: NormalizedPoint(x: 1, y: 0),
@@ -70,7 +104,8 @@ struct TrimCandidate {
       ),
       source: source,
       // The count rides in on the lookup response, not the detection.
-      pieceCountEstimate: pieceCountEstimate
+      pieceCountEstimate: pieceCountEstimate,
+      trimmedJPEG: jpeg
     )
   }
 }

--- a/ios/Pussel/Features/Capture/ConfirmTrimView.swift
+++ b/ios/Pussel/Features/Capture/ConfirmTrimView.swift
@@ -21,8 +21,8 @@ struct ConfirmTrimView: View {
   @State private var didPlayHint = false
   let candidate: TrimCandidate
   /// Decoded once at init rather than in `body`, which re-runs on every
-  /// rotate tap (base64-decoding the data URL and the JPEG each time would be
-  /// wasteful during the rotation animation).
+  /// rotate tap (decoding the JPEG each time would be wasteful during the
+  /// rotation animation).
   private let previewImage: UIImage?
 
   init(candidate: TrimCandidate) {
@@ -129,11 +129,11 @@ struct ConfirmTrimView: View {
           }
           .buttonStyle(.borderedProminent)
           .controlSize(.large)
-          // Gate on the cached preview (not the base64-decoding
-          // `trimmedJPEG` computed property) so this doesn't re-decode
-          // on every rotate tap and stays disabled exactly when the
-          // preview can't be shown — and on a valid piece count, since the
-          // grid estimate (and thus overlay marker sizing) depends on it.
+          // Gate on the cached preview rather than re-decoding
+          // `candidate.trimmedJPEG`, so this doesn't decode a JPEG on every
+          // rotate tap and stays disabled exactly when the preview can't be
+          // shown — and on a valid piece count, since the grid estimate (and
+          // thus overlay marker sizing) depends on it.
           .disabled(previewImage == nil || pieceCount == nil)
         }
       }

--- a/ios/Pussel/Features/Capture/GlareFree/GlareFreeCaptureController.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/GlareFreeCaptureController.swift
@@ -33,9 +33,18 @@ struct GlareFreeShot {
 /// then four corner shots that fire automatically — the guide dot is
 /// anchored to a fixed spot on the puzzle (`ingestGuide`), and once the
 /// user has steered it into the screen-center ring and held it there, the
-/// step's photo is taken and the next anchor lights up. A background
-/// composition pass (`GlareFreeComposer`) then fuses the burst.
-/// Dependency-injected capture and compose closures keep it unit-testable
+/// step's photo is taken and the next anchor lights up.
+///
+/// Composition (`GlareFreeComposer.Session`) runs *alongside* the capture
+/// rather than after it: the center shot opens the session, each corner
+/// shot is handed over the moment it lands and starts registering in the
+/// background, and the last step only waits for the frames still in flight
+/// plus the healing and rectification that genuinely need the whole burst.
+/// The seconds the user spends aiming at the next target are seconds the
+/// registration would otherwise have made them wait for afterwards, under a
+/// spinner.
+///
+/// Dependency-injected capture and session closures keep it unit-testable
 /// without a camera — mirrors `PieceScanController`.
 @Observable
 @MainActor
@@ -77,11 +86,20 @@ final class GlareFreeCaptureController {
   /// a nil offset means tracking is currently lost.
   private(set) var guide: GlareGuideUpdate?
 
+  /// Opens the composition for a burst from its reference shot and that
+  /// shot's camera geometry; nil when the reference is unusable.
+  typealias SessionFactory = (UIImage, PlaneCaptureGeometry?) async -> (
+    any GlareFreeComposeSession
+  )?
+
   private let capture: () async -> GlareFreeShot?
-  private let compose:
-    (UIImage, [UIImage], [CGSize?], [PlaneCaptureGeometry?]) async ->
-      GlareFreeComposer.Composite?
+  private let makeSession: SessionFactory
   private var captured: [GlareFreeShot] = []
+  /// The composition in progress, opened by the center shot. Nil before it
+  /// and after a restart, and also when the reference shot turned out to be
+  /// unusable — the flow then degrades to that shot alone, as it always did
+  /// when composition failed.
+  private var session: (any GlareFreeComposeSession)?
   private var aim = GlareAimStabilityTracker()
 
   #if DEBUG
@@ -92,20 +110,19 @@ final class GlareFreeCaptureController {
     static weak var debugActive: GlareFreeCaptureController?
   #endif
 
+  /// `session` opens the composition for a burst from its reference shot.
+  /// Detached by default: building it downscales the still and blurs the
+  /// two registration proxies, which has no business on the main actor.
   init(
     capture: @escaping () async -> GlareFreeShot?,
-    compose:
-      @escaping (UIImage, [UIImage], [CGSize?], [PlaneCaptureGeometry?]) async ->
-      GlareFreeComposer.Composite? = { reference, others, expectedShifts, geometries in
-        await Task.detached(priority: .userInitiated) {
-          GlareFreeComposer.compose(
-            reference: reference, others: others, expectedShifts: expectedShifts,
-            geometries: geometries)
-        }.value
-      }
+    session: @escaping SessionFactory = { reference, geometry in
+      await Task.detached(priority: .userInitiated) {
+        GlareFreeComposer.Session(reference: reference, geometry: geometry)
+      }.value
+    }
   ) {
     self.capture = capture
-    self.compose = compose
+    self.makeSession = session
   }
 
   var currentStep: GlareFreeStep? {
@@ -155,10 +172,11 @@ final class GlareFreeCaptureController {
     Task { await self.captureShot() }
   }
 
-  /// Takes the current step's photo and advances; the last step triggers
-  /// composition. Fired by the shutter button on the reference step and by
-  /// the aim dwell on the corner steps; shots while one is already
-  /// developing are ignored, so each step captures exactly once.
+  /// Takes the current step's photo, hands it to the composition, and
+  /// advances; the last step waits for that composition to finish. Fired by
+  /// the shutter button on the reference step and by the aim dwell on the
+  /// corner steps; shots while one is already developing are ignored, so
+  /// each step captures exactly once.
   func captureShot() async {
     guard case .capturing(let index) = phase, !isCapturing else { return }
     isCapturing = true
@@ -171,29 +189,45 @@ final class GlareFreeCaptureController {
     if index == 0 {
       referenceShot = shot.image
     }
-    guard index + 1 < Self.steps.count else {
-      await composeCaptured()
-      return
+    let isLast = index + 1 == Self.steps.count
+    if !isLast {
+      // Light the next anchor up *before* the shot goes off to register, so
+      // the user starts aiming while it does. Re-arming the aim matters as
+      // much: the stale dot would otherwise still sit at the screen center
+      // and instantly re-fire.
+      aim.reset()
+      guide = nil
+      phase = .capturing(step: index + 1)
     }
-    // Re-arm the aim for the next anchor; the stale dot would otherwise
-    // still sit at the screen center and instantly re-fire.
-    aim.reset()
-    guide = nil
-    phase = .capturing(step: index + 1)
+    if index == 0 {
+      // The center shot is the frame every other one registers onto, so
+      // preparing it gates all four registrations and is awaited here,
+      // which also keeps `addFrame` in capture order. Nothing can fire
+      // meanwhile — `isCapturing` is still set — and it lands well inside
+      // the seconds the user spends aiming at the first corner.
+      session = await makeSession(shot.image, shot.geometry)
+    } else {
+      session?.addFrame(
+        shot.image, expectedShift: Self.expectedShift(step: index), geometry: shot.geometry)
+    }
+    if isLast {
+      await composeCaptured()
+    }
   }
 
   private func composeCaptured() async {
     phase = .composing
     let reference = captured[0].image
-    let others = captured.dropFirst().map(\.image)
-    let geometries = captured.map(\.geometry)
-    let shifts = (1..<Self.steps.count).map(Self.expectedShift(step:))
-    // A composer failure still leaves the reference shot — degrade to a
-    // normal single-photo capture rather than dead-ending the flow. The
-    // view surfaces the degradation via `alignedFrameCount == 0`.
+    // Whatever is still registering, plus the healing and rectification
+    // that need the whole burst. A composition failure — or a reference
+    // shot too broken to open a session with — still leaves the reference
+    // shot: degrade to a normal single-photo capture rather than
+    // dead-ending the flow. The view surfaces the degradation via
+    // `alignedFrameCount == 0`.
     let result =
-      await compose(reference, others, shifts, geometries)
+      await session?.finish()
       ?? GlareFreeComposer.Composite(image: reference, alignedFrameCount: 0)
+    session = nil
     composite = result
     phase = .done
     // Fire-and-forget on a detached task: the flow shouldn't wait on disk
@@ -202,8 +236,12 @@ final class GlareFreeCaptureController {
     // async body happens to execute under the current language mode. The
     // whole call is compiled out of Release builds rather than relying on
     // `record`'s own internal no-op, so production never even spawns the
-    // task.
+    // task. The dump gets the burst exactly as it was shot — the original
+    // full-resolution stills, not the composer's working copies.
     #if DEBUG
+      let others = captured.dropFirst().map(\.image)
+      let geometries = captured.map(\.geometry)
+      let shifts = (1..<Self.steps.count).map(Self.expectedShift(step:))
       Task.detached(priority: .utility) {
         await GlareFreeDump.record(
           reference: reference, others: others, expectedShifts: shifts,
@@ -214,8 +252,12 @@ final class GlareFreeCaptureController {
   }
 
   /// Restarts the five-shot sequence (offered after a failed capture).
+  /// Whatever the abandoned burst still had registering is cancelled — its
+  /// frames belong to a reference shot the next burst won't share.
   func restart() {
     guard !isCapturing else { return }
+    session?.cancel()
+    session = nil
     captured = []
     composite = nil
     referenceShot = nil

--- a/ios/Pussel/Features/Capture/GlareFree/GlareFreeComposer.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/GlareFreeComposer.swift
@@ -126,8 +126,12 @@ enum GlareFreeComposer {
   // reuses the same `CIContext` for its own `createCGImage` calls.
   static let context = CIContext()
 
-  /// Builds the glare-free composite. Synchronous and heavy (a few seconds
-  /// for five frames) — call it off the main actor.
+  /// Builds the glare-free composite in one synchronous, heavy call (a few
+  /// seconds for five frames) — call it off the main actor. The guided
+  /// capture flow drives `Session` instead, which does the same work but
+  /// starts each frame's registration as its shot lands; this entry point
+  /// is the whole burst at once, for callers that have one already (the
+  /// tests, and the dump replays).
   ///
   /// `expectedShifts` optionally carries, per extra frame, the content
   /// displacement the guided capture flow expects (unit coordinates,
@@ -154,64 +158,26 @@ enum GlareFreeComposer {
     reference: UIImage, others: [UIImage], expectedShifts: [CGSize?]? = nil,
     geometries: [PlaneCaptureGeometry?]? = nil
   ) -> Composite? {
-    guard let referenceCG = downscaledUpright(reference),
-      let referenceProxies = registrationProxies(of: referenceCG)
+    guard let session = Session(reference: reference, geometry: geometries?.first.flatMap({ $0 }))
     else { return nil }
-    let extent = CGRect(x: 0, y: 0, width: referenceCG.width, height: referenceCG.height)
-    let referenceImage = CIImage(cgImage: referenceCG)
-    let rectifier = Rectifier(geometries: geometries, referenceWidth: referenceCG.width)
-
-    // Registration is unchanged from the plain min-composite pipeline: each
-    // frame that registers and passes `alignmentError`'s verification gate
-    // (inside `homography`/`refined`) contributes its warped image here,
-    // UNFILLED (transparent, not white, outside its own footprint) —
-    // filling gaps is now `healedComposite`'s job, which needs to tell
-    // "white because glare-free" apart from "white because unfilled".
-    var verifiedFrames: [CIImage] = []
-    let referenceGeometry = geometries?.first.flatMap { $0 }
+    // The same session the capture flow drives, only run inline: each frame
+    // is registered on the calling thread, in call order, rather than on its
+    // own task. Registration frames are independent of one another, so
+    // running them serially or concurrently produces the same composite —
+    // this way round keeps the entry point synchronous.
+    var registered: [RegisteredFrame] = []
     for (index, other) in others.enumerated() {
       let expectedShift = expectedShifts.flatMap { $0.indices.contains(index) ? $0[index] : nil }
-      let floatingGeometry = geometries.flatMap {
+      let geometry = geometries.flatMap {
         $0.indices.contains(index + 1) ? $0[index + 1] : nil
       }
-      // Both ends or neither: a seed needs the pose of the frame it starts
-      // from *and* the one it aims at.
-      let planePoses = floatingGeometry.flatMap { floating in
-        referenceGeometry.map { (floating: floating, reference: $0) }
-      }
-      guard let otherCG = downscaledUpright(other),
-        let warp = homography(
-          mapping: otherCG, ontoReferenceProxies: referenceProxies,
-          expectedShift: expectedShift, planePoses: planePoses),
-        let warped = warpedImage(otherCG, by: warp)
+      guard
+        let frame = session.registeredFrame(
+          other, expectedShift: expectedShift, geometry: geometry)
       else { continue }
-      verifiedFrames.append(warped.cropped(to: extent))
+      registered.append(frame)
     }
-
-    guard !verifiedFrames.isEmpty else {
-      guard let output = rectifier.render(referenceImage, extent: extent) else { return nil }
-      return Composite(image: output, alignedFrameCount: 0)
-    }
-
-    guard
-      let healed = healedComposite(
-        reference: referenceImage, verifiedFrames: verifiedFrames, extent: extent)
-    else {
-      // The masked-healing math failed outright (an unexpected Core
-      // Graphics allocation failure, say) — fall back to the reference
-      // alone rather than losing the whole capture. `alignedFrameCount`
-      // reports 0, not how many frames registered: it counts frames whose
-      // pixels reached the output, and none of the extra frames' did. It is
-      // not a claim that the output *is* the reference byte for byte — the
-      // reference's own pixels are here, and are still plane-rectified. 0 is
-      // what the capture view keys its "used the center photo as-is"
-      // degradation message on.
-      guard let output = rectifier.render(referenceImage, extent: extent) else { return nil }
-      return Composite(image: output, alignedFrameCount: 0)
-    }
-    let healedImage = healed.cgImage.map(CIImage.init(cgImage:)) ?? referenceImage
-    guard let output = rectifier.render(healedImage, extent: extent) else { return nil }
-    return Composite(image: output, alignedFrameCount: verifiedFrames.count)
+    return session.composite(from: registered)
   }
 
   // MARK: - Plane rectification
@@ -658,5 +624,165 @@ enum GlareFreeComposer {
       image.draw(in: CGRect(origin: .zero, size: targetSize))
     }
     return upright.cgImage
+  }
+}
+
+/// The incremental compositing surface the guided capture flow drives —
+/// `GlareFreeComposer.Session` in production, a recording stand-in in the
+/// controller's tests, which have no Vision to run.
+protocol GlareFreeComposeSession: AnyObject {
+  /// Hands over one corner frame; registration starts immediately and runs
+  /// in the background, so the caller can go on capturing.
+  func addFrame(_ image: UIImage, expectedShift: CGSize?, geometry: PlaneCaptureGeometry?)
+  /// Awaits every frame handed over so far, then fuses them.
+  func finish() async -> GlareFreeComposer.Composite?
+  /// Abandons the burst: outstanding registrations are cancelled and their
+  /// results discarded.
+  func cancel()
+}
+
+// MARK: - Incremental compositing
+
+extension GlareFreeComposer {
+  /// One frame's registration result, on its way out of the detached task
+  /// that produced it. The wrapper exists only to carry a `CIImage` — which
+  /// predates `Sendable` and declares no conformance — across that task's
+  /// boundary; each is built inside its own task and read exactly once,
+  /// after that task has finished.
+  struct RegisteredFrame: @unchecked Sendable {
+    let image: CIImage
+  }
+
+  /// `compose` spread out over the capture it fuses: the reference is
+  /// prepared as soon as the center shot lands, and each corner frame is
+  /// registered onto it the moment that corner is shot, on its own task.
+  ///
+  /// The four registrations are what makes `compose` slow (Vision's
+  /// bootstrap plus up to six refinement passes, per frame), they are
+  /// independent of one another, and the capture flow spends seconds
+  /// between shots waiting for the user to aim — so running them
+  /// concurrently, as the burst arrives, hides nearly all of that cost
+  /// behind the capture. Only the parts that genuinely need the whole burst
+  /// (masked healing and plane rectification) are left for `finish`.
+  ///
+  /// Nothing about the per-frame pipeline changes: `registeredFrame` is the
+  /// body of the old serial loop, called from a task instead of inline, and
+  /// `composite` is the old tail. The synchronous `compose` above runs the
+  /// same two through this same type.
+  final class Session: GlareFreeComposeSession {
+    private let referenceImage: CIImage
+    private let referenceProxies: RegistrationProxies
+    private let referenceGeometry: PlaneCaptureGeometry?
+    private let extent: CGRect
+    private let rectifier: Rectifier
+    /// One entry per `addFrame`, in call order — `finish` collects them by
+    /// index, so a burst's composite doesn't depend on which registration
+    /// happened to land first.
+    private var registrations: [Task<RegisteredFrame?, Never>] = []
+
+    /// Prepares the reference frame: the downscale and the two blurred
+    /// registration proxies every corner frame is registered against, done
+    /// once here rather than per frame. Heavy — construct it off the main
+    /// actor. Fails exactly where `compose` fails on its reference, and
+    /// means the same thing: the reference shot is unusable.
+    ///
+    /// `geometry` is the reference shot's own camera geometry; the corner
+    /// shots' come in with them. Only the reference's decides the
+    /// rectification, since it is the frame everything else is registered
+    /// onto.
+    init?(reference: UIImage, geometry: PlaneCaptureGeometry?) {
+      guard let referenceCG = GlareFreeComposer.downscaledUpright(reference),
+        let proxies = GlareFreeComposer.registrationProxies(of: referenceCG)
+      else { return nil }
+      self.referenceImage = CIImage(cgImage: referenceCG)
+      self.referenceProxies = proxies
+      self.referenceGeometry = geometry
+      self.extent = CGRect(x: 0, y: 0, width: referenceCG.width, height: referenceCG.height)
+      self.rectifier = Rectifier(geometries: [geometry], referenceWidth: referenceCG.width)
+    }
+
+    func addFrame(_ image: UIImage, expectedShift: CGSize?, geometry: PlaneCaptureGeometry?) {
+      registrations.append(
+        Task.detached(priority: .userInitiated) { [self] in
+          // A frame cancelled before its task ever started is simply
+          // dropped; one already inside Vision runs to completion and has
+          // its result discarded by `cancel`, which is cheap enough — the
+          // burst it belonged to is over either way.
+          guard !Task.isCancelled else { return nil }
+          return registeredFrame(image, expectedShift: expectedShift, geometry: geometry)
+        })
+    }
+
+    func finish() async -> Composite? {
+      var registered: [RegisteredFrame] = []
+      for registration in registrations {
+        guard let frame = await registration.value else { continue }
+        registered.append(frame)
+      }
+      registrations = []
+      return composite(from: registered)
+    }
+
+    func cancel() {
+      for registration in registrations { registration.cancel() }
+      registrations = []
+    }
+
+    /// Registers one corner frame onto the reference, unchanged from the
+    /// serial composer's loop body: downscale, seek the homography (same
+    /// seed hypotheses, same verification gate), warp, crop.
+    ///
+    /// The returned frame is UNFILLED — transparent, not white, outside its
+    /// own footprint. Filling the gaps is `healedComposite`'s job, which
+    /// needs to tell "white because glare-free" apart from "white because
+    /// unfilled". A frame that fails to register (Vision throws, or
+    /// refinement never converges, or the converged warp fails
+    /// verification) comes back nil and is skipped: a glare-free result
+    /// from three frames still beats the single reference shot.
+    fileprivate func registeredFrame(
+      _ image: UIImage, expectedShift: CGSize?, geometry: PlaneCaptureGeometry?
+    ) -> RegisteredFrame? {
+      // Both ends or neither: a seed needs the pose of the frame it starts
+      // from *and* the one it aims at.
+      let planePoses = geometry.flatMap { floating in
+        referenceGeometry.map { (floating: floating, reference: $0) }
+      }
+      guard let floatingCG = GlareFreeComposer.downscaledUpright(image),
+        let warp = GlareFreeComposer.homography(
+          mapping: floatingCG, ontoReferenceProxies: referenceProxies,
+          expectedShift: expectedShift, planePoses: planePoses),
+        let warped = GlareFreeComposer.warpedImage(floatingCG, by: warp)
+      else { return nil }
+      return RegisteredFrame(image: warped.cropped(to: extent))
+    }
+
+    /// Fuses the frames that registered — masked healing, then plane
+    /// rectification — into the finished composite.
+    fileprivate func composite(from registered: [RegisteredFrame]) -> Composite? {
+      let verifiedFrames = registered.map(\.image)
+      guard !verifiedFrames.isEmpty else {
+        guard let output = rectifier.render(referenceImage, extent: extent) else { return nil }
+        return Composite(image: output, alignedFrameCount: 0)
+      }
+      guard
+        let healed = GlareFreeComposer.healedComposite(
+          reference: referenceImage, verifiedFrames: verifiedFrames, extent: extent)
+      else {
+        // The masked-healing math failed outright (an unexpected Core
+        // Graphics allocation failure, say) — fall back to the reference
+        // alone rather than losing the whole capture. `alignedFrameCount`
+        // reports 0, not how many frames registered: it counts frames whose
+        // pixels reached the output, and none of the extra frames' did. It is
+        // not a claim that the output *is* the reference byte for byte — the
+        // reference's own pixels are here, and are still plane-rectified. 0 is
+        // what the capture view keys its "used the center photo as-is"
+        // degradation message on.
+        guard let output = rectifier.render(referenceImage, extent: extent) else { return nil }
+        return Composite(image: output, alignedFrameCount: 0)
+      }
+      let healedImage = healed.cgImage.map(CIImage.init(cgImage:)) ?? referenceImage
+      guard let output = rectifier.render(healedImage, extent: extent) else { return nil }
+      return Composite(image: output, alignedFrameCount: verifiedFrames.count)
+    }
   }
 }

--- a/ios/Pussel/Features/Capture/GlareFree/GlareFreeMaskedHealing.swift
+++ b/ios/Pussel/Features/Capture/GlareFree/GlareFreeMaskedHealing.swift
@@ -1,3 +1,4 @@
+import Accelerate
 import CoreGraphics
 import CoreImage
 import Foundation
@@ -14,7 +15,39 @@ import UIKit
 /// itself over SwiftLint's `type_body_length` ceiling; the masked-healing
 /// tunable constants stay declared on `GlareFreeComposer` itself, next to
 /// its other constants, as the single source of truth callers reference.
+///
+/// Every per-pixel step below runs through Accelerate (vDSP/vImage) rather
+/// than a hand-written Swift loop. That is a pure performance change --
+/// vDSP and vImage read and write the raw buffers handed to them with no
+/// colorspace interpretation whatsoever, so the sRGB-encoded-bytes domain
+/// this recipe depends on (see `healedComposite` and `GrayMap`) is
+/// untouched, unlike Core Image's compositing filters, which would
+/// linearize. The vector formulations are written to reproduce the scalar
+/// arithmetic's operand order, so results are bit-identical apart from the
+/// odd last-place difference where Accelerate contracts a multiply-add.
+/// This matters more than it looks: the app's own test host and every
+/// debug build run this code unoptimized, where a bounds-checked Swift
+/// loop over three million pixels costs roughly ten times what the same
+/// loop costs at `-O`, while an Accelerate call costs the same either way.
 extension GlareFreeComposer {
+  /// How many pixels each vectorized pass over a full-resolution frame
+  /// handles at a time. The float scratch planes the RGBA8 passes
+  /// de-interleave into are sized per span rather than per frame, which
+  /// keeps them a few megabytes (and mostly cache-resident) instead of
+  /// scaling with a 2048x1536 working buffer.
+  static let vectorSpanPixels = 1 << 18
+
+  /// One such span being worked on: a base pointer into a block of equally
+  /// sized scratch float planes, plus how many pixels the span covers. The
+  /// helpers below address the planes by index, which keeps their operand
+  /// lists down to the buffers they actually read and write.
+  struct VectorSpan {
+    let work: UnsafeMutablePointer<Float>
+    let count: Int
+    var size: vDSP_Length { vDSP_Length(count) }
+    func plane(_ index: Int) -> UnsafeMutablePointer<Float> { work + index * count }
+  }
+
   /// Runs the masked-healing recipe over `verifiedFrames` and blends the
   /// result over `reference`. Returns nil only on an unexpected Core
   /// Image/Graphics failure (a bitmap render or allocation coming back
@@ -105,33 +138,50 @@ extension GlareFreeComposer {
   /// A top-left-origin, row-major sRGB RGBA8 pixel buffer — the
   /// masked-healing math's representation of a full-resolution frame.
   /// Built once per frame via `rgbaBuffer(of:extent:)` and combined/blended
-  /// with plain array arithmetic, deliberately bypassing Core Image's own
-  /// (linear) compositing filters — see `healedComposite`'s docs for why.
+  /// with vDSP/vImage passes over the raw bytes, deliberately bypassing
+  /// Core Image's own (linear) compositing filters — see `healedComposite`'s
+  /// docs for why.
   struct RGBABuffer {
+    /// The alpha at which a warped frame counts as covering a pixel, read
+    /// from the frame's own alpha channel (`CIFilter.perspectiveTransform`'s
+    /// output is transparent outside the mapped quad). A firm threshold
+    /// rather than `> 0` sidesteps a thin ring of partial-alpha edge pixels
+    /// the warp's resampling can leave right at the quad boundary.
+    static let coveringAlpha: Float = 128
+
     let width: Int
     let height: Int
     /// `width * height * 4` bytes, RGBA, top-left-origin, row-major.
     var bytes: [UInt8]
 
-    /// Whether pixel `index` (0..<width*height) is inside this frame's own
-    /// warped footprint, read from its own alpha channel
-    /// (`CIFilter.perspectiveTransform`'s output is transparent outside
-    /// the mapped quad). A firm threshold rather than `> 0` sidesteps a
-    /// thin ring of partial-alpha edge pixels the warp's resampling can
-    /// leave right at the quad boundary.
-    func covers(_ index: Int) -> Bool { bytes[index * 4 + 3] >= 128 }
-
     /// Multiplies RGB by `gain`, clamped to a valid byte range; leaves
     /// alpha (coverage) untouched. Mirrors `stitch.py`'s
     /// `compute_gain_factor` application: `np.clip(warped * gain, 0, 255)`.
+    ///
+    /// `gain` is one scalar for the whole frame, so every byte value's
+    /// result is precomputed into a 256-entry table -- with exactly the
+    /// scalar expression this used to evaluate per pixel, making the
+    /// result bit-identical -- and applied in a single vImage lookup pass.
+    /// Alpha goes through an identity table, i.e. is copied unchanged.
     mutating func applyGain(_ gain: Float) {
       guard gain != 1 else { return }
-      for pixel in 0..<(width * height) {
-        let base = pixel * 4
-        for channel in 0..<3 {
-          let value = Float(bytes[base + channel]) * gain
-          bytes[base + channel] = UInt8(max(0, min(255, value)).rounded())
-        }
+      var gained = [UInt8](repeating: 0, count: 256)
+      var identity = [UInt8](repeating: 0, count: 256)
+      for value in 0..<256 {
+        gained[value] = UInt8(max(0, min(255, Float(value) * gain)).rounded())
+        identity[value] = UInt8(value)
+      }
+      let (spanWidth, spanHeight) = (width, height)
+      bytes.withUnsafeMutableBufferPointer { raw in
+        var source = vImage_Buffer(
+          data: raw.baseAddress, height: vImagePixelCount(spanHeight),
+          width: vImagePixelCount(spanWidth), rowBytes: spanWidth * 4)
+        var destination = source
+        // The tables are applied in memory order, so for this buffer's
+        // RGBA layout that is R, G, B and then (identity) A.
+        _ = vImageTableLookUp_ARGB8888(
+          &source, &destination, gained, gained, gained, identity,
+          vImage_Flags(kvImageNoFlags))
       }
     }
 
@@ -142,19 +192,58 @@ extension GlareFreeComposer {
     /// stays fully opaque in the result — the masked-healing composite is
     /// always meant to be viewed as a normal opaque photo.
     func blended(with other: RGBABuffer, alpha: [Float]) -> RGBABuffer {
-      var result = self
-      for pixel in 0..<(width * height) {
-        let base = pixel * 4
-        let weight = alpha[pixel]
-        for channel in 0..<3 {
-          let mine = Float(bytes[base + channel])
-          let theirs = Float(other.bytes[base + channel])
-          result.bytes[base + channel] = UInt8(
-            max(0, min(255, mine * (1 - weight) + theirs * weight)).rounded())
+      let count = width * height
+      // Seeded opaque, so the alpha byte no channel pass writes is already
+      // the 255 this blend promises.
+      var output = [UInt8](repeating: 255, count: count * 4)
+      let span = min(count, GlareFreeComposer.vectorSpanPixels)
+      var work = [Float](repeating: 0, count: 4 * span)
+      bytes.withUnsafeBufferPointer { mine in
+        other.bytes.withUnsafeBufferPointer { theirs in
+          alpha.withUnsafeBufferPointer { weight in
+            output.withUnsafeMutableBufferPointer { destination in
+              work.withUnsafeMutableBufferPointer { scratch in
+                var first = 0
+                while first < count {
+                  let run = min(span, count - first)
+                  Self.blendSpan(
+                    mine: mine.baseAddress! + first * 4, theirs: theirs.baseAddress! + first * 4,
+                    weight: weight.baseAddress! + first,
+                    into: destination.baseAddress! + first * 4,
+                    span: VectorSpan(work: scratch.baseAddress!, count: run))
+                  first += run
+                }
+              }
+            }
+          }
         }
-        result.bytes[base + 3] = 255
       }
-      return result
+      return RGBABuffer(width: width, height: height, bytes: output)
+    }
+
+    /// One `blended` span: each of the three color channels is
+    /// de-interleaved into a float plane, lerped, and written back
+    /// interleaved. Uses four of `span`'s scratch planes.
+    private static func blendSpan(
+      mine: UnsafePointer<UInt8>, theirs: UnsafePointer<UInt8>, weight: UnsafePointer<Float>,
+      into output: UnsafeMutablePointer<UInt8>, span: VectorSpan
+    ) {
+      let size = span.size
+      let (reference, healed) = (span.plane(0), span.plane(1))
+      let (inverse, blend) = (span.plane(2), span.plane(3))
+      var (low, high, half, one, negated) = (Float(0), Float(255), Float(0.5), Float(1), Float(-1))
+      vDSP_vsmsa(weight, 1, &negated, &one, inverse, 1, size)
+      for channel in 0..<3 {
+        vDSP_vfltu8(mine + channel, 4, reference, 1, size)
+        vDSP_vfltu8(theirs + channel, 4, healed, 1, size)
+        vDSP_vmma(reference, 1, inverse, 1, healed, 1, weight, 1, blend, 1, size)
+        vDSP_vclip(blend, 1, &low, &high, blend, 1, size)
+        // Adding a half and truncating is exactly `.rounded()` (which
+        // rounds halves away from zero) on the clamped, non-negative
+        // value, so this reproduces the scalar `UInt8` conversion.
+        vDSP_vsadd(blend, 1, &half, blend, 1, size)
+        vDSP_vfixu8(blend, 1, output + channel, 4, size)
+      }
     }
 
     /// Builds a `CGImage` directly from this buffer's raw bytes — row-
@@ -181,19 +270,39 @@ extension GlareFreeComposer {
     }
 
     /// Derives this buffer's gray+coverage representation directly from
-    /// its own RGBA bytes, with no extra Core Image render pass.
+    /// its own RGBA bytes, with no extra Core Image render pass. The three
+    /// color channels are de-interleaved straight into the weighted sum,
+    /// one strided byte-to-float conversion each, accumulated in the same
+    /// left-to-right order the scalar expression used.
     func grayMap() -> GrayMap {
-      var values = [Float](repeating: 0, count: width * height)
-      var coverage = [Bool](repeating: false, count: width * height)
-      for pixel in 0..<values.count {
-        let base = pixel * 4
-        let red = Float(bytes[base])
-        let green = Float(bytes[base + 1])
-        let blue = Float(bytes[base + 2])
-        // `cv2.cvtColor(..., COLOR_BGR2GRAY)`'s weights -- matched exactly
-        // so the brightness thresholds below mean what `stitch.py` intends.
-        values[pixel] = 0.299 * red + 0.587 * green + 0.114 * blue
-        coverage[pixel] = bytes[base + 3] >= 128
+      let count = width * height
+      var values = [Float](repeating: 0, count: count)
+      var coverage = [Bool](repeating: false, count: count)
+      var channel = [Float](repeating: 0, count: count)
+      bytes.withUnsafeBufferPointer { source in
+        let base = source.baseAddress!
+        let size = vDSP_Length(count)
+        values.withUnsafeMutableBufferPointer { gray in
+          channel.withUnsafeMutableBufferPointer { plane in
+            let (out, band) = (gray.baseAddress!, plane.baseAddress!)
+            // `cv2.cvtColor(..., COLOR_BGR2GRAY)`'s weights -- matched
+            // exactly so the brightness thresholds below mean what
+            // `stitch.py` intends.
+            var (red, green, blue) = (Float(0.299), Float(0.587), Float(0.114))
+            vDSP_vfltu8(base, 4, out, 1, size)
+            vDSP_vsmul(out, 1, &red, out, 1, size)
+            vDSP_vfltu8(base + 1, 4, band, 1, size)
+            vDSP_vsma(band, 1, &green, out, 1, out, 1, size)
+            vDSP_vfltu8(base + 2, 4, band, 1, size)
+            vDSP_vsma(band, 1, &blue, out, 1, out, 1, size)
+          }
+        }
+        // Coverage stays a scalar pass: it is one byte compare per pixel
+        // into a `[Bool]`, with nothing for vDSP to accumulate.
+        let threshold = UInt8(RGBABuffer.coveringAlpha)
+        coverage.withUnsafeMutableBufferPointer { covered in
+          for pixel in 0..<count { covered[pixel] = base[pixel * 4 + 3] >= threshold }
+        }
       }
       return GrayMap(width: width, height: height, values: values, coverage: coverage)
     }
@@ -202,31 +311,81 @@ extension GlareFreeComposer {
   /// The gain-corrected min-composite: the darkest RGB any covering frame
   /// observed at each pixel, falling back to `reference` wherever no
   /// frame covers at all. Mirrors `stitch.py`'s
-  /// `build_gain_corrected_min_composite` (its white-seeded running
-  /// minimum is mathematically the same thing: the first covering frame's
-  /// own value can only ever be <= white, so seeding directly with it
-  /// instead is equivalent and skips a redundant comparison).
+  /// `build_gain_corrected_min_composite`, and now literally shares its
+  /// white-seeded shape: every frame's non-covering pixels are lifted to
+  /// white before the running minimum, which is what lets the whole
+  /// per-pixel coverage conditional become a branch-free vDSP pass (a
+  /// white sample can never win a minimum against a real one, and the
+  /// pixels no frame covered at all are selected back to the reference at
+  /// the end). Runs a span at a time; see `vectorSpanPixels`.
   static func buildMinStack(reference: RGBABuffer, frames: [RGBABuffer]) -> RGBABuffer {
-    var stack = reference
-    var coveredAny = [Bool](repeating: false, count: reference.width * reference.height)
-    for frame in frames {
-      for pixel in 0..<(reference.width * reference.height) {
-        guard frame.covers(pixel) else { continue }
-        let base = pixel * 4
-        if coveredAny[pixel] {
-          for channel in 0..<3 {
-            stack.bytes[base + channel] = min(
-              stack.bytes[base + channel], frame.bytes[base + channel])
-          }
-        } else {
-          for channel in 0..<3 {
-            stack.bytes[base + channel] = frame.bytes[base + channel]
-          }
-          coveredAny[pixel] = true
+    guard !frames.isEmpty else { return reference }
+    let count = reference.width * reference.height
+    // Seeded from the reference so the alpha channel (which no pass below
+    // writes) carries the reference's own coverage, as it always has.
+    var output = reference.bytes
+    let span = min(count, vectorSpanPixels)
+    var work = [Float](repeating: 0, count: 7 * span)
+    output.withUnsafeMutableBufferPointer { destination in
+      work.withUnsafeMutableBufferPointer { scratch in
+        var first = 0
+        while first < count {
+          let run = min(span, count - first)
+          minStackSpan(
+            reference: reference, frames: frames, first: first,
+            into: destination.baseAddress! + first * 4,
+            span: VectorSpan(work: scratch.baseAddress!, count: run))
+          first += run
         }
       }
     }
-    return stack
+    return RGBABuffer(width: reference.width, height: reference.height, bytes: output)
+  }
+
+  /// One `buildMinStack` span, using seven of `span`'s scratch planes: the
+  /// current frame's "missing" mask, the running "no frame has covered this
+  /// yet" mask, two working planes, and the three running per-channel
+  /// minima (planes 4, 5 and 6).
+  private static func minStackSpan(
+    reference: RGBABuffer, frames: [RGBABuffer], first: Int,
+    into output: UnsafeMutablePointer<UInt8>, span: VectorSpan
+  ) {
+    let size = span.size
+    let (missing, unseen) = (span.plane(0), span.plane(1))
+    let (sample, blend) = (span.plane(2), span.plane(3))
+    var (white, one, negated) = (Float(255), Float(1), Float(-1))
+    vDSP_vfill(&white, unseen, 1, size)
+    for plane in 0..<3 { vDSP_vfill(&white, span.plane(4 + plane), 1, size) }
+    for frame in frames {
+      frame.bytes.withUnsafeBufferPointer { source in
+        let base = source.baseAddress! + first * 4
+        // `missing` is 0 where this frame's own alpha says it covers and
+        // 255 where it doesn't -- the coverage conditional, as a value.
+        var (covering, magnitude, lift) = (RGBABuffer.coveringAlpha, Float(-127.5), Float(127.5))
+        vDSP_vfltu8(base + 3, 4, missing, 1, size)
+        vDSP_vlim(missing, 1, &covering, &magnitude, missing, 1, size)
+        vDSP_vsadd(missing, 1, &lift, missing, 1, size)
+        vDSP_vmin(unseen, 1, missing, 1, unseen, 1, size)
+        for plane in 0..<3 {
+          let darkest = span.plane(4 + plane)
+          vDSP_vfltu8(base + plane, 4, sample, 1, size)
+          vDSP_vmax(sample, 1, missing, 1, sample, 1, size)
+          vDSP_vmin(darkest, 1, sample, 1, darkest, 1, size)
+        }
+      }
+    }
+    // `unseen` becomes an exact 0/1 selector (and `missing`, now free, its
+    // complement), so the fallback is a plain two-term multiply-add.
+    vDSP_vsdiv(unseen, 1, &white, unseen, 1, size)
+    vDSP_vsmsa(unseen, 1, &negated, &one, missing, 1, size)
+    reference.bytes.withUnsafeBufferPointer { source in
+      let base = source.baseAddress! + first * 4
+      for plane in 0..<3 {
+        vDSP_vfltu8(base + plane, 4, sample, 1, size)
+        vDSP_vmma(span.plane(4 + plane), 1, missing, 1, sample, 1, unseen, 1, blend, 1, size)
+        vDSP_vfixu8(blend, 1, output + plane, 4, size)
+      }
+    }
   }
 
   /// Renders `image` (already sized to `extent`) to a top-left-origin,
@@ -303,30 +462,64 @@ extension GlareFreeComposer {
   /// Bilinear-upscales a flattened `fromWidth`x`fromHeight` map to
   /// `toWidth`x`toHeight` — used to bring the mask-resolution glare alpha
   /// up to compositing resolution before the final blend.
+  ///
+  /// Separated into the same two stages the per-pixel version evaluated in
+  /// (horizontal first, then vertical), but a whole row at a time. Every
+  /// output column reads the same pair of source columns with the same
+  /// pair of weights, so those are computed once and each source row is
+  /// resampled horizontally with two `vDSP_vgathr` gathers and one
+  /// multiply-add; the vertical stage is then a plain lerp between two
+  /// already-horizontal rows.
   static func upscale(
     _ values: [Float], fromWidth: Int, fromHeight: Int, toWidth: Int, toHeight: Int
   ) -> [Float] {
     guard fromWidth != toWidth || fromHeight != toHeight else { return values }
-    var output = [Float](repeating: 0, count: toWidth * toHeight)
+    var left = [vDSP_Length](repeating: 0, count: toWidth)
+    var right = [vDSP_Length](repeating: 0, count: toWidth)
+    var fraction = [Float](repeating: 0, count: toWidth)
+    var inverse = [Float](repeating: 0, count: toWidth)
     let scaleX = Float(fromWidth) / Float(toWidth)
+    for x in 0..<toWidth {
+      let srcX = (Float(x) + 0.5) * scaleX - 0.5
+      let x0 = max(0, min(fromWidth - 1, Int(floor(srcX))))
+      let x1 = min(fromWidth - 1, x0 + 1)
+      let fracX = max(0, min(1, srcX - Float(x0)))
+      // `vDSP_vgathr` indexes from 1, relative to the row it is handed.
+      (left[x], right[x]) = (vDSP_Length(x0 + 1), vDSP_Length(x1 + 1))
+      (fraction[x], inverse[x]) = (fracX, 1 - fracX)
+    }
+    var rows = [Float](repeating: 0, count: fromHeight * toWidth)
+    var gathered = [Float](repeating: 0, count: 2 * toWidth)
+    let width = vDSP_Length(toWidth)
+    values.withUnsafeBufferPointer { source in
+      rows.withUnsafeMutableBufferPointer { resampled in
+        gathered.withUnsafeMutableBufferPointer { pair in
+          let (nearer, further) = (pair.baseAddress!, pair.baseAddress! + toWidth)
+          for y in 0..<fromHeight {
+            let row = source.baseAddress! + y * fromWidth
+            vDSP_vgathr(row, left, 1, nearer, 1, width)
+            vDSP_vgathr(row, right, 1, further, 1, width)
+            vDSP_vmma(
+              nearer, 1, inverse, 1, further, 1, fraction, 1,
+              resampled.baseAddress! + y * toWidth, 1, width)
+          }
+        }
+      }
+    }
+    var output = [Float](repeating: 0, count: toWidth * toHeight)
     let scaleY = Float(fromHeight) / Float(toHeight)
-    for y in 0..<toHeight {
-      let srcY = (Float(y) + 0.5) * scaleY - 0.5
-      let y0 = max(0, min(fromHeight - 1, Int(floor(srcY))))
-      let y1 = min(fromHeight - 1, y0 + 1)
-      let fracY = max(0, min(1, srcY - Float(y0)))
-      for x in 0..<toWidth {
-        let srcX = (Float(x) + 0.5) * scaleX - 0.5
-        let x0 = max(0, min(fromWidth - 1, Int(floor(srcX))))
-        let x1 = min(fromWidth - 1, x0 + 1)
-        let fracX = max(0, min(1, srcX - Float(x0)))
-        let topLeft = values[y0 * fromWidth + x0]
-        let topRight = values[y0 * fromWidth + x1]
-        let bottomLeft = values[y1 * fromWidth + x0]
-        let bottomRight = values[y1 * fromWidth + x1]
-        let top = topLeft * (1 - fracX) + topRight * fracX
-        let bottom = bottomLeft * (1 - fracX) + bottomRight * fracX
-        output[y * toWidth + x] = top * (1 - fracY) + bottom * fracY
+    rows.withUnsafeBufferPointer { resampled in
+      output.withUnsafeMutableBufferPointer { destination in
+        for y in 0..<toHeight {
+          let srcY = (Float(y) + 0.5) * scaleY - 0.5
+          let y0 = max(0, min(fromHeight - 1, Int(floor(srcY))))
+          let y1 = min(fromHeight - 1, y0 + 1)
+          var fracY = max(0, min(1, srcY - Float(y0)))
+          var inverseY = 1 - fracY
+          let target = destination.baseAddress! + y * toWidth
+          vDSP_vsmul(resampled.baseAddress! + y0 * toWidth, 1, &inverseY, target, 1, width)
+          vDSP_vsma(resampled.baseAddress! + y1 * toWidth, 1, &fracY, target, 1, target, 1, width)
+        }
       }
     }
     return output
@@ -361,7 +554,12 @@ extension GlareFreeComposer {
     /// meaningfully read anyway.
     func scaled(by gain: Float) -> GrayMap {
       var result = self
-      result.values = values.map { max(0, min(255, $0 * gain)) }
+      var (multiplier, low, high) = (gain, Float(0), Float(255))
+      result.values.withUnsafeMutableBufferPointer { plane in
+        let (base, size) = (plane.baseAddress!, vDSP_Length(plane.count))
+        vDSP_vsmul(base, 1, &multiplier, base, 1, size)
+        vDSP_vclip(base, 1, &low, &high, base, 1, size)
+      }
       return result
     }
   }
@@ -379,6 +577,25 @@ extension GlareFreeComposer {
     let featherSigma: Float
   }
 
+  /// `coverage`'s per-pixel flags as a 0/1 float plane, so the coverage
+  /// conditionals below can be masked selects instead of branches. `Bool`
+  /// occupies a single byte, and thresholding at a half after the integer
+  /// conversion keeps that independent of which non-zero byte value the
+  /// runtime happens to store for `true`.
+  private static func coverageIndicator(
+    _ coverage: [Bool], into output: UnsafeMutablePointer<Float>, count: Int
+  ) {
+    let size = vDSP_Length(count)
+    var half = Float(0.5)
+    coverage.withUnsafeBufferPointer { flags in
+      flags.baseAddress!.withMemoryRebound(to: UInt8.self, capacity: count) { raw in
+        vDSP_vfltu8(raw, 1, output, 1, size)
+      }
+    }
+    vDSP_vlim(output, 1, &half, &half, output, 1, size)
+    vDSP_vsadd(output, 1, &half, output, 1, size)
+  }
+
   /// Median reference/warped gray ratio over covered, mid-tone pixels --
   /// one frame's exposure gain. Corrects an exposure/white-balance
   /// mismatch between a corner shot and the reference before it enters
@@ -387,18 +604,32 @@ extension GlareFreeComposer {
   /// which pixel actually has less glare. Mirrors `stitch.py`'s
   /// `compute_gain_factor`. Internal (not private) for direct unit
   /// testing.
+  ///
+  /// The qualifying-pixel scan stays scalar: it compacts a sparse,
+  /// data-dependent subset into a dense array, which has no vector form,
+  /// but it runs over raw pointers into a pre-sized buffer so neither
+  /// bounds checks nor `append`'s uniqueness check is in the loop.
   static func gainFactor(reference: GrayMap, warped: GrayMap, range: ClosedRange<Float>) -> Float {
-    var ratios: [Float] = []
-    ratios.reserveCapacity(warped.values.count)
-    for index in 0..<warped.values.count {
-      guard warped.coverage[index] else { continue }
-      let warpedValue = warped.values[index]
-      let referenceValue = reference.values[index]
-      guard range.contains(warpedValue), range.contains(referenceValue) else { continue }
-      ratios.append(referenceValue / max(warpedValue, 1))
+    var ratios = [Float](repeating: 0, count: warped.values.count)
+    var kept = 0
+    warped.values.withUnsafeBufferPointer { warpedValues in
+      reference.values.withUnsafeBufferPointer { referenceValues in
+        warped.coverage.withUnsafeBufferPointer { covered in
+          ratios.withUnsafeMutableBufferPointer { output in
+            for index in 0..<warpedValues.count {
+              guard covered[index] else { continue }
+              let warpedValue = warpedValues[index]
+              let referenceValue = referenceValues[index]
+              guard range.contains(warpedValue), range.contains(referenceValue) else { continue }
+              output[kept] = referenceValue / max(warpedValue, 1)
+              kept += 1
+            }
+          }
+        }
+      }
     }
-    guard !ratios.isEmpty else { return 1.0 }
-    return median(of: ratios)
+    guard kept > 0 else { return 1.0 }
+    return median(of: &ratios, count: kept)
   }
 
   /// Per-pixel darkening estimate for the glare MASK's own candidacy
@@ -443,31 +674,61 @@ extension GlareFreeComposer {
   /// at 4 frames) covering frames show the true darker surface. Fewer
   /// than 2 covering frames get 0 (no mask -- no meaningful vote at all).
   /// Internal (not private) for direct unit testing.
+  ///
+  /// The vote runs as whole-plane vDSP passes rather than a per-pixel
+  /// branch, and reproduces the scalar version's semantics exactly: a
+  /// non-covering frame contributes a sentinel far below any gray value
+  /// (so it can never place in the top two), the running best/runner-up
+  /// update becomes `runnerUp = max(runnerUp, min(best, sample))`, and
+  /// the "exactly four covered" and "at least two covered" conditions
+  /// become 0/1 selectors multiplied through at the end.
   static func robustDarkening(reference: GrayMap, correctedFrames: [GrayMap]) -> [Float] {
-    var darkening = [Float](repeating: 0, count: reference.values.count)
+    let count = reference.values.count
+    var darkening = [Float](repeating: 0, count: count)
     guard !correctedFrames.isEmpty else { return darkening }
-    for index in 0..<reference.values.count {
-      // Track the two brightest covering samples in a single pass — this
-      // runs per pixel at mask resolution, where a per-pixel sort's
-      // allocations would be a real CPU cost during capture.
-      var count = 0
-      var maxGray = -Float.infinity
-      var secondMaxGray = -Float.infinity
-      for frame in correctedFrames where frame.coverage[index] {
-        let value = frame.values[index]
-        count += 1
-        if value > maxGray {
-          secondMaxGray = maxGray
-          maxGray = value
-        } else if value > secondMaxGray {
-          secondMaxGray = value
+    let size = vDSP_Length(count)
+    var work = [Float](repeating: 0, count: 6 * count)
+    work.withUnsafeMutableBufferPointer { scratch in
+      let covered = scratch.baseAddress!
+      let (masked, tally) = (covered + count, covered + 2 * count)
+      let (best, runnerUp, spare) = (covered + 3 * count, covered + 4 * count, covered + 5 * count)
+      // Finite, not -infinity: the count gate below multiplies the unused
+      // `reference - sentinel` away, and `0 * infinity` would be a NaN.
+      var absent = Float(-1e30)
+      var rise = -absent
+      vDSP_vfill(&absent, best, 1, size)
+      vDSP_vfill(&absent, runnerUp, 1, size)
+      for frame in correctedFrames {
+        coverageIndicator(frame.coverage, into: covered, count: count)
+        vDSP_vadd(covered, 1, tally, 1, tally, 1, size)
+        frame.values.withUnsafeBufferPointer { values in
+          vDSP_vmul(values.baseAddress!, 1, covered, 1, masked, 1, size)
         }
+        vDSP_vsmsa(covered, 1, &rise, &absent, spare, 1, size)
+        vDSP_vadd(masked, 1, spare, 1, masked, 1, size)
+        vDSP_vmin(best, 1, masked, 1, spare, 1, size)
+        vDSP_vmax(runnerUp, 1, spare, 1, runnerUp, 1, size)
+        vDSP_vmax(best, 1, masked, 1, best, 1, size)
       }
-      guard count >= 2 else { continue }
-      // 4 covering frames: second-brightest (3-of-4 vote). 2 or 3: the
-      // brightest (all-of-N vote) -- see the docs above for why.
-      let robustGray = count == 4 ? secondMaxGray : maxGray
-      darkening[index] = max(0, reference.values[index] - robustGray)
+      var (half, negativeHalf, one, negated) = (Float(0.5), Float(-0.5), Float(1), Float(-1))
+      var (lessFour, two, zero) = (Float(-4), Float(2), Float(0))
+      // `spare` becomes 1 exactly where four frames covered, `covered` its
+      // complement, so the vote's two branches are one multiply-add.
+      vDSP_vsadd(tally, 1, &lessFour, spare, 1, size)
+      vDSP_vabs(spare, 1, spare, 1, size)
+      vDSP_vlim(spare, 1, &half, &negativeHalf, spare, 1, size)
+      vDSP_vsadd(spare, 1, &half, spare, 1, size)
+      vDSP_vsmsa(spare, 1, &negated, &one, covered, 1, size)
+      vDSP_vmma(runnerUp, 1, spare, 1, best, 1, covered, 1, masked, 1, size)
+      reference.values.withUnsafeBufferPointer { values in
+        vDSP_vsub(masked, 1, values.baseAddress!, 1, masked, 1, size)
+      }
+      vDSP_vthr(masked, 1, &zero, masked, 1, size)
+      vDSP_vlim(tally, 1, &two, &half, spare, 1, size)
+      vDSP_vsadd(spare, 1, &half, spare, 1, size)
+      darkening.withUnsafeMutableBufferPointer { output in
+        vDSP_vmul(masked, 1, spare, 1, output.baseAddress!, 1, size)
+      }
     }
     return darkening
   }
@@ -480,50 +741,71 @@ extension GlareFreeComposer {
   /// cover a glare patch's soft rim, then feather into a smooth alpha. See
   /// `MaskTuning`'s docs for the resolution `tuning`'s spatial fields are
   /// expected at. Internal (not private) for direct unit testing.
+  ///
+  /// Both thresholds are compared with `nextUp` limits: `vDSP_vlim`'s test
+  /// is `>=`, and the smallest representable step above the limit turns
+  /// that back into the strict `>` the scalar comparisons used, exactly.
   static func glareAlpha(reference: GrayMap, darkeningRobust: [Float], tuning: MaskTuning)
     -> [Float]
   {
-    let width = reference.width
-    let height = reference.height
-    let blurredDarkening = gaussianBlur(
+    let (width, height) = (reference.width, reference.height)
+    let count = width * height
+    let size = vDSP_Length(count)
+    var rawMask = gaussianBlur(
       darkeningRobust, width: width, height: height, sigma: tuning.blurSigma)
-    var rawMask = [Float](repeating: 0, count: width * height)
-    for index in 0..<rawMask.count {
-      if blurredDarkening[index] > tuning.darkeningThreshold,
-        reference.values[index] > tuning.brightnessFloor
-      {
-        rawMask[index] = 255
+    var brightEnough = [Float](repeating: 0, count: count)
+    var (darkeningLimit, brightnessLimit) = (
+      tuning.darkeningThreshold.nextUp, tuning.brightnessFloor.nextUp
+    )
+    var (half, full, low, high) = (Float(0.5), Float(255), Float(0), Float(1))
+    rawMask.withUnsafeMutableBufferPointer { mask in
+      brightEnough.withUnsafeMutableBufferPointer { bright in
+        let (candidate, floor) = (mask.baseAddress!, bright.baseAddress!)
+        vDSP_vlim(candidate, 1, &darkeningLimit, &half, candidate, 1, size)
+        vDSP_vsadd(candidate, 1, &half, candidate, 1, size)
+        vDSP_vlim(reference.values, 1, &brightnessLimit, &half, floor, 1, size)
+        vDSP_vsadd(floor, 1, &half, floor, 1, size)
+        vDSP_vmul(candidate, 1, floor, 1, candidate, 1, size)
+        vDSP_vsmul(candidate, 1, &full, candidate, 1, size)
       }
     }
     let dilated = dilateMax(rawMask, width: width, height: height, radius: tuning.dilateRadius)
-    let feathered = gaussianBlur(dilated, width: width, height: height, sigma: tuning.featherSigma)
-    return feathered.map { min(1, max(0, $0 / 255)) }
+    var feathered = gaussianBlur(
+      dilated, width: width, height: height, sigma: tuning.featherSigma)
+    feathered.withUnsafeMutableBufferPointer { alpha in
+      let base = alpha.baseAddress!
+      vDSP_vsdiv(base, 1, &full, base, 1, size)
+      vDSP_vclip(base, 1, &low, &high, base, 1, size)
+    }
+    return feathered
   }
 
-  /// The median of `values`; numpy's convention for an even count (the
-  /// average of the two middle elements) so this matches `np.median`
-  /// exactly. Selected via quickselect rather than a full sort: the gain
-  /// estimate feeds this a large fraction of the mask-resolution pixels
-  /// per verified frame, where an O(n log n) sort (plus its full-size
-  /// sorted copy) is measurable capture-time work for two order
-  /// statistics.
-  private static func median(of values: [Float]) -> Float {
-    let count = values.count
+  /// The median of `values`' first `count` entries; numpy's convention for
+  /// an even count (the average of the two middle elements) so this
+  /// matches `np.median` exactly. Selected via quickselect rather than a
+  /// full sort: the gain estimate feeds this a large fraction of the
+  /// mask-resolution pixels per verified frame, where an O(n log n) sort
+  /// (plus its full-size sorted copy) is measurable capture-time work for
+  /// two order statistics.
+  private static func median(of values: inout [Float], count: Int) -> Float {
     guard count > 0 else { return 0 }
-    var buffer = values
-    let upper = quickselect(&buffer, rank: count / 2)
-    if count % 2 == 1 { return upper }
-    // Quickselect leaves everything below index k partitioned <= the kth
-    // order statistic, so the lower middle element is that prefix's max.
-    let lower = buffer[0..<(count / 2)].max() ?? upper
-    return (lower + upper) / 2
+    return values.withUnsafeMutableBufferPointer { buffer in
+      let region = UnsafeMutableBufferPointer(rebasing: buffer[0..<count])
+      let upper = quickselect(region, rank: count / 2)
+      if count % 2 == 1 { return upper }
+      // Quickselect leaves everything below index k partitioned <= the kth
+      // order statistic, so the lower middle element is that prefix's max.
+      var lower = upper
+      vDSP_maxv(region.baseAddress!, 1, &lower, vDSP_Length(count / 2))
+      return (lower + upper) / 2
+    }
   }
 
   /// The `k`th-smallest element of `buffer` (0-based) via iterative
   /// Hoare-partition quickselect with a median-of-three pivot, expected
   /// O(n) with no allocations. Postcondition: `buffer[..<k]` holds only
   /// values `<=` the returned element.
-  private static func quickselect(_ buffer: inout [Float], rank: Int) -> Float {
+  private static func quickselect(_ buffer: UnsafeMutableBufferPointer<Float>, rank: Int) -> Float {
     var low = 0
     var high = buffer.count - 1
     while low < high {
@@ -555,6 +837,37 @@ extension GlareFreeComposer {
     return buffer[rank]
   }
 
+  /// `values` widened by `radius` clamped samples on each side of every
+  /// row (`vertical == false`) or by `radius` clamped rows above and below
+  /// (`vertical == true`). With the boundary materialized this way, one
+  /// separable pass is just a fixed shift of the whole padded buffer per
+  /// kernel tap, with no per-sample index clamping left to do -- exactly
+  /// the shape vDSP wants, and the reason the two filters below are a
+  /// handful of whole-buffer calls instead of a triple loop.
+  private static func padded(
+    _ values: [Float], width: Int, height: Int, radius: Int, vertical: Bool
+  ) -> [Float] {
+    let stride = vertical ? width : width + 2 * radius
+    let rows = vertical ? height + 2 * radius : height
+    var output = [Float](repeating: 0, count: stride * rows)
+    output.withUnsafeMutableBufferPointer { padding in
+      values.withUnsafeBufferPointer { source in
+        for row in 0..<rows {
+          let line =
+            source.baseAddress! + min(max(vertical ? row - radius : row, 0), height - 1) * width
+          let target = padding.baseAddress! + row * stride
+          (target + (vertical ? 0 : radius)).update(from: line, count: width)
+          guard !vertical else { continue }
+          for index in 0..<radius {
+            target[index] = line[0]
+            target[radius + width + index] = line[width - 1]
+          }
+        }
+      }
+    }
+    return output
+  }
+
   /// Separable Gaussian blur of a flattened `width`x`height` map,
   /// clamped-edge boundary (`stitch.py`'s `cv2.GaussianBlur` defaults to
   /// `BORDER_REFLECT_101`; clamped-edge is a minor, deliberate
@@ -575,28 +888,35 @@ extension GlareFreeComposer {
       sum += weight
     }
     for index in kernel.indices { kernel[index] /= sum }
+    let horizontal = blurPass(values, width: width, height: height, kernel: kernel, vertical: false)
+    return blurPass(horizontal, width: width, height: height, kernel: kernel, vertical: true)
+  }
 
-    func clampIndex(_ value: Int, _ limit: Int) -> Int { min(max(value, 0), limit - 1) }
-
-    var horizontal = [Float](repeating: 0, count: values.count)
-    for y in 0..<height {
-      let rowBase = y * width
-      for x in 0..<width {
-        var acc: Float = 0
-        for offset in -radius...radius {
-          acc += values[rowBase + clampIndex(x + offset, width)] * kernel[offset + radius]
+  /// One separable blur pass: each output row accumulated from the padded
+  /// buffer once per kernel tap, ascending, so every output sample sums
+  /// its taps in the same order the scalar inner loop did. A tap is a
+  /// fixed shift of `step` elements — one sample along a padded row, one
+  /// whole row down a padded column — which is what makes the whole pass
+  /// a handful of `vDSP_vsma` calls with no index clamping left in it.
+  private static func blurPass(
+    _ values: [Float], width: Int, height: Int, kernel: [Float], vertical: Bool
+  ) -> [Float] {
+    let radius = (kernel.count - 1) / 2
+    let source = padded(values, width: width, height: height, radius: radius, vertical: vertical)
+    let stride = vertical ? width : width + 2 * radius
+    let step = vertical ? width : 1
+    var output = [Float](repeating: 0, count: width * height)
+    source.withUnsafeBufferPointer { input in
+      output.withUnsafeMutableBufferPointer { blurred in
+        let size = vDSP_Length(width)
+        for row in 0..<height {
+          let line = input.baseAddress! + row * stride
+          let target = blurred.baseAddress! + row * width
+          for tap in 0...(2 * radius) {
+            var weight = kernel[tap]
+            vDSP_vsma(line + tap * step, 1, &weight, target, 1, target, 1, size)
+          }
         }
-        horizontal[rowBase + x] = acc
-      }
-    }
-    var output = [Float](repeating: 0, count: values.count)
-    for x in 0..<width {
-      for y in 0..<height {
-        var acc: Float = 0
-        for offset in -radius...radius {
-          acc += horizontal[clampIndex(y + offset, height) * width + x] * kernel[offset + radius]
-        }
-        output[y * width + x] = acc
       }
     }
     return output
@@ -616,26 +936,37 @@ extension GlareFreeComposer {
   {
     let pixelRadius = Int(radius.rounded())
     guard pixelRadius > 0 else { return values }
+    let horizontal = maxPass(
+      values, width: width, height: height, radius: pixelRadius, vertical: false)
+    return maxPass(horizontal, width: width, height: height, radius: pixelRadius, vertical: true)
+  }
 
-    var horizontal = [Float](repeating: 0, count: values.count)
-    for y in 0..<height {
-      let rowBase = y * width
-      for x in 0..<width {
-        var best: Float = 0
-        for neighborX in max(0, x - pixelRadius)...min(width - 1, x + pixelRadius) {
-          best = max(best, values[rowBase + neighborX])
+  /// One separable max pass. Clamping the boundary (rather than clipping
+  /// the kernel at it, as the scalar loop did) is exactly equivalent for a
+  /// max filter -- a clamped sample only repeats a value the clipped
+  /// window already contained -- so this is the same result from a running
+  /// `vDSP_vmax` over the padded buffer, one tap at a time.
+  private static func maxPass(
+    _ values: [Float], width: Int, height: Int, radius: Int, vertical: Bool
+  ) -> [Float] {
+    let source = padded(values, width: width, height: height, radius: radius, vertical: vertical)
+    let stride = vertical ? width : width + 2 * radius
+    let step = vertical ? width : 1
+    var output = [Float](repeating: 0, count: width * height)
+    source.withUnsafeBufferPointer { input in
+      output.withUnsafeMutableBufferPointer { dilated in
+        let size = vDSP_Length(width)
+        var zero = Float(0)
+        for row in 0..<height {
+          let line = input.baseAddress! + row * stride
+          let target = dilated.baseAddress! + row * width
+          target.update(from: line, count: width)
+          for tap in 1...(2 * radius) {
+            vDSP_vmax(target, 1, line + tap * step, 1, target, 1, size)
+          }
+          // The scalar filter seeded its running best at 0, so floor here.
+          vDSP_vthr(target, 1, &zero, target, 1, size)
         }
-        horizontal[rowBase + x] = best
-      }
-    }
-    var output = [Float](repeating: 0, count: values.count)
-    for x in 0..<width {
-      for y in 0..<height {
-        var best: Float = 0
-        for neighborY in max(0, y - pixelRadius)...min(height - 1, y + pixelRadius) {
-          best = max(best, horizontal[neighborY * width + x])
-        }
-        output[y * width + x] = best
       }
     }
     return output

--- a/ios/Pussel/Models/PuzzleModels.swift
+++ b/ios/Pussel/Models/PuzzleModels.swift
@@ -16,7 +16,14 @@ struct QuadCorners: Codable, Equatable {
 /// Response of POST /api/v1/puzzle/detect-frame.
 struct DetectFrameResponse: Codable, Equatable {
   /// data:image/jpeg;base64,... of the trimmed, perspective-corrected puzzle.
-  let trimmedImage: String
+  ///
+  /// Null (or absent) whenever the request opts out with `include_image=false`,
+  /// which is what `APIClient.detectFrame` always sends: the app re-warps the
+  /// same region locally from `corners` (see `TrimCandidate.croppedJPEG`), so
+  /// the echoed copy would be a base64 payload nobody reads. Kept optional
+  /// rather than dropped so a response from a backend that still echoes it
+  /// decodes unchanged.
+  let trimmedImage: String?
   let corners: QuadCorners
   let confidence: Double
 }

--- a/ios/Pussel/Networking/APIClient.swift
+++ b/ios/Pussel/Networking/APIClient.swift
@@ -52,9 +52,20 @@ final class APIClient {
     return try decoder.decode(BarcodeLookupResponse.self, from: data)
   }
 
+  /// Detects the puzzle's frame in the photo and returns its corners.
+  ///
+  /// `include_image=false` opts out of the server echoing its own
+  /// perspective-corrected crop back as a base64 data URL: the app warps the
+  /// identical region locally from the returned `corners` (see
+  /// `TrimCandidate.croppedJPEG(from:corners:)`), so the echo would only be a
+  /// second copy of the photo travelling back over the wire.
   func detectFrame(jpegData: Data) async throws -> DetectFrameResponse {
     let request = makeMultipartRequest(
-      path: "api/v1/puzzle/detect-frame", jpegData: jpegData, filename: "puzzle.jpg")
+      path: "api/v1/puzzle/detect-frame",
+      jpegData: jpegData,
+      filename: "puzzle.jpg",
+      fields: ["include_image": "false"]
+    )
     return try await sendDecoding(request)
   }
 

--- a/ios/Pussel/Support/ImageUtilities.swift
+++ b/ios/Pussel/Support/ImageUtilities.swift
@@ -12,7 +12,7 @@ enum ImageUtilities {
   /// `perspectiveCorrected(from:corners:maxDimension:)`).
   ///
   /// The uploaded image is capped at 1920 by `normalizedJPEG`, and the crop
-  /// taken from it is smaller again, so on a 3× phone the server's copy is
+  /// taken from it is smaller again, so on a 3× phone the uploaded copy is
   /// already at one image pixel per device pixel when it merely *fits* the
   /// screen: pinching it magnifies JPEG artefacts from the first gesture.
   ///
@@ -104,11 +104,12 @@ enum ImageUtilities {
   /// rotate it (see `AppModel.acceptTrim`) can do so before encoding, and pay
   /// one lossy pass instead of two.
   ///
-  /// This reproduces locally the crop the backend's detect-frame endpoint
-  /// already returned, but from a higher-resolution source: `corners` are
-  /// normalized, so they describe the same region of the photo at any
-  /// resolution, and re-running the warp here avoids uploading a second,
-  /// much larger copy of the photo just to get a sharper picture back.
+  /// This is how the app produces both crops it keeps: the upload-size trim
+  /// (`TrimCandidate.croppedJPEG`, which is why detect-frame is asked not to
+  /// echo its own copy back) and the sharper zoom copy warped from the
+  /// higher-resolution photo. `corners` are normalized, so they describe the
+  /// same region at any resolution, and re-running the warp locally avoids
+  /// moving a second copy of the photo over the wire in either direction.
   ///
   /// The output frames the same region as the server's `trimmed_image` and
   /// carries its aspect ratio (the target size below mirrors the dst_w/dst_h

--- a/ios/PusselTests/APIClientTests.swift
+++ b/ios/PusselTests/APIClientTests.swift
@@ -96,6 +96,34 @@ final class APIClientTests: XCTestCase {
     XCTAssertTrue(body.contains("name=\"file\"; filename=\"puzzle.jpg\""))
   }
 
+  // MARK: - detectFrame
+
+  func testDetectFrameSendsIncludeImageFalse() async throws {
+    authStore.backendToken = "tok"
+    StubURLProtocol.handler = { _ in (200, Self.detectFrameJSON) }
+    _ = try await client.detectFrame(jpegData: Data("JPEG".utf8))
+    let req = try XCTUnwrap(StubURLProtocol.receivedRequests.first)
+    XCTAssertEqual(req.url?.path, "/api/v1/puzzle/detect-frame")
+    XCTAssertEqual(req.httpMethod, "POST")
+    let body = try bodyString(of: req)
+    // The pinned wire contract: a multipart text field, literal "false",
+    // alongside the file part. Without it the backend echoes a base64 copy of
+    // the photo back that the app would only throw away.
+    XCTAssertTrue(
+      body.contains("Content-Disposition: form-data; name=\"include_image\"\r\n\r\nfalse\r\n"),
+      "detect-frame must send include_image=false; body was:\n\(body)")
+    XCTAssertTrue(body.contains("name=\"file\"; filename=\"puzzle.jpg\""))
+  }
+
+  func testDetectFrameDecodesResponseWithoutTrimmedImage() async throws {
+    authStore.backendToken = "tok"
+    StubURLProtocol.handler = { _ in (200, Self.detectFrameJSON) }
+    let response = try await client.detectFrame(jpegData: Data("JPEG".utf8))
+    XCTAssertNil(response.trimmedImage)
+    XCTAssertEqual(response.confidence, 0.87)
+    XCTAssertEqual(response.corners.topLeft, NormalizedPoint(x: 0.1, y: 0.1))
+  }
+
   func testAuthorizationHeaderAttached() async throws {
     authStore.backendToken = "token123"
     StubURLProtocol.handler = { _ in
@@ -288,7 +316,49 @@ final class APIClientTests: XCTestCase {
     )
   }
 
+  // MARK: - Helpers
+
+  /// The request body as text. URLSession has replaced `httpBody` with a
+  /// stream by the time a URLProtocol sees the request, so the stub's captured
+  /// requests have to be read back out of that stream — `httpBody` alone is
+  /// nil there (which is why the other body assertions in this file build
+  /// their request with `makeMultipartRequest` instead of sending it).
+  private func bodyString(of request: URLRequest) throws -> String {
+    if let body = request.httpBody {
+      return try XCTUnwrap(String(bytes: body, encoding: .utf8))
+    }
+    let stream = try XCTUnwrap(request.httpBodyStream)
+    stream.open()
+    defer { stream.close() }
+    var data = Data()
+    var buffer = [UInt8](repeating: 0, count: 4096)
+    while stream.hasBytesAvailable {
+      let read = stream.read(&buffer, maxLength: buffer.count)
+      guard read > 0 else { break }
+      data.append(buffer, count: read)
+    }
+    return try XCTUnwrap(String(bytes: data, encoding: .utf8))
+  }
+
   // MARK: - JSON fixtures
+
+  /// A detect-frame response in the include_image=false shape: corners and
+  /// confidence, no echoed crop.
+  private static let detectFrameJSON: Data = {
+    let json = """
+      {
+        "trimmed_image": null,
+        "corners": {
+          "top_left": {"x": 0.1, "y": 0.1},
+          "top_right": {"x": 0.9, "y": 0.1},
+          "bottom_right": {"x": 0.9, "y": 0.9},
+          "bottom_left": {"x": 0.1, "y": 0.9}
+        },
+        "confidence": 0.87
+      }
+      """
+    return Data(json.utf8)
+  }()
 
   private static let geometryUploadJSON: Data = {
     let json = """

--- a/ios/PusselTests/GlareFreeCaptureControllerTests.swift
+++ b/ios/PusselTests/GlareFreeCaptureControllerTests.swift
@@ -4,8 +4,62 @@ import simd
 
 @testable import Pussel
 
+/// A stand-in for `GlareFreeComposer.Session`: records the burst the
+/// controller drives it with instead of registering anything, so the state
+/// machine can be tested without Vision.
+private final class RecordingComposeSession: GlareFreeComposeSession {
+  struct Frame {
+    let image: UIImage
+    let expectedShift: CGSize?
+    let geometry: PlaneCaptureGeometry?
+  }
+
+  let reference: UIImage
+  let referenceGeometry: PlaneCaptureGeometry?
+  /// The corner frames handed over so far, in the order they arrived.
+  private(set) var frames: [Frame] = []
+  private(set) var finishCount = 0
+  private(set) var isCancelled = false
+  /// Models a composition that failed outright — `finish` returning nil.
+  var fails = false
+
+  init(reference: UIImage, geometry: PlaneCaptureGeometry?) {
+    self.reference = reference
+    self.referenceGeometry = geometry
+  }
+
+  func addFrame(_ image: UIImage, expectedShift: CGSize?, geometry: PlaneCaptureGeometry?) {
+    frames.append(Frame(image: image, expectedShift: expectedShift, geometry: geometry))
+  }
+
+  func finish() async -> GlareFreeComposer.Composite? {
+    finishCount += 1
+    guard !fails else { return nil }
+    // One aligned frame per corner handed over, so a test can tell from the
+    // composite alone that the burst reached the session intact.
+    return GlareFreeComposer.Composite(image: reference, alignedFrameCount: frames.count)
+  }
+
+  func cancel() { isCancelled = true }
+}
+
+/// Keeps hold of the stand-in session the controller opens for its
+/// reference shot, which only exists once that shot has been taken.
+private final class SessionSpy {
+  var session: RecordingComposeSession?
+
+  /// The controller's session factory, wired to this spy.
+  func factory() -> (UIImage, PlaneCaptureGeometry?) async -> (any GlareFreeComposeSession)? {
+    { [self] reference, geometry in
+      let opened = RecordingComposeSession(reference: reference, geometry: geometry)
+      session = opened
+      return opened
+    }
+  }
+}
+
 /// Tests for the five-shot glare-free capture state machine, with capture
-/// and compose injected — no camera or Vision involved.
+/// and the compositing session injected — no camera or Vision involved.
 @MainActor
 final class GlareFreeCaptureControllerTests: XCTestCase {
   private func solidImage() -> UIImage {
@@ -38,35 +92,36 @@ final class GlareFreeCaptureControllerTests: XCTestCase {
   }
 
   func testAdvancesThroughAllStepsThenComposes() async {
+    let spy = SessionSpy()
     let controller = GlareFreeCaptureController(
-      capture: { GlareFreeShot(image: self.solidImage()) },
-      compose: { reference, others, _, _ in
-        GlareFreeComposer.Composite(image: reference, alignedFrameCount: others.count)
-      })
+      capture: { GlareFreeShot(image: self.solidImage()) }, session: spy.factory())
     for step in 0..<GlareFreeCaptureController.steps.count {
       XCTAssertEqual(controller.phase, .capturing(step: step))
       XCTAssertEqual(controller.capturedCount, step)
       await controller.captureShot()
     }
     XCTAssertEqual(controller.phase, .done)
-    // The fake compose reports one aligned frame per non-reference shot,
-    // proving the reference/others split reached it intact.
+    // The stand-in session reports one aligned frame per corner shot,
+    // proving the reference/corner split reached it intact.
     XCTAssertEqual(
       controller.composite?.alignedFrameCount, GlareFreeCaptureController.steps.count - 1)
   }
 
   func testCenterShotBecomesTrackingReference() async {
     let reference = solidImage()
+    let spy = SessionSpy()
     let controller = GlareFreeCaptureController(
-      capture: { GlareFreeShot(image: reference) }, compose: { _, _, _, _ in nil })
+      capture: { GlareFreeShot(image: reference) }, session: spy.factory())
     XCTAssertNil(controller.referenceShot)
     await controller.captureShot()
     XCTAssertIdentical(controller.referenceShot, reference)
+    // ...and opens the composition, which every corner registers onto.
+    XCTAssertIdentical(spy.session?.reference, reference)
   }
 
   func testAimDwellAutoCapturesCornerStep() async {
     let controller = GlareFreeCaptureController(
-      capture: { GlareFreeShot(image: self.solidImage()) }, compose: { _, _, _, _ in nil })
+      capture: { GlareFreeShot(image: self.solidImage()) }, session: SessionSpy().factory())
     await controller.captureShot()
     XCTAssertEqual(controller.phase, .capturing(step: 1))
 
@@ -89,7 +144,7 @@ final class GlareFreeCaptureControllerTests: XCTestCase {
 
   func testOffTargetDwellDoesNotCapture() async {
     let controller = GlareFreeCaptureController(
-      capture: { GlareFreeShot(image: self.solidImage()) }, compose: { _, _, _, _ in nil })
+      capture: { GlareFreeShot(image: self.solidImage()) }, session: SessionSpy().factory())
     await controller.captureShot()
 
     // The dot sits at its resting anchor position (offset zero) — well
@@ -105,7 +160,7 @@ final class GlareFreeCaptureControllerTests: XCTestCase {
 
   func testGuideIsIgnoredWhileAimingTheReferenceShot() {
     let controller = GlareFreeCaptureController(
-      capture: { GlareFreeShot(image: self.solidImage()) }, compose: { _, _, _, _ in nil })
+      capture: { GlareFreeShot(image: self.solidImage()) }, session: SessionSpy().factory())
     controller.ingestGuide(onTargetUpdate(step: 1))
     XCTAssertNil(controller.guide)
     XCTAssertEqual(controller.phase, .capturing(step: 0))
@@ -113,7 +168,7 @@ final class GlareFreeCaptureControllerTests: XCTestCase {
 
   func testDotPositionTracksAnchorPlusOffset() async throws {
     let controller = GlareFreeCaptureController(
-      capture: { GlareFreeShot(image: self.solidImage()) }, compose: { _, _, _, _ in nil })
+      capture: { GlareFreeShot(image: self.solidImage()) }, session: SessionSpy().factory())
     // While aiming the reference shot the dot marks the screen center.
     XCTAssertEqual(controller.dotUnitPosition, CGPoint(x: 0.5, y: 0.5))
     await controller.captureShot()
@@ -127,53 +182,72 @@ final class GlareFreeCaptureControllerTests: XCTestCase {
     XCTAssertEqual(dot.y, anchor.y - 0.05, accuracy: 1e-9)
   }
 
-  func testComposeReceivesTheExpectedShifts() async throws {
-    var receivedShifts: [CGSize?] = []
+  func testEachCornerIsHandedOverWithItsExpectedShift() async throws {
+    let spy = SessionSpy()
     let controller = GlareFreeCaptureController(
-      capture: { GlareFreeShot(image: self.solidImage()) },
-      compose: { reference, _, shifts, _ in
-        receivedShifts = shifts
-        return GlareFreeComposer.Composite(image: reference, alignedFrameCount: 4)
-      })
+      capture: { GlareFreeShot(image: self.solidImage()) }, session: spy.factory())
     for _ in GlareFreeCaptureController.steps.indices {
       await controller.captureShot()
     }
-    XCTAssertEqual(receivedShifts.count, GlareFreeCaptureController.steps.count - 1)
+    let frames = try XCTUnwrap(spy.session?.frames)
+    XCTAssertEqual(frames.count, GlareFreeCaptureController.steps.count - 1)
     // Each corner shot is expected to have moved the content by its
     // anchor's offset from the center — e.g. the top-left anchor at
     // (0.25, 0.32) means the content moved (+0.25, +0.18).
-    let first = try XCTUnwrap(receivedShifts.first ?? nil)
+    let first = try XCTUnwrap(frames.first?.expectedShift)
     XCTAssertEqual(first.width, 0.25, accuracy: 1e-9)
     XCTAssertEqual(first.height, 0.18, accuracy: 1e-9)
   }
 
-  func testComposeReceivesEachShotsGeometry() async throws {
-    var received: [PlaneCaptureGeometry?] = []
+  func testTheSessionGetsTheReferenceGeometryAndEachCornersOwn() async throws {
     var shotIndex = 0
+    let spy = SessionSpy()
     let controller = GlareFreeCaptureController(
       capture: {
         defer { shotIndex += 1 }
-        // Geometry on the reference and the second corner only: the array
-        // the composer gets must keep its holes where they are, since it
-        // reads position 0 as the reference's and the rest by offset.
+        // Geometry on the reference and the second corner only: the
+        // reference's own opens the session (it is the one that decides the
+        // rectification), and each corner's must travel with that corner
+        // rather than being shifted onto a neighbour.
         let carries = shotIndex == 0 || shotIndex == 2
         return GlareFreeShot(
           image: self.solidImage(),
           geometry: carries ? self.geometry(planeHeight: Float(shotIndex) - 1) : nil)
       },
-      compose: { reference, _, _, geometries in
-        received = geometries
-        return GlareFreeComposer.Composite(image: reference, alignedFrameCount: 4)
-      })
+      session: spy.factory())
     for _ in GlareFreeCaptureController.steps.indices {
       await controller.captureShot()
     }
-    XCTAssertEqual(received.count, GlareFreeCaptureController.steps.count)
-    XCTAssertEqual(try XCTUnwrap(received[0]).planeHeight, -1)
-    XCTAssertNil(received[1])
-    XCTAssertEqual(try XCTUnwrap(received[2]).planeHeight, 1)
-    XCTAssertNil(received[3])
-    XCTAssertNil(received[4])
+    let session = try XCTUnwrap(spy.session)
+    XCTAssertEqual(try XCTUnwrap(session.referenceGeometry).planeHeight, -1)
+    XCTAssertEqual(session.frames.count, GlareFreeCaptureController.steps.count - 1)
+    XCTAssertNil(session.frames[0].geometry)
+    XCTAssertEqual(try XCTUnwrap(session.frames[1].geometry).planeHeight, 1)
+    XCTAssertNil(session.frames[2].geometry)
+    XCTAssertNil(session.frames[3].geometry)
+  }
+
+  func testCornersRegisterWhileTheBurstIsStillBeingShot() async {
+    let spy = SessionSpy()
+    /// How many corners were already registering as each shot was taken;
+    /// -1 while there is no session at all.
+    var registeringAtShot: [Int] = []
+    let controller = GlareFreeCaptureController(
+      capture: {
+        registeringAtShot.append(spy.session.map { $0.frames.count } ?? -1)
+        return GlareFreeShot(image: self.solidImage())
+      },
+      session: spy.factory())
+    for _ in GlareFreeCaptureController.steps.indices {
+      await controller.captureShot()
+    }
+    // The center shot opens the composition, and every corner joins it as
+    // it lands: the last shot is taken with three registrations already
+    // under way. This is the whole point of the session — that work used to
+    // start only once the burst was complete, under the spinner.
+    XCTAssertEqual(registeringAtShot, [-1, 0, 1, 2, 3])
+    // And the wait itself happens exactly once, at the end.
+    XCTAssertEqual(spy.session?.finishCount, 1)
   }
 
   private func geometry(planeHeight: Float) -> PlaneCaptureGeometry {
@@ -185,8 +259,8 @@ final class GlareFreeCaptureControllerTests: XCTestCase {
   func testNilCaptureFailsTheStep() async {
     let controller = GlareFreeCaptureController(
       capture: { nil },
-      compose: { _, _, _, _ in
-        XCTFail("compose should not run after a failed capture")
+      session: { _, _ in
+        XCTFail("no composition should open after a failed capture")
         return nil
       })
     await controller.captureShot()
@@ -196,7 +270,8 @@ final class GlareFreeCaptureControllerTests: XCTestCase {
   }
 
   func testRestartAfterFailureBeginsANewSequence() async {
-    let controller = GlareFreeCaptureController(capture: { nil }, compose: { _, _, _, _ in nil })
+    let controller = GlareFreeCaptureController(
+      capture: { nil }, session: { _, _ in nil })
     await controller.captureShot()
     controller.restart()
     XCTAssertEqual(controller.phase, .capturing(step: 0))
@@ -205,9 +280,32 @@ final class GlareFreeCaptureControllerTests: XCTestCase {
     XCTAssertNil(controller.referenceShot)
   }
 
-  func testNilComposeFallsBackToReferenceShot() async {
+  func testRestartCancelsTheCompositionInFlight() async throws {
+    let spy = SessionSpy()
     let controller = GlareFreeCaptureController(
-      capture: { GlareFreeShot(image: self.solidImage()) }, compose: { _, _, _, _ in nil })
+      capture: { GlareFreeShot(image: self.solidImage()) }, session: spy.factory())
+    await controller.captureShot()
+    await controller.captureShot()
+    let abandoned = try XCTUnwrap(spy.session)
+    XCTAssertEqual(abandoned.frames.count, 1)
+    controller.restart()
+    // The frame already registering belongs to a reference shot the next
+    // burst won't share, so its result is worth nothing — drop it rather
+    // than letting it run on.
+    XCTAssertTrue(abandoned.isCancelled)
+    XCTAssertEqual(abandoned.finishCount, 0)
+  }
+
+  func testFailedCompositionFallsBackToReferenceShot() async {
+    let spy = SessionSpy()
+    let controller = GlareFreeCaptureController(
+      capture: { GlareFreeShot(image: self.solidImage()) },
+      session: { [spy] reference, geometry in
+        let opened = RecordingComposeSession(reference: reference, geometry: geometry)
+        opened.fails = true
+        spy.session = opened
+        return opened
+      })
     for _ in GlareFreeCaptureController.steps.indices {
       await controller.captureShot()
     }
@@ -216,5 +314,20 @@ final class GlareFreeCaptureControllerTests: XCTestCase {
     // aligned-frame count so the view can tell the user.
     XCTAssertEqual(controller.composite?.alignedFrameCount, 0)
     XCTAssertNotNil(controller.composite?.image)
+  }
+
+  func testAnUnusableReferenceShotStillFinishesTheFlow() async {
+    // No session at all — the reference shot was too broken to prepare
+    // one. The burst still has to end somewhere the user can act on, which
+    // is the same degraded single-photo result as a failed composition.
+    let reference = solidImage()
+    let controller = GlareFreeCaptureController(
+      capture: { GlareFreeShot(image: reference) }, session: { _, _ in nil })
+    for _ in GlareFreeCaptureController.steps.indices {
+      await controller.captureShot()
+    }
+    XCTAssertEqual(controller.phase, .done)
+    XCTAssertEqual(controller.composite?.alignedFrameCount, 0)
+    XCTAssertIdentical(controller.composite?.image, reference)
   }
 }

--- a/ios/PusselTests/GlareFreeComposerTests.swift
+++ b/ios/PusselTests/GlareFreeComposerTests.swift
@@ -516,3 +516,67 @@ final class GlareFreeComposerTests: XCTestCase {
     )
   }
 }
+
+// MARK: - Incremental session
+
+/// The incremental face of the composer, driven the way the capture flow
+/// drives it. In an extension so these keep the fixtures above without
+/// pushing the class body past SwiftLint's `type_body_length` ceiling.
+extension GlareFreeComposerTests {
+  /// The pipelined path the capture flow actually uses: the same burst as
+  /// `testComposeRemovesReferenceGlare`, handed over a frame at a time so
+  /// the four registrations overlap, must heal the reference's glare just
+  /// as the all-at-once call does.
+  func testSessionHealsTheSameBurstHandedOverFrameByFrame() async throws {
+    let base = testCard()
+    let referenceGlare = CGPoint(x: 160, y: 160)
+    let reference = frame(base: base, translation: .zero, glareCenter: referenceGlare)
+    let shots: [(translation: CGSize, glare: CGPoint)] = [
+      (CGSize(width: 42, height: -38), CGPoint(x: 352, y: 160)),
+      (CGSize(width: -40, height: 36), CGPoint(x: 160, y: 352)),
+      (CGSize(width: 38, height: 40), CGPoint(x: 352, y: 352)),
+      (CGSize(width: -36, height: -42), CGPoint(x: 256, y: 96)),
+    ]
+
+    let session = try XCTUnwrap(GlareFreeComposer.Session(reference: reference, geometry: nil))
+    for shot in shots {
+      session.addFrame(
+        frame(base: base, translation: shot.translation, glareCenter: shot.glare),
+        expectedShift: CGSize(
+          width: shot.translation.width / CGFloat(cardSize),
+          height: shot.translation.height / CGFloat(cardSize)),
+        geometry: nil)
+    }
+    let composite = await session.finish()
+    let result = try XCTUnwrap(composite)
+
+    XCTAssertEqual(
+      result.alignedFrameCount, shots.count,
+      "all synthetic frames should register onto the reference")
+    XCTAssertEqual(result.image.size, reference.size)
+    let healed = pixel(of: result.image, at: referenceGlare)
+    assertClose(
+      healed, pixel(of: base, at: referenceGlare), tolerance: 40,
+      "glare spot should heal to the card color")
+    let clean = CGPoint(x: 96, y: 288)
+    assertClose(
+      pixel(of: result.image, at: clean), pixel(of: base, at: clean), tolerance: 40,
+      "clean area should keep the card color")
+  }
+
+  func testCancellingASessionDiscardsItsFrames() async throws {
+    let base = testCard()
+    let session = try XCTUnwrap(GlareFreeComposer.Session(reference: base, geometry: nil))
+    session.addFrame(
+      frame(base: base, translation: CGSize(width: 42, height: -38), glareCenter: nil),
+      expectedShift: nil, geometry: nil)
+    // A restart mid-burst: whatever that frame registers to is worth
+    // nothing without the burst it belonged to, so it must not reach a
+    // later composite.
+    session.cancel()
+    let composite = await session.finish()
+    let result = try XCTUnwrap(composite)
+    XCTAssertEqual(result.alignedFrameCount, 0)
+    XCTAssertEqual(result.image.size, base.size)
+  }
+}

--- a/ios/PusselTests/ImageUtilitiesTests.swift
+++ b/ios/PusselTests/ImageUtilitiesTests.swift
@@ -134,6 +134,82 @@ final class ImageUtilitiesTests: XCTestCase {
     XCTAssertEqual(turned.size.height * turned.scale, 800, accuracy: 1)
   }
 
+  // MARK: TrimCandidate.croppedJPEG(from:corners:)
+
+  /// The upload-size photo as the app holds it: JPEG bytes at an exact pixel
+  /// size, which is what `croppedJPEG` warps.
+  private func makeJPEG(width: Int, height: Int) throws -> Data {
+    try XCTUnwrap(makeImage(width: width, height: height).jpegData(compressionQuality: 0.9))
+  }
+
+  private func decodedPixelSize(_ data: Data) throws -> CGSize {
+    let image = try XCTUnwrap(UIImage(data: data))
+    return CGSize(width: image.size.width * image.scale, height: image.size.height * image.scale)
+  }
+
+  func testCroppedJPEGMatchesCornerGeometry() throws {
+    // The local crop stands in for the server's `trimmed_image`, so its
+    // dimensions must be the ones the corners imply — here the left half of an
+    // 800×400 photo, i.e. a 400×400 square, not the source's 2:1 frame.
+    let corners = QuadCorners(
+      topLeft: NormalizedPoint(x: 0, y: 0),
+      topRight: NormalizedPoint(x: 0.5, y: 0),
+      bottomRight: NormalizedPoint(x: 0.5, y: 1),
+      bottomLeft: NormalizedPoint(x: 0, y: 1))
+    let jpeg = try makeJPEG(width: 800, height: 400)
+    let cropped = try XCTUnwrap(TrimCandidate.croppedJPEG(from: jpeg, corners: corners))
+    let size = try decodedPixelSize(cropped)
+    XCTAssertEqual(size.width, 400, accuracy: 2)
+    XCTAssertEqual(size.height, 400, accuracy: 2)
+  }
+
+  func testCroppedJPEGStraightensSkewedQuadToLongestEdges() throws {
+    // Same sizing rule as the server's warp (longer of each side's two source
+    // edges): a photo shot at an angle straightens to the full 800 wide.
+    let corners = QuadCorners(
+      topLeft: NormalizedPoint(x: 0.25, y: 0),
+      topRight: NormalizedPoint(x: 0.75, y: 0),
+      bottomRight: NormalizedPoint(x: 1, y: 1),
+      bottomLeft: NormalizedPoint(x: 0, y: 1))
+    let jpeg = try makeJPEG(width: 800, height: 400)
+    let cropped = try XCTUnwrap(TrimCandidate.croppedJPEG(from: jpeg, corners: corners))
+    XCTAssertEqual(try decodedPixelSize(cropped).width, 800, accuracy: 2)
+  }
+
+  func testCroppedJPEGDoesNotDownscaleTheUploadSizeCopy() throws {
+    // No cap of its own: the source is already the 1920-capped upload copy, so
+    // a full-frame quad must come back at full size.
+    let jpeg = try makeJPEG(width: 800, height: 400)
+    let cropped = try XCTUnwrap(
+      TrimCandidate.croppedJPEG(from: jpeg, corners: fullFrameCorners()))
+    XCTAssertEqual(try decodedPixelSize(cropped), CGSize(width: 800, height: 400))
+  }
+
+  func testCroppedJPEGReturnsNilForUndecodableBytes() {
+    // acceptTrim's "Could not decode the trimmed image." guard depends on this
+    // failing rather than yielding the uncropped photo.
+    XCTAssertNil(
+      TrimCandidate.croppedJPEG(from: Data([0x00, 0x01, 0x02]), corners: fullFrameCorners()))
+  }
+
+  func testCroppedJPEGReturnsNilForDegenerateQuad() throws {
+    let point = NormalizedPoint(x: 0.5, y: 0.5)
+    let corners = QuadCorners(
+      topLeft: point, topRight: point, bottomRight: point, bottomLeft: point)
+    let jpeg = try makeJPEG(width: 800, height: 400)
+    XCTAssertNil(TrimCandidate.croppedJPEG(from: jpeg, corners: corners))
+  }
+
+  func testWholeImageCandidateIsItsOwnTrim() {
+    // The barcode path never sees detect-frame: no server crop, no local warp,
+    // the box image itself is the trim.
+    let jpeg = Data("JPEGBYTES".utf8)
+    let candidate = TrimCandidate.wholeImage(jpeg: jpeg, source: .barcodeLookup)
+    XCTAssertEqual(candidate.trimmedJPEG, jpeg)
+    XCTAssertNil(candidate.detection.trimmedImage)
+    XCTAssertEqual(candidate.detection.confidence, 1.0)
+  }
+
   // MARK: rotatedJPEG(from:quarterTurns:)
 
   func testRotatedJPEGZeroTurnsReturnsInputUnchanged() throws {

--- a/ios/PusselTests/ModelDecodingTests.swift
+++ b/ios/PusselTests/ModelDecodingTests.swift
@@ -33,37 +33,6 @@ final class ModelDecodingTests: XCTestCase {
     XCTAssertNil(response.user.picture)
   }
 
-  func testDecodeDetectFrameResponse() throws {
-    let json = """
-      {
-        "trimmed_image": "data:image/jpeg;base64,aGVsbG8=",
-        "corners": {
-          "top_left": {"x": 0.1, "y": 0.1},
-          "top_right": {"x": 0.9, "y": 0.1},
-          "bottom_right": {"x": 0.9, "y": 0.9},
-          "bottom_left": {"x": 0.1, "y": 0.9}
-        },
-        "confidence": 0.87
-      }
-      """
-    let response = try decoder.decode(DetectFrameResponse.self, from: Data(json.utf8))
-    XCTAssertEqual(response.confidence, 0.87)
-    XCTAssertEqual(response.corners.topLeft, NormalizedPoint(x: 0.1, y: 0.1))
-    XCTAssertEqual(response.corners.bottomRight, NormalizedPoint(x: 0.9, y: 0.9))
-    XCTAssertEqual(ImageUtilities.decodeDataURL(response.trimmedImage), Data("hello".utf8))
-    // A stray piece_count_estimate from an older backend must not break decoding.
-    XCTAssertNoThrow(
-      try decoder.decode(
-        DetectFrameResponse.self,
-        from: Data(
-          """
-          {"trimmed_image": "data:image/jpeg;base64,aGVsbG8=",
-           "corners": {"top_left": {"x": 0, "y": 0}, "top_right": {"x": 1, "y": 0},
-                       "bottom_right": {"x": 1, "y": 1}, "bottom_left": {"x": 0, "y": 1}},
-           "confidence": 0.5, "piece_count_estimate": 1000}
-          """.utf8)))
-  }
-
   func testDecodePuzzleUploadResponse() throws {
     let json = """
       {"puzzle_id": "3f2b9c", "image_url": null}
@@ -442,5 +411,87 @@ final class ModelDecodingTests: XCTestCase {
     XCTAssertEqual(GeometryEdgeType.tab.glyph, "T")
     XCTAssertEqual(GeometryEdgeType.blank.glyph, "B")
     XCTAssertEqual(GeometryEdgeType.flat.glyph, "F")
+  }
+}
+
+/// Decoding tests for POST /api/v1/puzzle/detect-frame, whose payload shape
+/// depends on the request's `include_image` field (see `APIClient.detectFrame`).
+/// Their own suite so the response contract has one place to grow.
+final class DetectFrameDecodingTests: XCTestCase {
+  private let decoder: JSONDecoder = {
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    return decoder
+  }()
+
+  func testDecodeDetectFrameResponse() throws {
+    let json = """
+      {
+        "trimmed_image": "data:image/jpeg;base64,aGVsbG8=",
+        "corners": {
+          "top_left": {"x": 0.1, "y": 0.1},
+          "top_right": {"x": 0.9, "y": 0.1},
+          "bottom_right": {"x": 0.9, "y": 0.9},
+          "bottom_left": {"x": 0.1, "y": 0.9}
+        },
+        "confidence": 0.87
+      }
+      """
+    let response = try decoder.decode(DetectFrameResponse.self, from: Data(json.utf8))
+    XCTAssertEqual(response.confidence, 0.87)
+    XCTAssertEqual(response.corners.topLeft, NormalizedPoint(x: 0.1, y: 0.1))
+    XCTAssertEqual(response.corners.bottomRight, NormalizedPoint(x: 0.9, y: 0.9))
+    // A backend that still echoes the crop must keep decoding, even though the
+    // app no longer asks for it (include_image=false) or reads it.
+    XCTAssertEqual(
+      response.trimmedImage.flatMap(ImageUtilities.decodeDataURL), Data("hello".utf8))
+    // A stray piece_count_estimate from an older backend must not break decoding.
+    XCTAssertNoThrow(
+      try decoder.decode(
+        DetectFrameResponse.self,
+        from: Data(
+          """
+          {"trimmed_image": "data:image/jpeg;base64,aGVsbG8=",
+           "corners": {"top_left": {"x": 0, "y": 0}, "top_right": {"x": 1, "y": 0},
+                       "bottom_right": {"x": 1, "y": 1}, "bottom_left": {"x": 0, "y": 1}},
+           "confidence": 0.5, "piece_count_estimate": 1000}
+          """.utf8)))
+  }
+
+  func testDecodeDetectFrameResponseWithoutTrimmedImage() throws {
+    // The include_image=false shape the app asks for: corners and confidence
+    // only, with the crop echoed back as null…
+    let nulled = """
+      {
+        "trimmed_image": null,
+        "corners": {
+          "top_left": {"x": 0.1, "y": 0.1},
+          "top_right": {"x": 0.9, "y": 0.1},
+          "bottom_right": {"x": 0.9, "y": 0.9},
+          "bottom_left": {"x": 0.1, "y": 0.9}
+        },
+        "confidence": 0.87
+      }
+      """
+    let response = try decoder.decode(DetectFrameResponse.self, from: Data(nulled.utf8))
+    XCTAssertNil(response.trimmedImage)
+    XCTAssertEqual(response.confidence, 0.87)
+    XCTAssertEqual(response.corners.topRight, NormalizedPoint(x: 0.9, y: 0.1))
+
+    // …or omitted from the payload entirely.
+    let absent = """
+      {
+        "corners": {
+          "top_left": {"x": 0, "y": 0},
+          "top_right": {"x": 1, "y": 0},
+          "bottom_right": {"x": 1, "y": 1},
+          "bottom_left": {"x": 0, "y": 1}
+        },
+        "confidence": 0.5
+      }
+      """
+    let sparse = try decoder.decode(DetectFrameResponse.self, from: Data(absent.utf8))
+    XCTAssertNil(sparse.trimmedImage)
+    XCTAssertEqual(sparse.corners.bottomLeft, NormalizedPoint(x: 0, y: 1))
   }
 }

--- a/ios/README.md
+++ b/ios/README.md
@@ -78,6 +78,20 @@ make ios-deploy IOS_DEVICE=<name-or-udid>   # device is auto-detected otherwise
 `ios-deploy` needs `DEVELOPMENT_TEAM` set in `Config/Secrets.xcconfig` (device
 signing) and a device that's connected and trusts this Mac.
 
+It builds the Debug configuration with Swift optimization on
+(`SWIFT_OPTIMIZATION_LEVEL=-O`, `SWIFT_COMPILATION_MODE=wholemodule`): at
+`-Onone` the glare-free compose step takes ~8-10x longer (19.5s vs 2.5s on a
+real capture), which is the phone the app is actually scanned with. Only
+codegen changes — `DEBUG` is still defined, so the debug-only features below
+(auth bypass, command channel, `GlareFreeDumps` recording) all still work. The
+optimized build uses its own derived-data directory, `ios/.build-opt`, so it
+doesn't force full rebuilds when alternating with `ios-run` / `ios-test`.
+Turn it off — and fall back to the shared `ios/.build` — with:
+
+```bash
+make ios-deploy IOS_OPTIMIZE=0
+```
+
 ## Screenshots
 
 `make ios-screenshot` captures a booted Simulator or a connected device at


### PR DESCRIPTION
## Why

The wait after the 5-shot glare-free puzzle scan felt like "the server is slow". Measurement says otherwise: the backend's detect-frame is 60–315 ms server-side (~80 ms HTTP round trip on LAN), while the on-device compose was **19.5 s** for a real capture in a Debug build (2.5 s with `-O`) — the per-pixel Swift healing loops suffer ~10× under `-Onone`, and `make ios-deploy` installs Debug builds.

## What

- **Optimized device deploys** — `make ios-deploy` builds with `SWIFT_OPTIMIZATION_LEVEL=-O` + whole-module by default, into its own `ios/.build-opt` derived data so it doesn't thrash the Debug simulator builds. Opt out with `IOS_OPTIMIZE=0`. `DEBUG` compilation conditions are kept, so GlareFreeDumps recording and the debug driver still work.
- **Registration overlaps capture** — new `GlareFreeComposer.Session` registers each corner frame the moment its shot lands (detached, concurrent), while the user is still aiming the next corner; `finish()` awaits the frames in index order and runs healing + rectification. A controller test proves three of four registrations are under way before the last shutter. The static `compose()` keeps its exact signature/semantics as a wrapper, so existing tests run unmodified.
- **Healing on Accelerate** — `GlareFreeMaskedHealing`'s gain/min-stack/blend/gray/upscale/blur/dilate/vote loops now run on vDSP/vImage with the same sRGB-byte semantics. Output is **bit-identical** on a real capture dump (0 differing pixels of 9.4 M); the full-size compose drops 19.5 s → **2.6 s** even at `-Onone`.
- **Slimmer detect-frame** — the endpoint accepts an `include_image` form field (default true, so the web client is unaffected). The iOS app sends `false` and builds the confirm-screen crop locally from the returned corners via the existing `perspectiveCorrected` path; the response shrinks ~220 KB → ~300 B and the server skips warp/encode/base64. The endpoint's CPU work now runs via `asyncio.to_thread` instead of blocking the event loop.

## Measurements

| Leg | Before | After |
|---|---|---|
| Compose, real dump, Debug build (Mac) | 19.5 s | 2.6 s |
| Compose test suite (2 heavy tests) | 8.5 s / 8.2 s | ~1.2 s / ~1.0 s |
| detect-frame response size | ~220 KB | ~300 B |
| detect-frame server-side | 60–315 ms | unchanged minus warp/encode |

On-device the compose also starts ~3 frames earlier, so the visible spinner should drop from ~30 s to roughly 1–3 s.

## Verification

- `make check` green across backend/network/shared/frontend/iOS; backend 343/343 tests; full iOS suite passes.
- Real-dump integration test: same 2/4 aligned frames, bit-identical composite (mean/max abs diff 0/0).
- Live end-to-end curl against the updated backend confirms both `include_image` modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)