### PR TITLE
Keep the home list where the user left it when reopening a puzzle

### DIFF
--- a/ios/Pussel/App/AppFlow.swift
+++ b/ios/Pussel/App/AppFlow.swift
@@ -121,10 +121,12 @@ final class AppFlowStore {
   /// picker on appear; cleared once consumed.
   var pendingRetake: CaptureSource?
 
-  /// Where the home screen's list was scrolled to, in points, or nil if it has
-  /// never been scrolled. Lives here rather than in `CapturePuzzleView` because
-  /// the phase switch tears that view down: opening a puzzle destroys its
-  /// `ScrollView`, and going back builds a new one, which starts at the top.
+  /// Where the home screen's list was scrolled to, in points, or nil until
+  /// that screen has reported its geometry at least once (a fresh launch, or
+  /// after a sign-out) — a list sitting at the top reports 0, not nil. Lives
+  /// here rather than in `CapturePuzzleView` because the phase switch tears
+  /// that view down: opening a puzzle destroys its `ScrollView`, and going
+  /// back builds a new one, which starts at the top.
   ///
   /// Deliberately *not* cleared by `reset()` — going back is a reset, and
   /// coming back to where you left off is the whole point. Sign-out clears it

--- a/ios/Pussel/App/AppFlow.swift
+++ b/ios/Pussel/App/AppFlow.swift
@@ -121,6 +121,19 @@ final class AppFlowStore {
   /// picker on appear; cleared once consumed.
   var pendingRetake: CaptureSource?
 
+  /// Where the home screen's list was scrolled to, in points, or nil if it has
+  /// never been scrolled. Lives here rather than in `CapturePuzzleView` because
+  /// the phase switch tears that view down: opening a puzzle destroys its
+  /// `ScrollView`, and going back builds a new one, which starts at the top.
+  ///
+  /// Deliberately *not* cleared by `reset()` — going back is a reset, and
+  /// coming back to where you left off is the whole point. Sign-out clears it
+  /// explicitly instead.
+  ///
+  /// `@ObservationIgnored` because it's written on every scrolled frame: an
+  /// observed property here would invalidate the whole wizard while scrolling.
+  @ObservationIgnored var homeScrollOffset: CGFloat?
+
   /// The stored puzzle whose files are being read for a solve session, if any
   /// (see `AppModel.openPuzzle`). Doubles as the home-screen row's spinner and
   /// as the token that tells a finished read whether it is still wanted:

--- a/ios/Pussel/App/RootView.swift
+++ b/ios/Pussel/App/RootView.swift
@@ -55,6 +55,10 @@ struct AppFlowView: View {
               Button("Sign Out", role: .destructive) {
                 model.authService.signOut()
                 model.flow.reset()
+                // `reset()` keeps the home screen's scroll position on purpose
+                // (see `homeScrollOffset`); signing out is the one exit that
+                // should not restore it.
+                model.flow.homeScrollOffset = nil
               }
             } header: {
               if let user = model.auth.user {

--- a/ios/Pussel/Features/Capture/CapturePuzzleView.swift
+++ b/ios/Pussel/Features/Capture/CapturePuzzleView.swift
@@ -9,7 +9,11 @@ private struct ScrollSnapshot: Equatable {
   /// How far the list has been scrolled from its resting top, which is what
   /// `ScrollPosition.scrollTo(y:)` takes — `contentOffset` is measured from
   /// under the navigation bar instead, so it sits one top inset lower.
-  var scrolledY: CGFloat { offset + insetTop }
+  ///
+  /// Clamped at 0: a rubber-band overscroll at the top reads as negative, and
+  /// leaving the screen mid-bounce would otherwise store a position that only
+  /// exists while a finger is on the glass.
+  var scrolledY: CGFloat { max(0, offset + insetTop) }
 }
 
 struct CapturePuzzleView: View {

--- a/ios/Pussel/Features/Capture/CapturePuzzleView.swift
+++ b/ios/Pussel/Features/Capture/CapturePuzzleView.swift
@@ -1,11 +1,28 @@
 import PhotosUI
 import SwiftUI
 
+/// The bits of the list's scroll geometry the offset restore needs.
+private struct ScrollSnapshot: Equatable {
+  let offset: CGFloat
+  let insetTop: CGFloat
+
+  /// How far the list has been scrolled from its resting top, which is what
+  /// `ScrollPosition.scrollTo(y:)` takes — `contentOffset` is measured from
+  /// under the navigation bar instead, so it sits one top inset lower.
+  var scrolledY: CGFloat { offset + insetTop }
+}
+
 struct CapturePuzzleView: View {
   @Environment(AppModel.self) private var model
   @State private var showCamera = false
   @State private var showLibrary = false
   @State private var photoItem: PhotosPickerItem?
+  /// Drives the restore of `flow.homeScrollOffset` — see `body`.
+  @State private var scrollPosition = ScrollPosition()
+  /// False until `restoreScrollOffset` has run. A freshly built `ScrollView`
+  /// reports its geometry (offset 0) before `onAppear`, which would overwrite
+  /// the very offset we came back to restore.
+  @State private var hasRestoredScroll = false
 
   private var hasSavedPuzzles: Bool {
     !model.store.puzzles.isEmpty
@@ -22,6 +39,20 @@ struct CapturePuzzleView: View {
       }
     }
     .scrollBounceBehavior(.basedOnSize)
+    // This screen is rebuilt from scratch every time the wizard comes back to
+    // it (see `AppFlowStore.homeScrollOffset`), so the offset is remembered
+    // out here and put back on appear — otherwise reopening a puzzle from far
+    // down the list always returns the user to the top.
+    .scrollPosition($scrollPosition)
+    .onScrollGeometryChange(for: ScrollSnapshot.self) { geometry in
+      ScrollSnapshot(offset: geometry.contentOffset.y, insetTop: geometry.contentInsets.top)
+    } action: { _, snapshot in
+      guard hasRestoredScroll else {
+        restoreScrollOffset(snapshot)
+        return
+      }
+      model.flow.homeScrollOffset = snapshot.scrolledY
+    }
     .overlay(alignment: .bottom) { UndoDeleteSnackbar() }
     .animation(.snappy, value: model.store.pendingDelete)
     .fullScreenCover(isPresented: cameraCoverIsPresented) {
@@ -49,6 +80,18 @@ struct CapturePuzzleView: View {
       }
     }
     .onAppear(perform: reopenPickerIfRetaking)
+  }
+
+  /// Puts the list back where it was before the wizard left this screen.
+  ///
+  /// Waits for the navigation bar's inset to land: a fresh `ScrollView` reports
+  /// its geometry once before the bar is accounted for, and scrolling in that
+  /// pass is undone (and re-resolved a top inset off) when the inset arrives.
+  private func restoreScrollOffset(_ snapshot: ScrollSnapshot) {
+    guard snapshot.insetTop > 0 else { return }
+    hasRestoredScroll = true
+    guard let scrolledY = model.flow.homeScrollOffset else { return }
+    scrollPosition.scrollTo(y: scrolledY)
   }
 
   private var content: some View {

--- a/ios/PusselTests/AppFlowNavigationTests.swift
+++ b/ios/PusselTests/AppFlowNavigationTests.swift
@@ -106,4 +106,16 @@ final class AppFlowNavigationTests: XCTestCase {
     XCTAssertNil(flow.errorMessage)
     XCTAssertNil(flow.pendingRetake)
   }
+
+  /// The home screen's `ScrollView` dies with the phase switch, so its offset
+  /// is parked on the store — and `reset()` must leave it alone, or coming
+  /// back from a puzzle opened far down the list lands at the top again.
+  func testGoBackKeepsTheHomeScrollOffset() {
+    let flow = AppFlowStore()
+    flow.homeScrollOffset = 420
+    flow.phase = .solving(session())
+
+    flow.goBack()
+    XCTAssertEqual(flow.homeScrollOffset, 420)
+  }
 }


### PR DESCRIPTION
## The bug

Scroll down the saved-puzzles list, tap one of the lower puzzles, then go back — the home screen is back at the top instead of where it was when the puzzle was tapped. Reproduced in the Simulator before touching anything.

## Why it happens

`AppFlowView` swaps wizard phases inside a `Group { switch }` (`ios/Pussel/App/RootView.swift`), so opening a puzzle destroys `CapturePuzzleView` along with its `ScrollView`. Going back builds a brand-new one, which always starts at offset 0. The offset has to live somewhere that outlives the phase switch.

## The fix

- **`AppFlow.swift`** — new `homeScrollOffset` on `AppFlowStore`, `@ObservationIgnored` so per-frame scroll writes don't invalidate the whole wizard. `reset()` deliberately leaves it alone (going back *is* a reset, and returning to the same place is the point); sign-out clears it explicitly.
- **`CapturePuzzleView.swift`** — `onScrollGeometryChange` records the offset, `ScrollPosition.scrollTo(y:)` puts it back when the screen is rebuilt.

## Two things worth a reviewer's attention

Both were found by instrumenting the running app, not by reading the code:

1. A fresh `ScrollView` reports its geometry (offset 0) **before** `onAppear`, clobbering the saved value we came back to restore. Recording is therefore gated on `hasRestoredScroll`.
2. `contentOffset.y` sits one navigation-bar inset (116pt here) below what `scrollTo(y:)` takes, and a restore issued during the pre-inset layout pass gets re-resolved a *second* inset off when the inset lands — the list ended up ~234pt from where it should be. So the restore waits for `insetTop > 0`, and the stored value (`offset + insetTop`) is inset-independent.

## Verification

Driven in the Simulator with real scroll/tap gestures, screenshots diffed pixel-wise:

- Scroll to the bottom of the list → open a lower puzzle → back: home screen **pixel-identical** to the pre-tap state.
- Same from a mid-list position: identical apart from the fading scroll indicator.
- Cold launch still opens at the top.

`make check-ios` clean; all 304 unit tests pass, including a new `testGoBackKeepsTheHomeScrollOffset` covering the `reset()` contract.

**Caveat on method:** my synthetic taps on the back chevron kept missing, so the back navigation in the runs above went through the app's debug `reset` command — the same `flow.reset()` the chevron calls. The chevron's own hit-testing was not re-exercised; it is unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)