### PR TITLE
Hide the back item's glass background on the home screen

### DIFF
--- a/ios/Pussel/App/RootView.swift
+++ b/ios/Pussel/App/RootView.swift
@@ -42,6 +42,12 @@ struct AppFlowView: View {
         ToolbarItem(placement: .topBarLeading) {
           backButton
         }
+        // The bar draws each item's glass background itself, behind the item's
+        // content — so the hidden chevron below left an empty capsule sitting
+        // in the corner of the home screen. Dropping the shared background is
+        // what actually takes the button out of sight; it does not unmount the
+        // item, so `backButton`'s reason for staying put still holds.
+        .sharedBackgroundVisibility(model.flow.canGoBack ? .automatic : .hidden)
         ToolbarItem(placement: .topBarTrailing) {
           Menu {
             #if DEBUG
@@ -98,7 +104,8 @@ struct AppFlowView: View {
     .accessibilityLabel("Back to puzzles")
     // Hidden rather than omitted, so the item itself stays put. Disabled and
     // hidden from VoiceOver with it, so an invisible chevron is never a live
-    // control on the home screen.
+    // control on the home screen. The item's glass background is hidden
+    // alongside it, up where the toolbar item is declared.
     .opacity(canGoBack ? 1 : 0)
     .disabled(!canGoBack)
     .accessibilityHidden(!canGoBack)


### PR DESCRIPTION
## What

The home screen shipped with an empty dark circle in its top-left corner — a button-shaped hole with nothing in it.

It wasn't a new button. It was the wizard's back chevron from #156, which is deliberately kept mounted in the navigation bar for the whole flow and merely hidden with `.opacity(0)` on the phases that have nowhere to go back to. On iOS 26+ the bar draws each toolbar item's Liquid Glass background *itself*, behind the item's content — so hiding the glyph left the capsule behind.

## Why this fix

`.sharedBackgroundVisibility(.hidden)` drops the item's glass background without unmounting the item. That matters: #156's whole point is that the button is already installed and hit-testable the instant `canGoBack` turns true, so there is no window for a tap right after opening a puzzle to fall into. Omitting the item, or wrapping it in a conditional, would reintroduce exactly that window.

```swift
ToolbarItem(placement: .topBarLeading) {
  backButton
}
.sharedBackgroundVisibility(model.flow.canGoBack ? .automatic : .hidden)
```

Deployment target is iOS 26.0, so the API is available unconditionally.

## Verification

- **Device (iPhone 15,4 / iOS 27):** built, deployed, screenshotted — the capsule is gone from the front page.
- **Simulator:** the chevron still renders normally *with* its glass capsule on confirm-trim, and a synthetic tap on it still navigates home, so the item remains mounted and hit-testable.
- `make check-ios` clean; `make ios-test` — 303 tests, 0 failures.

## For the reviewer

One thing I did **not** exercise: the specific race #156 fixed — tapping back *immediately* after opening a puzzle, before its images finish decoding on the main thread. Reproducing it needs a real device open, and the debug driver is Simulator-only. This change alters background rendering rather than item identity, so I'd expect the fix intact, but it is untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)